### PR TITLE
chore: increase visibility of prod -> staging db sync

### DIFF
--- a/startup-staging.sh
+++ b/startup-staging.sh
@@ -31,11 +31,10 @@ echo "✅ Database migrations completed successfully"
 
 # Sync production data to staging if both database URLs are available
 if [ -n "$PROD_DATABASE_URL" ] && [ -n "$STAGING_DATABASE_URL" ]; then
-    echo "📊 Starting production data sync in background..."
-    nohup python sync_staging_db.py > /tmp/sync.log 2>&1 &
-    SYNC_PID=$!
-    echo "💡 Sync running in background (PID: $SYNC_PID) - check /tmp/sync.log for status"
-    echo "   App will start immediately and sync will complete shortly"
+    echo "📊 Starting production data sync..."
+    echo "💡 This will run synchronously to ensure visibility in deployment logs"
+    python sync_staging_db.py
+    echo "✅ Production data sync completed"
 else
     echo "⚠️  Required environment variables not set, skipping production data sync"
     echo "   Staging will use empty database"


### PR DESCRIPTION
The sync that keeps the staging environment's DB up to date with production was failing due to the staging app not having permissions to access the prod DB. I fixed that, but am also changing it so that now if the sync fails, it will cause the deployment to fail and I'll know about it.

Eventually if the prod DB gets huge and this sync is slow, we can revisit this and consider running the sync in the background again.