### PR TITLE
chore: redirect back to an item's page after editing it

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -280,7 +280,8 @@ def edit_item(item_id):
 
         db.session.commit()
         flash('Item has been updated.', 'success')
-        return redirect(url_for('main.profile'))
+        # After editing an item, redirect the user back to the item's detail page
+        return redirect(url_for('main.item_detail', item_id=item.id))
     
     # Prepopulate tags field
     form.tags.data = ', '.join([tag.name for tag in item.tags])


### PR DESCRIPTION
That way you can see the changes took place. It previously took you back to your profile, which seems undesirable.