### PR TITLE
chore: show lock symbol for private circles on index page

### DIFF
--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -39,7 +39,12 @@
                 <div class="circles-grid">
                     {% for circle in circles %}
                         <div class="circle-card">
-                            <h3>{{ circle.name }}</h3>
+                            <h3>
+                                {% if circle.requires_approval %}
+                                    <i class="fas fa-lock text-muted me-2"></i>
+                                {% endif %}
+                                {{ circle.name }}
+                            </h3>
                             <p>{{ circle.description[:100] }}{% if circle.description|length > 100 %}...{% endif %}</p>
                             <div class="d-flex justify-content-between align-items-center">
                                 <small class="text-muted">


### PR DESCRIPTION
Now there's a lock on the index.html page for private circles:
<img width="995" height="416" alt="image" src="https://github.com/user-attachments/assets/4cc3f857-df3f-49d8-93cc-5b6372396b19" />

Just as there already was on the Circles page.