### PR TITLE
fix: pass ?next parameter into token confirmation email

### DIFF
--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -50,7 +50,7 @@ def send_email(to_email, subject, text_content, html_content=None):
         return False
 
 
-def send_confirmation_email(user):
+def send_confirmation_email(user, next_url=None):
     """Send email confirmation to user"""
     from app import db  # Import db here to avoid circular imports
     
@@ -58,7 +58,10 @@ def send_confirmation_email(user):
     
     db.session.commit()
     
-    confirmation_url = url_for('auth.confirm_email', token=token, _external=True)
+    url_kwargs = dict(token=token, _external=True)
+    if next_url:
+        url_kwargs['next'] = next_url
+    confirmation_url = url_for('auth.confirm_email', **url_kwargs)
     
     print(f"Confirmation URL: {confirmation_url}")
     


### PR DESCRIPTION
Fixes #237

This PR rolls back some of #232 and attempts to successfully persist  the `?next` value through the registration flow, by adding it as a parameter to the confirm-email-address token link.

Note that due to the email aspect of this bug, this is hard to test with 100% authenticity on local or even staging, so I may lean toward merging to main and completing my testing there.