### PR TITLE
chore: rename 'free' to 'giveaway' on item card ribbon

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -355,16 +355,16 @@ h1 {
 
 .giveaway-ribbon {
     position: absolute;
-    top: 0.85rem;
-    left: -2.35rem;
-    width: 8rem;
-    padding: 0.2rem 0;
+    top: 1.1rem;
+    left: -3.1rem;
+    width: 11rem;
+    padding: 0.3rem 0;
     background-color: #198754;
     color: #fff;
     text-align: center;
     font-size: 0.72rem;
     font-weight: 700;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.07em;
     transform: rotate(-45deg);
     z-index: 1;
 }

--- a/app/templates/main/_item_card.html
+++ b/app/templates/main/_item_card.html
@@ -5,7 +5,7 @@
             <!-- Giveaway badge -->
             {% if item.is_giveaway %}
                 <span class="giveaway-ribbon">
-                    FREE
+                    GIVEAWAY
                 </span>
             {% endif %}
             <!-- Availability status badge -->
@@ -27,7 +27,7 @@
             <!-- Giveaway badge for items without images -->
             {% if item.is_giveaway %}
                 <span class="giveaway-ribbon">
-                    FREE
+                    GIVEAWAY
                 </span>
             {% endif %}
             <!-- Availability status badge for items without images -->


### PR DESCRIPTION
"FREE" was confusing because everything on Meutch is free. These items are different because they're giveaways, not loans. This makes that clearer.
<img width="491" height="768" alt="image" src="https://github.com/user-attachments/assets/33f971e9-a0cb-4799-92a3-f5a7d8b53a88" />

Credit to my son Ari for reporting this issue.