### PR TITLE
fix: handle circle join message notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 ### Bug Fixes
 - Fix: submitting a borrow request without a message now correctly shows an inline validation error instead of silently doing nothing on mobile browsers ([#213](https://github.com/sfirke/meutch/issues/213)).
 - Fix: users without location set now can't create public giveaways or requests ([#231](https://github.com/sfirke/meutch/issues/231)). 
+- Fix: pending private-circle join approvals no longer count as unread messages; circles pending badge remains the admin signal, and already-handled join requests can no longer be re-processed by another admin.
 
 ## Feb 2026
 

--- a/app/circles/routes.py
+++ b/app/circles/routes.py
@@ -310,27 +310,6 @@ def join_circle(circle_id):
             )
             db.session.add(join_request)
 
-            admin_users = User.query.join(
-                circle_members,
-                and_(
-                    User.id == circle_members.c.user_id,
-                    circle_members.c.circle_id == circle.id,
-                    circle_members.c.is_admin == True
-                )
-            ).all()
-
-            for admin_user in admin_users:
-                notification_message = Message(
-                    sender_id=current_user.id,
-                    recipient_id=admin_user.id,
-                    circle_id=circle.id,
-                    body=(
-                        f"{current_user.full_name} requested to join the circle '{circle.name}'."
-                        + (f" Message: {form.message.data}" if form.message.data else "")
-                    )
-                )
-                db.session.add(notification_message)
-
             db.session.commit()
             
             # Send email notification to circle admins
@@ -419,6 +398,10 @@ def handle_join_request(circle_id, request_id, action):
     
     if join_request.circle_id != circle.id:
         flash('Invalid join request.', 'danger')
+        return redirect(url_for('circles.view_circle', circle_id=circle_id))
+
+    if join_request.status != 'pending':
+        flash('This join request has already been handled.', 'info')
         return redirect(url_for('circles.view_circle', circle_id=circle_id))
     
     if action == 'approve':

--- a/app/context_processors.py
+++ b/app/context_processors.py
@@ -1,14 +1,12 @@
 # app/context_processors.py
 
 from flask_login import current_user
-from sqlalchemy import select
 from app.utils.geocoding import format_distance
 # Remove model imports from top level
 
 def inject_unread_messages_count():
     # Import models at function level to avoid circular imports
-    from app import db
-    from app.models import Message, CircleJoinRequest, circle_members
+    from app.models import Message
 
     if current_user.is_authenticated:
         # Count all unread messages where the current user is the recipient
@@ -19,23 +17,7 @@ def inject_unread_messages_count():
             Message.sender_id != current_user.id  # Exclude self-sent messages
         ).count()
 
-        # Also include pending circle join requests for circles where the user is an admin
-        # Find circles current_user administers
-        admin_circle_ids_sq = select(circle_members.c.circle_id).where(
-            circle_members.c.user_id == current_user.id,
-            circle_members.c.is_admin == True,
-        )
-
-        pending_join_requests = (
-            db.session.query(CircleJoinRequest)
-            .filter(
-                CircleJoinRequest.circle_id.in_(admin_circle_ids_sq),
-                CircleJoinRequest.status == 'pending',
-            )
-            .count()
-        )
-
-        return dict(unread_messages_count=unread_messages + pending_join_requests)
+        return dict(unread_messages_count=unread_messages)
     return dict(unread_messages_count=0)
 
 def inject_total_pending():

--- a/tests/integration/test_circle_join_email_notifications.py
+++ b/tests/integration/test_circle_join_email_notifications.py
@@ -54,15 +54,12 @@ class TestCircleJoinRequestEmailIntegration:
                 # Verify email was sent to both admins
                 assert mock_send_email.call_count == 2
 
-                # Verify in-app messages were created for both admins
+                # Verify no in-app messages were created for admins
                 admin_messages = Message.query.filter_by(
                     sender_id=requesting_user.id,
                     circle_id=circle.id
                 ).all()
-                assert len(admin_messages) == 2
-                admin_recipient_ids = {msg.recipient_id for msg in admin_messages}
-                assert admin_recipient_ids == {admin1.id, admin2.id}
-                assert all("requested to join the circle" in msg.body for msg in admin_messages)
+                assert len(admin_messages) == 0
                 
                 # Check that both admins received emails
                 call_args_list = mock_send_email.call_args_list
@@ -76,20 +73,77 @@ class TestCircleJoinRequestEmailIntegration:
                 assert 'New Join Request for Test Circle' in subject
                 assert 'I would like to join this circle please!' in text_content
 
-                # Verify circle conversations are visible in existing inbox/thread UX
-                login_user(client, admin1.email)
-                inbox_response = client.get('/messages')
-                assert inbox_response.status_code == 200
-                assert b'Circle: Test Circle' in inbox_response.data
+    def test_second_admin_action_on_handled_request_is_ignored(self, client, app):
+        """A handled join request should not be handled again by another admin."""
+        with app.app_context():
+            requesting_user = UserFactory()
+            admin1 = UserFactory()
+            admin2 = UserFactory()
+            circle = CircleFactory(name='Test Circle', requires_approval=True)
 
-                thread_message = Message.query.filter_by(
-                    sender_id=requesting_user.id,
-                    recipient_id=admin1.id,
+            db.session.execute(
+                circle_members.insert().values(
+                    user_id=admin1.id,
+                    circle_id=circle.id,
+                    joined_at=datetime.now(UTC),
+                    is_admin=True
+                )
+            )
+            db.session.execute(
+                circle_members.insert().values(
+                    user_id=admin2.id,
+                    circle_id=circle.id,
+                    joined_at=datetime.now(UTC),
+                    is_admin=True
+                )
+            )
+
+            join_request = CircleJoinRequest(
+                circle_id=circle.id,
+                user_id=requesting_user.id,
+                message='Please let me join',
+                status='pending'
+            )
+            db.session.add(join_request)
+            db.session.commit()
+
+            with patch('app.utils.email.send_email') as mock_send_email:
+                mock_send_email.return_value = True
+
+                login_user(client, admin1.email)
+                first_response = client.post(
+                    f'/circles/{circle.id}/request/{join_request.id}/approve',
+                    follow_redirects=True
+                )
+                assert first_response.status_code == 200
+
+                join_request = db.session.get(CircleJoinRequest, join_request.id)
+                assert join_request.status == 'approved'
+                assert mock_send_email.call_count == 1
+
+                first_decision_count = Message.query.filter_by(
+                    recipient_id=requesting_user.id,
                     circle_id=circle.id
-                ).first()
-                thread_response = client.get(f'/message/{thread_message.id}')
-                assert thread_response.status_code == 200
-                assert b'Circle: Test Circle' in thread_response.data
+                ).count()
+                assert first_decision_count == 1
+
+                login_user(client, admin2.email)
+                second_response = client.post(
+                    f'/circles/{circle.id}/request/{join_request.id}/reject',
+                    follow_redirects=True
+                )
+                assert second_response.status_code == 200
+                assert b'already been handled' in second_response.data
+
+                join_request = db.session.get(CircleJoinRequest, join_request.id)
+                assert join_request.status == 'approved'
+                assert mock_send_email.call_count == 1
+
+                second_decision_count = Message.query.filter_by(
+                    recipient_id=requesting_user.id,
+                    circle_id=circle.id
+                ).count()
+                assert second_decision_count == 1
 
     def test_approve_join_request_sends_email_notification(self, client, app):
         """Test that approving a join request sends email notification to the requesting user."""

--- a/tests/unit/test_context_processors.py
+++ b/tests/unit/test_context_processors.py
@@ -195,8 +195,8 @@ class TestUnreadMessagesCount:
             # Both counts should be identical
             assert context_count == conversation_count == 2
 
-    def test_inject_unread_messages_count_includes_pending_circle_requests_for_admin(self, app):
-        """Admins should see pending circle join requests counted."""
+    def test_inject_unread_messages_count_excludes_pending_circle_requests_for_admin(self, app):
+        """Pending circle join requests should not contribute to unread message count."""
         with app.app_context():
             admin = UserFactory()
             requester1 = UserFactory()
@@ -220,7 +220,7 @@ class TestUnreadMessagesCount:
 
             with patch('app.context_processors.current_user', admin):
                 result = inject_unread_messages_count()
-                assert result == {'unread_messages_count': 2}
+                assert result == {'unread_messages_count': 0}
 
     def test_inject_unread_messages_count_excludes_circle_requests_for_non_admin(self, app):
         """Non-admin members should not see pending join requests counted."""


### PR DESCRIPTION
Fix #247.  Pending private-circle join approvals no longer count as unread messages; circles pending badge remains the admin signal, and already-handled join requests can no longer be re-processed by another admin.