### PR TITLE
fix: unread-messages bubble alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Requests feed now defaults to an "All" view that combines public requests and shared-circle requests, keeps a "My Circles" filter, and defaults new requests to public visibility ([#255](https://github.com/sfirke/meutch/pull/255)).
 - Make all text adjacent to a radio button or checkbox tappable ([#263](https://github.com/sfirke/meutch/pull/263)).
 - Improve conversation view about an item (image formatting, say "pending pickup" instead of "borrowed") ([#264](https://github.com/sfirke/meutch/pull/264)).
+- Fix unread message badge alignment on mobile and desktop for clarity ([#265](https://github.com/sfirke/meutch/pull/265)).
 
 ### Bug Fixes
 - Fix: submitting a borrow request without a message now correctly shows an inline validation error instead of silently doing nothing on mobile browsers ([#213](https://github.com/sfirke/meutch/issues/213)).

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -83,8 +83,8 @@
                 <ul class="navbar-nav">
                     {% if current_user.is_authenticated %}
                         <li class="nav-item">
-                            <a class="nav-link d-inline-flex align-items-center gap-2" href="{{ url_for('main.messages') }}">
-                                <span class="d-inline-flex align-items-center">
+                            <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('main.messages') }}">
+                                <span class="d-flex align-items-center">
                                     <i class="fas fa-envelope me-1"></i>Messages
                                 </span>
                                 {% if unread_messages_count > 0 %}
@@ -95,8 +95,8 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link d-inline-flex align-items-center gap-2" href="{{ url_for('circles.manage_circles') }}">
-                                <span class="d-inline-flex align-items-center">
+                            <a class="nav-link d-flex align-items-center gap-2" href="{{ url_for('circles.manage_circles') }}">
+                                <span class="d-flex align-items-center">
                                     <i class="fas fa-users me-1"></i>Circles
                                 </span>
                                 {% if total_pending > 0 %}


### PR DESCRIPTION
fix #212 - behaves correctly now on mobile and PC, also adds full-width clickability to mobile menu buttons for Circles and Messages

AFTER (PC):
<img width="468" height="113" alt="image" src="https://github.com/user-attachments/assets/34e83787-ae3c-4b15-b1d0-061f11d0b202" />
