### PR TITLE
feat: filter homepage items by shared circle membership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ app/static/uploads/circles/*
 !app/static/uploads/items/.gitkeep
 !app/static/uploads/profiles/.gitkeep
 !app/static/uploads/circles/.gitkeep
+
+# markdown design files
+dev_docs/*

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -72,9 +72,9 @@
                 <div class="empty-state">
                     <i class="fas fa-users-slash"></i>
                     <h4>No circles yet</h4>
-                    <p>You're not a member of any circles yet. Create one to start sharing resources with your community!</p>
-                    <a href="{{ url_for('circles.create_circle') }}" class="btn btn-primary">
-                        <i class="fas fa-plus me-1"></i>Create Your First Circle
+                    <p>You're not a member of any circles yet. Join a circle near you to start sharing resources with your community!</p>
+                    <a href="{{ url_for('circles.search_circles') }}" class="btn btn-primary">
+                        <i class="fas fa-search me-1"></i>Find Circles to Join
                     </a>
                 </div>
             {% endif %}
@@ -156,16 +156,24 @@
         {% else %}
             <div class="empty-state">
                 <i class="fas fa-box"></i>
-                <h4>No items available</h4>
-                <p>No items are currently available for sharing. {% if current_user.is_authenticated %}Be the first to list something!{% else %}Join our community to start sharing.{% endif %}</p>
-                {% if current_user.is_authenticated %}
-                    <a href="{{ url_for('main.list_item') }}" class="btn btn-primary">
-                        <i class="fas fa-plus me-1"></i>List Your First Item
+                {% if current_user.is_authenticated and not circles %}
+                    <h4>Join a circle to see items</h4>
+                    <p>You're not a member of any circles yet. Join a circle near you to see items from your community!</p>
+                    <a href="{{ url_for('circles.search_circles') }}" class="btn btn-primary">
+                        <i class="fas fa-search me-1"></i>Find Circles to Join
                     </a>
                 {% else %}
-                    <a href="{{ url_for('auth.register') }}" class="btn btn-primary">
-                        <i class="fas fa-user-plus me-1"></i>Join Meutch
-                    </a>
+                    <h4>No items available</h4>
+                    <p>No items are currently available for sharing. {% if current_user.is_authenticated %}Be the first to list something!{% else %}Join our community to start sharing.{% endif %}</p>
+                    {% if current_user.is_authenticated %}
+                        <a href="{{ url_for('main.list_item') }}" class="btn btn-primary">
+                            <i class="fas fa-plus me-1"></i>List Your First Item
+                        </a>
+                    {% else %}
+                        <a href="{{ url_for('auth.register') }}" class="btn btn-primary">
+                            <i class="fas fa-user-plus me-1"></i>Join Meutch
+                        </a>
+                    {% endif %}
                 {% endif %}
             </div>
         {% endif %}

--- a/tests/integration/test_item_visibility.py
+++ b/tests/integration/test_item_visibility.py
@@ -2,6 +2,7 @@ import pytest
 from app.models import Item, User, Category, Circle, db, circle_members
 from tests.factories import UserFactory, ItemFactory, CategoryFactory, CircleFactory
 from flask import url_for
+from conftest import login_user
 
 @pytest.mark.usefixtures('app')
 class TestItemVisibility:
@@ -49,3 +50,155 @@ class TestItemVisibility:
         assert response.status_code == 200
         # The item should be visible
         assert item.name.encode() in response.data
+
+    def test_authenticated_user_does_not_see_own_items(self, client):
+        """Test that authenticated users don't see their own items on homepage."""
+        category = CategoryFactory()
+        user = UserFactory()
+        db.session.commit()
+        
+        # Create a circle and add user
+        circle = CircleFactory(requires_approval=False)
+        db.session.commit()
+        db.session.execute(circle_members.insert().values(user_id=user.id, circle_id=circle.id))
+        db.session.commit()
+        
+        # Create an item owned by the user
+        item = ItemFactory(owner=user, category=category)
+        db.session.commit()
+        
+        # Login as the user
+        login_user(client, user.email)
+        
+        response = client.get(url_for('main.index'))
+        assert response.status_code == 200
+        # User should NOT see their own item
+        assert item.name.encode() not in response.data
+
+    def test_authenticated_user_sees_items_from_shared_circle(self, client):
+        """Test that authenticated users see items from users in shared circles."""
+        category = CategoryFactory()
+        user1 = UserFactory()
+        user2 = UserFactory()
+        db.session.commit()
+        
+        # Create a circle and add both users
+        circle = CircleFactory(requires_approval=False)
+        db.session.commit()
+        db.session.execute(circle_members.insert().values(user_id=user1.id, circle_id=circle.id))
+        db.session.execute(circle_members.insert().values(user_id=user2.id, circle_id=circle.id))
+        db.session.commit()
+        
+        # Create an item owned by user2
+        item = ItemFactory(owner=user2, category=category)
+        db.session.commit()
+        
+        # Login as user1
+        login_user(client, user1.email)
+        
+        response = client.get(url_for('main.index'))
+        assert response.status_code == 200
+        # User1 should see user2's item
+        assert item.name.encode() in response.data
+
+    def test_authenticated_user_does_not_see_items_from_non_circle_members(self, client):
+        """Test that authenticated users don't see items from users not in their circles."""
+        category = CategoryFactory()
+        user1 = UserFactory()
+        user2 = UserFactory()
+        user3 = UserFactory()
+        db.session.commit()
+        
+        # Create two separate circles
+        circle1 = CircleFactory(requires_approval=False)
+        circle2 = CircleFactory(requires_approval=False)
+        db.session.commit()
+        
+        # Add user1 to circle1, user3 to circle2 (no overlap)
+        db.session.execute(circle_members.insert().values(user_id=user1.id, circle_id=circle1.id))
+        db.session.execute(circle_members.insert().values(user_id=user3.id, circle_id=circle2.id))
+        db.session.commit()
+        
+        # Create items for user2 (not in any circle) and user3 (in different circle)
+        item2 = ItemFactory(owner=user2, category=category, name="User2 Item")
+        item3 = ItemFactory(owner=user3, category=category, name="User3 Item")
+        db.session.commit()
+        
+        # Login as user1
+        login_user(client, user1.email)
+        
+        response = client.get(url_for('main.index'))
+        assert response.status_code == 200
+        # User1 should NOT see items from user2 or user3
+        assert item2.name.encode() not in response.data
+        assert item3.name.encode() not in response.data
+
+    def test_authenticated_user_sees_items_from_multiple_circles(self, client):
+        """Test that authenticated users see items from all their circles."""
+        category = CategoryFactory()
+        user1 = UserFactory()
+        user2 = UserFactory()
+        user3 = UserFactory()
+        db.session.commit()
+        
+        # Create two circles
+        circle1 = CircleFactory(requires_approval=False, name="Circle 1")
+        circle2 = CircleFactory(requires_approval=False, name="Circle 2")
+        db.session.commit()
+        
+        # Add user1 to both circles, user2 to circle1, user3 to circle2
+        db.session.execute(circle_members.insert().values(user_id=user1.id, circle_id=circle1.id))
+        db.session.execute(circle_members.insert().values(user_id=user1.id, circle_id=circle2.id))
+        db.session.execute(circle_members.insert().values(user_id=user2.id, circle_id=circle1.id))
+        db.session.execute(circle_members.insert().values(user_id=user3.id, circle_id=circle2.id))
+        db.session.commit()
+        
+        # Create items for user2 and user3
+        item2 = ItemFactory(owner=user2, category=category, name="User2 Item from Circle1")
+        item3 = ItemFactory(owner=user3, category=category, name="User3 Item from Circle2")
+        db.session.commit()
+        
+        # Login as user1
+        login_user(client, user1.email)
+        
+        response = client.get(url_for('main.index'))
+        assert response.status_code == 200
+        # User1 should see items from both circles
+        assert item2.name.encode() in response.data
+        assert item3.name.encode() in response.data
+
+    def test_authenticated_user_with_no_circles_sees_empty_state(self, client):
+        """Test that authenticated users with no circles see the 'Join a circle' message."""
+        user = UserFactory()
+        db.session.commit()
+        
+        # Login as user (who is not in any circles)
+        login_user(client, user.email)
+        
+        response = client.get(url_for('main.index'))
+        assert response.status_code == 200
+        response_text = response.data.decode('utf-8')
+        # Should see the join circle message
+        assert 'Join a circle to see items' in response_text
+        assert 'Find Circles to Join' in response_text
+
+    def test_authenticated_user_in_circle_with_no_other_members(self, client):
+        """Test authenticated user in a circle alone sees empty state."""
+        category = CategoryFactory()
+        user = UserFactory()
+        db.session.commit()
+        
+        # Create a circle with only this user
+        circle = CircleFactory(requires_approval=False)
+        db.session.commit()
+        db.session.execute(circle_members.insert().values(user_id=user.id, circle_id=circle.id))
+        db.session.commit()
+        
+        # Login as user
+        login_user(client, user.email)
+        
+        response = client.get(url_for('main.index'))
+        assert response.status_code == 200
+        response_text = response.data.decode('utf-8')
+        # Should see empty state (no items from circle-mates)
+        assert 'No items available' in response_text or 'Join a circle' in response_text

--- a/tests/integration/test_routes.py
+++ b/tests/integration/test_routes.py
@@ -53,18 +53,20 @@ class TestMainRoutes:
         """Test that authenticated users get pagination controls."""
         with app.app_context():
             user = auth_user()
+            other_user = UserFactory()
             category = CategoryFactory()
             
-            # Create a public circle and add the user to it
+            # Create a circle and add both users to it so auth_user can see other_user's items
             from app.models import Circle
-            circle = Circle(name="Test Public Circle", description="Test", requires_approval=False)
+            circle = Circle(name="Test Circle", description="Test", requires_approval=False)
             db.session.add(circle)
             circle.members.append(user)
+            circle.members.append(other_user)
             db.session.commit()
             
-            # Create more than 12 items to trigger pagination
+            # Create more than 12 items for the other user (not auth_user)
             for i in range(15):
-                ItemFactory(owner=user, category=category, available=True)
+                ItemFactory(owner=other_user, category=category, available=True)
             
             login_user(client, user.email)
             response = client.get('/')


### PR DESCRIPTION
- Authenticated users now only see items from users who share at least one circle with them
- Own items are always excluded from homepage view
- Users with no circles see empty state encouraging them to find and join existing circles
- Unauthenticated users continue to see items from all public circle members (unchanged)*
- Maintains chronological ordering (`created_at` desc) and pagination (12 items/page)

*I will fix this in a subsequent PR, where public users will see only items from specially-flagged users.