### PR TITLE
Fix #315: Adjust cropper nodes to 10px with -5px margin for symmetry

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1255,6 +1255,15 @@ footer h6 {
 .cropper-point::before {
     display: none !important;
 }
+
+/* Multi-image drag and drop support */
+.multi-image-container.drag-over {
+    border: 2px dashed var(--primary-color) !important;
+    background-color: rgba(79, 209, 199, 0.1) !important;
+    border-radius: var(--border-radius);
+    transition: all 0.2s ease;
+}
+
 /* ============================================
    Requests Feed — Social-media-style cards
    ============================================ */

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2,15 +2,24 @@
 
 /* Root Variables for easy theming */
 :root {
-    --primary-color: #4fd1c7;        /* Soft teal */
-    --primary-dark: #319795;         /* Darker teal */
-    --secondary-color: #718096;      /* Muted gray */
-    --success-color: #38b2ac;        /* Teal green */
-    --warning-color: #f6ad55;        /* Goldenrod */
-    --danger-color: #fc8181;         /* Coral */
-    --light-bg: #fffffe;             /* Off-white */
-    --dark-text: #2d3748;            /* Dark gray */
-    --muted-text: #718096;           /* Muted gray */
+    --primary-color: #4fd1c7;
+    /* Soft teal */
+    --primary-dark: #319795;
+    /* Darker teal */
+    --secondary-color: #718096;
+    /* Muted gray */
+    --success-color: #38b2ac;
+    /* Teal green */
+    --warning-color: #f6ad55;
+    /* Goldenrod */
+    --danger-color: #fc8181;
+    /* Coral */
+    --light-bg: #fffffe;
+    /* Off-white */
+    --dark-text: #2d3748;
+    /* Dark gray */
+    --muted-text: #718096;
+    /* Muted gray */
     --border-color: #e2e8f0;
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
     --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
@@ -26,7 +35,8 @@ body {
     background-color: var(--light-bg);
     color: var(--dark-text);
     line-height: 1.6;
-    padding-top: 70px; /* Account for fixed navbar */
+    padding-top: 70px;
+    /* Account for fixed navbar */
 }
 
 /* Custom Bootstrap Variables Override */
@@ -90,6 +100,7 @@ body {
         opacity: 0;
         transform: translateY(-20px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);
@@ -155,11 +166,17 @@ body {
 }
 
 .main-content .row:first-child.mb-5 {
-    margin-bottom: 2rem !important; /* Reduce from default 3rem */
+    margin-bottom: 2rem !important;
+    /* Reduce from default 3rem */
 }
 
 /* Typography */
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
     font-weight: 600;
     color: var(--dark-text);
     margin-bottom: 1rem;
@@ -370,7 +387,8 @@ h1 {
 }
 
 /* Tags and Categories */
-.category, .tag {
+.category,
+.tag {
     display: inline-block;
     padding: 0.25rem 0.75rem;
     margin: 0.125rem;
@@ -398,7 +416,8 @@ h1 {
 
 /* Tag-specific styling */
 .tag {
-    background: rgba(79, 209, 199, 0.1); /* Light teal background using primary color */
+    background: rgba(79, 209, 199, 0.1);
+    /* Light teal background using primary color */
     color: var(--primary-dark);
     border-color: var(--primary-color);
 }
@@ -463,7 +482,7 @@ input[type="file"]:focus {
         justify-content: center;
         text-align: center;
     }
-    
+
     input[type="file"]::file-selector-button {
         background: var(--primary-color);
         color: white;
@@ -475,7 +494,7 @@ input[type="file"]:focus {
         cursor: pointer;
         transition: background-color 0.2s ease;
     }
-    
+
     input[type="file"]::file-selector-button:hover {
         background: var(--primary-dark);
     }
@@ -535,11 +554,13 @@ input[type="file"]:focus {
 }
 
 /* Sections */
-.user-circles, .items-section {
+.user-circles,
+.items-section {
     margin-bottom: 3rem;
 }
 
-.user-circles h2, .items-section h2 {
+.user-circles h2,
+.items-section h2 {
     color: var(--dark-text);
     font-weight: 600;
     font-size: 1.75rem;
@@ -577,31 +598,31 @@ footer h6 {
     .main-content {
         padding: 1rem 0;
     }
-    
+
     h1 {
         font-size: 2rem;
     }
-    
+
     /* Hero logo smaller on mobile */
     .hero-logo {
         width: 80px;
         height: 80px;
     }
-    
+
     .items-grid {
         grid-template-columns: 1fr;
         gap: 1rem;
     }
-    
+
     .circles-grid {
         grid-template-columns: 1fr;
         gap: 1rem;
     }
-    
+
     .card-body {
         padding: 1rem;
     }
-    
+
     .circle-card {
         padding: 1rem;
     }
@@ -621,11 +642,11 @@ footer h6 {
     body {
         padding-top: 70px;
     }
-    
+
     .navbar-brand {
         font-size: 1.25rem;
     }
-    
+
     .container {
         padding: 0 1rem;
     }
@@ -658,16 +679,17 @@ footer h6 {
 
 /* Print styles */
 @media print {
+
     .navbar,
     footer,
     .btn {
         display: none !important;
     }
-    
+
     .main-content {
         padding-top: 0;
     }
-    
+
     .card {
         box-shadow: none;
         border: 1px solid #ccc;
@@ -687,8 +709,10 @@ footer h6 {
 
 /* Optional: Ensure images don't have default link styles */
 .item-link img {
-    display: block; /* Removes bottom margin/padding */
-    color: inherit; /* Inherit text color */
+    display: block;
+    /* Removes bottom margin/padding */
+    color: inherit;
+    /* Inherit text color */
 }
 
 /* Ensure inner text doesn't get extra styles from <a> */
@@ -700,7 +724,8 @@ footer h6 {
 /* Ensure the 'My Items' edit and delete buttons are styled correctly */
 .card-footer a.btn {
     margin-right: 5px;
-    text-decoration: none; /* Remove underlines from buttons */
+    text-decoration: none;
+    /* Remove underlines from buttons */
 }
 
 /* Optional: Prevent links inside the card footer from affecting the parent link */
@@ -720,6 +745,7 @@ footer h6 {
     position: relative;
     z-index: 2;
 }
+
 /* Ensure text colors are readable */
 .card-title.text-primary {
     color: #007bff !important;
@@ -734,21 +760,25 @@ footer h6 {
     height: 150px;
     object-fit: cover;
     border-radius: 50%;
-    border: 2px solid #ddd; /* Optional: Add a border for better appearance */
+    border: 2px solid #ddd;
+    /* Optional: Add a border for better appearance */
 }
 
 .profile-picture-link {
     position: fixed;
     top: 15px;
     right: 15px;
-    z-index: 1000; /* Ensures the profile picture stays above other elements */
+    z-index: 1000;
+    /* Ensures the profile picture stays above other elements */
 }
 
 .profile-picture-small {
     border-radius: 50%;
     object-fit: cover;
-    border: 2px solid #fff; /* Optional: Adds a white border around the image */
-    box-shadow: 0 0 5px rgba(0, 0, 0, 0.3); /* Optional: Adds a subtle shadow for depth */
+    border: 2px solid #fff;
+    /* Optional: Adds a white border around the image */
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+    /* Optional: Adds a subtle shadow for depth */
     cursor: pointer;
 }
 
@@ -761,7 +791,8 @@ footer h6 {
 }
 
 .faq-item h4 {
-    color: #0d6efd; /* Bootstrap primary color */
+    color: #0d6efd;
+    /* Bootstrap primary color */
 }
 
 .faq-item p {
@@ -770,7 +801,8 @@ footer h6 {
 }
 
 .item-image {
-    max-width: 400px; /* Adjust the value as needed */
+    max-width: 400px;
+    /* Adjust the value as needed */
     width: 100%;
     height: auto;
     object-fit: contain;
@@ -863,11 +895,11 @@ footer h6 {
         position: static;
         margin-bottom: 2rem;
     }
-    
+
     .item-detail-image {
         max-height: 60vh;
     }
-    
+
     .item-detail-image-placeholder {
         height: 300px;
     }
@@ -959,9 +991,12 @@ footer h6 {
 /* Flex Layout for Form Rows */
 .form-row {
     display: flex;
-    gap: 20px; /* Space between the columns */
-    align-items: flex-start; /* Align items to the top */
-    margin-bottom: 15px; /* Space below the row */
+    gap: 20px;
+    /* Space between the columns */
+    align-items: flex-start;
+    /* Align items to the top */
+    margin-bottom: 15px;
+    /* Space below the row */
 }
 
 .message-card {
@@ -970,34 +1005,44 @@ footer h6 {
     transition: transform 0.1s ease-in-out;
 }
 
-.message-mine, .message-theirs {
+.message-mine,
+.message-theirs {
     /* Remove margin-left and margin-right */
     margin-left: 0;
     margin-right: 0;
-    max-width: 80%; /* Optional: Adjust the width as needed */
+    max-width: 80%;
+    /* Optional: Adjust the width as needed */
     /* Ensure consistent padding */
     padding: 10px;
-    border-radius: 5px; /* Rounded corners for better aesthetics */
+    border-radius: 5px;
+    /* Rounded corners for better aesthetics */
 }
 
 /* Styles for messages sent by the current user */
 .message-mine {
-    background-color: #e3f2fd; /* Light blue */
-    border-left: 4px solid #1976d2; /* Blue border */
-    margin-left: 40px; /* Indent slightly from the left */
+    background-color: #e3f2fd;
+    /* Light blue */
+    border-left: 4px solid #1976d2;
+    /* Blue border */
+    margin-left: 40px;
+    /* Indent slightly from the left */
 }
 
 /* Styles for messages sent by others */
 .message-theirs {
-    background-color: #f5f5f5; /* Light grey */
-    border-left: 4px solid #757575; /* Grey border */
+    background-color: #f5f5f5;
+    /* Light grey */
+    border-left: 4px solid #757575;
+    /* Grey border */
     /* No indentation for others' messages */
 }
 
 /* Styles for loan-related messages */
 .message-loan {
-    border-left: 4px solid #ffc107; /* Amber border */
-    background-color: #fff8e1; /* Light amber background */
+    border-left: 4px solid #ffc107;
+    /* Amber border */
+    background-color: #fff8e1;
+    /* Light amber background */
 }
 
 .message-loan .card-header {
@@ -1006,7 +1051,8 @@ footer h6 {
 }
 
 .message-loan .loan-request-details {
-    background-color: #fff3cd; /* Light yellow background */
+    background-color: #fff3cd;
+    /* Light yellow background */
     border: 1px solid #ffeeba;
     padding: 10px;
     border-radius: 5px;
@@ -1014,7 +1060,8 @@ footer h6 {
 
 /* Optional: Add an icon to loan-related messages */
 .message-loan::before {
-    content: "📋"; /* Clipboard icon */
+    content: "📋";
+    /* Clipboard icon */
     margin-right: 8px;
     font-size: 1.2em;
     /* Ensure the icon doesn't disrupt the layout */
@@ -1024,7 +1071,8 @@ footer h6 {
 
 /* Optional: Different text color for loan-related messages */
 .message-loan p {
-    color: #856404; /* Dark yellow */
+    color: #856404;
+    /* Dark yellow */
 }
 
 /* Timestamp styling */
@@ -1043,14 +1091,16 @@ footer h6 {
 
 /* Unread message indicator */
 .unread-message {
-    border-bottom: 2px solid #dc3545; /* Red bottom border for unread messages */
+    border-bottom: 2px solid #dc3545;
+    /* Red bottom border for unread messages */
 }
 
 /* Additional styles for better distinction */
 .message-loan.message-mine {
     background-color: #fff3cd;
     border-left: 4px solid #ffc107;
-    margin-left: 40px; /* Maintain indentation */
+    margin-left: 40px;
+    /* Maintain indentation */
 }
 
 .message-loan.message-theirs {
@@ -1060,14 +1110,16 @@ footer h6 {
 
 /* Optional: Hover effects for loan-related messages */
 .message-loan:hover {
-    background-color: #ffeeba; /* Slightly darker amber on hover */
+    background-color: #ffeeba;
+    /* Slightly darker amber on hover */
 }
 
 /* Ensure icons are properly aligned */
 .message-loan .card-header::before,
 .message-loan .card-body::before {
     content: "";
-    display: none; /* Remove if not needed */
+    display: none;
+    /* Remove if not needed */
 }
 
 /* Optional: Improve readability by adding padding */
@@ -1077,7 +1129,8 @@ footer h6 {
 
 /* Optional: Adjust overall message card styles for better appearance */
 .message-card {
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* Subtle shadow for depth */
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    /* Subtle shadow for depth */
 }
 
 /* Thumbnail styling */
@@ -1188,33 +1241,35 @@ footer h6 {
 /* Mobile/Touch Device Optimization */
 /* Hide drag-and-drop specific UI on touch devices where drag-and-drop isn't supported */
 @media (hover: none) and (pointer: coarse) {
+
     /* Simplify the drop zone for mobile - remove drag language */
-    .drag-drop-zone .drag-drop-content > p:first-of-type,
-    .drag-drop-zone .drag-drop-content > p:nth-of-type(2) {
+    .drag-drop-zone .drag-drop-content>p:first-of-type,
+    .drag-drop-zone .drag-drop-content>p:nth-of-type(2) {
         display: none;
     }
-    
+
     /* Make the icon smaller and adjust spacing */
     .drag-drop-content .fa-cloud-upload-alt {
         font-size: 2rem !important;
         margin-bottom: 0.5rem !important;
     }
-    
+
     /* Reduce padding on mobile */
     .drag-drop-zone {
         padding: 1.5rem 1rem;
     }
-    
+
     /* Disable hover effects on touch devices */
     .drag-drop-zone:hover {
         border-color: var(--border-color);
         background-color: #fafafa;
     }
-    
+
     .drag-drop-zone:hover .fa-cloud-upload-alt {
         color: var(--muted-text);
     }
 }
+
 /* Node sizes and symmetry */
 .cropper-point {
     width: 35px !important;
@@ -1229,14 +1284,51 @@ footer h6 {
 }
 
 /* Bulletproof positioning using top/left percentages and translate */
-.cropper-point.point-e { top: 50% !important; left: 100% !important; right: auto !important; }
-.cropper-point.point-n { top: 0 !important; left: 50% !important; }
-.cropper-point.point-w { top: 50% !important; left: 0 !important; }
-.cropper-point.point-s { top: 100% !important; left: 50% !important; bottom: auto !important; }
-.cropper-point.point-ne { top: 0 !important; left: 100% !important; right: auto !important; }
-.cropper-point.point-nw { top: 0 !important; left: 0 !important; }
-.cropper-point.point-sw { top: 100% !important; left: 0 !important; bottom: auto !important; }
-.cropper-point.point-se { top: 100% !important; left: 100% !important; right: auto !important; bottom: auto !important; }
+.cropper-point.point-e {
+    top: 50% !important;
+    left: 100% !important;
+    right: auto !important;
+}
+
+.cropper-point.point-n {
+    top: 0 !important;
+    left: 50% !important;
+}
+
+.cropper-point.point-w {
+    top: 50% !important;
+    left: 0 !important;
+}
+
+.cropper-point.point-s {
+    top: 100% !important;
+    left: 50% !important;
+    bottom: auto !important;
+}
+
+.cropper-point.point-ne {
+    top: 0 !important;
+    left: 100% !important;
+    right: auto !important;
+}
+
+.cropper-point.point-nw {
+    top: 0 !important;
+    left: 0 !important;
+}
+
+.cropper-point.point-sw {
+    top: 100% !important;
+    left: 0 !important;
+    bottom: auto !important;
+}
+
+.cropper-point.point-se {
+    top: 100% !important;
+    left: 100% !important;
+    right: auto !important;
+    bottom: auto !important;
+}
 
 /* Hover */
 .cropper-point:hover {
@@ -1302,7 +1394,10 @@ footer h6 {
 .share-preview-hero::before {
     content: '';
     position: absolute;
-    top: 0; left: 0; right: 0; bottom: 0;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     background: rgba(0, 0, 0, 0.25);
     pointer-events: none;
 }
@@ -1641,6 +1736,7 @@ footer h6 {
 }
 
 @keyframes fab-attention {
+
     0%,
     100% {
         transform: scale(1);
@@ -1673,25 +1769,25 @@ footer h6 {
 }
 
 /* Checked states per type */
-.btn-check:checked + .feed-type-pill--requests {
+.btn-check:checked+.feed-type-pill--requests {
     background: var(--primary-color);
     border-color: var(--primary-color);
     color: white;
 }
 
-.btn-check:checked + .feed-type-pill--giveaways {
+.btn-check:checked+.feed-type-pill--giveaways {
     background: var(--success-color);
     border-color: var(--success-color);
     color: white;
 }
 
-.btn-check:checked + .feed-type-pill--circle-joins {
+.btn-check:checked+.feed-type-pill--circle-joins {
     background: #0dcaf0;
     border-color: #0dcaf0;
     color: white;
 }
 
-.btn-check:checked + .feed-type-pill--loans {
+.btn-check:checked+.feed-type-pill--loans {
     background: var(--secondary-color);
     border-color: var(--secondary-color);
     color: white;
@@ -1757,6 +1853,7 @@ html {
         font-weight: 600 !important;
         transition: background-color 0.2s ease, color 0.2s ease;
     }
+
     .nav-register:hover {
         background-color: var(--primary-color) !important;
         color: #fff !important;
@@ -1768,7 +1865,8 @@ html {
    - Desktop lg+: brand + Login + Register pill
 */
 .landing-page .navbar-toggler,
-.landing-page .navbar-mobile-login { /* already hidden here; shown outside collapse */
+.landing-page .navbar-mobile-login {
+    /* already hidden here; shown outside collapse */
 }
 
 .landing-page .navbar-toggler {
@@ -1790,9 +1888,11 @@ html {
         flex-grow: 1;
         align-items: center;
     }
+
     .landing-page .navbar-nav.me-auto {
         display: none !important;
     }
+
     .landing-page .navbar-collapse .navbar-nav {
         margin-left: auto;
     }
@@ -1811,7 +1911,10 @@ html {
 .landing-hero::before {
     content: '';
     position: absolute;
-    top: 0; left: 0; right: 0; bottom: 0;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     background: rgba(0, 0, 0, 0.25);
     pointer-events: none;
 }
@@ -1821,7 +1924,7 @@ html {
     height: 260px;
     object-fit: contain;
     opacity: 0.92;
-    filter: drop-shadow(0 8px 24px rgba(0,0,0,0.4));
+    filter: drop-shadow(0 8px 24px rgba(0, 0, 0, 0.4));
 }
 
 .landing-headline {
@@ -1911,7 +2014,7 @@ html {
     width: 64px;
     height: 64px;
     border-radius: 50%;
-    background: linear-gradient(135deg, rgba(79,209,199,0.15), rgba(49,151,149,0.15));
+    background: linear-gradient(135deg, rgba(79, 209, 199, 0.15), rgba(49, 151, 149, 0.15));
     color: var(--primary-dark);
     font-size: 1.5rem;
     display: flex;
@@ -2149,6 +2252,7 @@ body.multi-image-reordering * {
     .multi-image-thumb-overlay {
         opacity: 1;
     }
+
     .multi-image-grid {
         grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
         gap: 0.5rem;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1235,22 +1235,21 @@ footer h6 {
 }
 
 /* Corners */
-.cropper-point.point-se { right: -20px !important; bottom: -20px !important; }
-.cropper-point.point-sw { left: -20px !important; bottom: -20px !important; }
-.cropper-point.point-nw { left: -20px !important; top: -20px !important; }
-.cropper-point.point-ne { right: -20px !important; top: -20px !important; }
+.cropper-point.point-se { right: -18px !important; bottom: -18px !important; }
+.cropper-point.point-sw { left: -18px !important; bottom: -18px !important; }
+.cropper-point.point-nw { left: -18px !important; top: -18px !important; }
+.cropper-point.point-ne { right: -18px !important; top: -18px !important; }
 
 /* Sides */
-.cropper-point.point-n { top: -20px !important; left: 50% !important; }
-.cropper-point.point-s { bottom: -20px !important; left: 50% !important; }
-.cropper-point.point-e { right: -20px !important; top: 50% !important; }
-.cropper-point.point-w { left: -20px !important; top: 50% !important; }
+.cropper-point.point-n { top: -18px !important; left: 50% !important; }
+.cropper-point.point-s { bottom: -18px !important; left: 50% !important; }
+.cropper-point.point-e { right: -18px !important; top: 50% !important; }
+.cropper-point.point-w { left: -18px !important; top: 50% !important; }
 
 /* Cleanup */
 .cropper-point::before {
     display: none !important;
 }
-
 /* ============================================
    Requests Feed — Social-media-style cards
    ============================================ */

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1216,31 +1216,39 @@ footer h6 {
     }
 }
 
-/* ===================================================================
-   FIX: Image Cropper Drag Nodes Symmetry
-   =================================================================== */
-
 .cropper-point {
-    width: 10px !important;
-    height: 10px !important;
+    width: 35px !important;
+    height: 35px !important;
     background-color: var(--primary-color) !important;
-    opacity: 0.9 !important;
-    border: 1px solid white; /* Better visibility */
+    opacity: 0.95 !important;
+    border: 3px solid #fff;
     border-radius: 50%;
+
+    transform: translate(-50%, -50%) !important;
+    transition: all 0.2s ease;
+    z-index: 10;
 }
 
-/* Southeast (Bottom-Right) corner node adjustment */
-.cropper-point.point-se {
-    right: -5px !important;
-    bottom: -5px !important;
-    width: 12px !important; 
-    height: 12px !important;
+/* Hover */
+.cropper-point:hover {
+    transform: translate(-50%, -50%) scale(1.1);
 }
 
-/* Make corner points more visible with better contrast */
-.cropper-point {
-    opacity: 0.9 !important;
-    background-color: var(--primary-color) !important;
+/* Corners */
+.cropper-point.point-se { right: -20px !important; bottom: -20px !important; }
+.cropper-point.point-sw { left: -20px !important; bottom: -20px !important; }
+.cropper-point.point-nw { left: -20px !important; top: -20px !important; }
+.cropper-point.point-ne { right: -20px !important; top: -20px !important; }
+
+/* Sides */
+.cropper-point.point-n { top: -20px !important; left: 50% !important; }
+.cropper-point.point-s { bottom: -20px !important; left: 50% !important; }
+.cropper-point.point-e { right: -20px !important; top: 50% !important; }
+.cropper-point.point-w { left: -20px !important; top: 50% !important; }
+
+/* Cleanup */
+.cropper-point::before {
+    display: none !important;
 }
 
 /* ============================================

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1216,22 +1216,32 @@ footer h6 {
     }
 }
 
-/* Photo Preview - Cropper.js Customization */
-/* Make all corner handles mobile-friendly with large touch targets (48px minimum per WCAG) */
-/* but show as small, consistent circles for a polished appearance */
-/* Clip handles to the crop-box so all four corners show a consistent quarter-arc on load */
-.cropper-crop-box {
-    overflow: hidden !important;
-}
+/* ===================================================================
+   FIX: Image Cropper Drag Nodes Symmetry
+   =================================================================== */
+
+/* All drag points (blue circles) are used for resizing */
 .cropper-point {
-    width: 48px !important;
-    height: 48px !important;
-    margin-top: -24px !important;
-    margin-left: -24px !important;
-    background-color: transparent !important;
-    border: 3px solid var(--primary-color) !important;
-    border-radius: 50% !important;
-    opacity: 0.75 !important;
+    width: 10px !important;
+    height: 10px !important;
+    background-color: var(--primary-color) !important;
+    opacity: 0.9 !important;
+    border: 1px solid white; /* Better visibility */
+    border-radius: 50%;
+}
+
+/* Southeast (Bottom-Right) corner node adjustment */
+.cropper-point.point-se {
+    right: -5px !important;
+    bottom: -5px !important;
+    width: 12px !important; 
+    height: 12px !important;
+}
+
+/* Make corner points more visible with better contrast */
+.cropper-point {
+    opacity: 0.9 !important;
+    background-color: var(--primary-color) !important;
 }
 
 /* ============================================

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1223,28 +1223,33 @@ footer h6 {
     opacity: 0.95 !important;
     border: 3px solid #fff;
     border-radius: 50%;
-
-    transform: translate(-50%, -50%) !important;
+    margin: 0 !important; /* Reset Cropper margins */
     transition: all 0.2s ease;
     z-index: 10;
 }
 
-/* Hover */
-.cropper-point:hover {
-    transform: translate(-50%, -50%) scale(1.1);
-}
-
-/* Corners */
-.cropper-point.point-se { right: -18px !important; bottom: -18px !important; }
-.cropper-point.point-sw { left: -18px !important; bottom: -18px !important; }
-.cropper-point.point-nw { left: -18px !important; top: -18px !important; }
-.cropper-point.point-ne { right: -18px !important; top: -18px !important; }
+/* Base Transforms */
+.cropper-point.point-nw { left: 0 !important; top: 0 !important; transform: translate(-50%, -50%) !important; }
+.cropper-point.point-ne { right: 0 !important; top: 0 !important; transform: translate(50%, -50%) !important; }
+.cropper-point.point-sw { left: 0 !important; bottom: 0 !important; transform: translate(-50%, 50%) !important; }
+.cropper-point.point-se { right: 0 !important; bottom: 0 !important; transform: translate(50%, 50%) !important; }
 
 /* Sides */
-.cropper-point.point-n { top: -18px !important; left: 50% !important; }
-.cropper-point.point-s { bottom: -18px !important; left: 50% !important; }
-.cropper-point.point-e { right: -18px !important; top: 50% !important; }
-.cropper-point.point-w { left: -18px !important; top: 50% !important; }
+.cropper-point.point-n  { top: 0 !important; left: 50% !important; transform: translate(-50%, -50%) !important; }
+.cropper-point.point-s  { bottom: 0 !important; left: 50% !important; transform: translate(-50%, 50%) !important; }
+.cropper-point.point-e  { right: 0 !important; top: 50% !important; transform: translate(50%, -50%) !important; }
+.cropper-point.point-w  { left: 0 !important; top: 50% !important; transform: translate(-50%, -50%) !important; }
+
+/* Hover States */
+.cropper-point.point-nw:hover { transform: translate(-50%, -50%) scale(1.1) !important; }
+.cropper-point.point-ne:hover { transform: translate(50%, -50%) scale(1.1) !important; }
+.cropper-point.point-sw:hover { transform: translate(-50%, 50%) scale(1.1) !important; }
+.cropper-point.point-se:hover { transform: translate(50%, 50%) scale(1.1) !important; }
+
+.cropper-point.point-n:hover  { transform: translate(-50%, -50%) scale(1.1) !important; }
+.cropper-point.point-s:hover  { transform: translate(-50%, 50%) scale(1.1) !important; }
+.cropper-point.point-e:hover  { transform: translate(50%, -50%) scale(1.1) !important; }
+.cropper-point.point-w:hover  { transform: translate(-50%, -50%) scale(1.1) !important; }
 
 /* Cleanup */
 .cropper-point::before {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1215,41 +1215,33 @@ footer h6 {
         color: var(--muted-text);
     }
 }
-
+/* Node sizes and symmetry */
 .cropper-point {
     width: 35px !important;
     height: 35px !important;
     background-color: var(--primary-color) !important;
-    opacity: 0.95 !important;
-    border: 3px solid #fff;
+    opacity: 0.9 !important;
     border-radius: 50%;
-    margin: 0 !important; /* Reset Cropper margins */
     transition: all 0.2s ease;
     z-index: 10;
+    transform: translate(-50%, -50%) !important;
+    margin: 0 !important;
 }
 
-/* Base Transforms */
-.cropper-point.point-nw { left: 0 !important; top: 0 !important; transform: translate(-50%, -50%) !important; }
-.cropper-point.point-ne { right: 0 !important; top: 0 !important; transform: translate(50%, -50%) !important; }
-.cropper-point.point-sw { left: 0 !important; bottom: 0 !important; transform: translate(-50%, 50%) !important; }
-.cropper-point.point-se { right: 0 !important; bottom: 0 !important; transform: translate(50%, 50%) !important; }
+/* Bulletproof positioning using top/left percentages and translate */
+.cropper-point.point-e { top: 50% !important; left: 100% !important; right: auto !important; }
+.cropper-point.point-n { top: 0 !important; left: 50% !important; }
+.cropper-point.point-w { top: 50% !important; left: 0 !important; }
+.cropper-point.point-s { top: 100% !important; left: 50% !important; bottom: auto !important; }
+.cropper-point.point-ne { top: 0 !important; left: 100% !important; right: auto !important; }
+.cropper-point.point-nw { top: 0 !important; left: 0 !important; }
+.cropper-point.point-sw { top: 100% !important; left: 0 !important; bottom: auto !important; }
+.cropper-point.point-se { top: 100% !important; left: 100% !important; right: auto !important; bottom: auto !important; }
 
-/* Sides */
-.cropper-point.point-n  { top: 0 !important; left: 50% !important; transform: translate(-50%, -50%) !important; }
-.cropper-point.point-s  { bottom: 0 !important; left: 50% !important; transform: translate(-50%, 50%) !important; }
-.cropper-point.point-e  { right: 0 !important; top: 50% !important; transform: translate(50%, -50%) !important; }
-.cropper-point.point-w  { left: 0 !important; top: 50% !important; transform: translate(-50%, -50%) !important; }
-
-/* Hover States */
-.cropper-point.point-nw:hover { transform: translate(-50%, -50%) scale(1.1) !important; }
-.cropper-point.point-ne:hover { transform: translate(50%, -50%) scale(1.1) !important; }
-.cropper-point.point-sw:hover { transform: translate(-50%, 50%) scale(1.1) !important; }
-.cropper-point.point-se:hover { transform: translate(50%, 50%) scale(1.1) !important; }
-
-.cropper-point.point-n:hover  { transform: translate(-50%, -50%) scale(1.1) !important; }
-.cropper-point.point-s:hover  { transform: translate(-50%, 50%) scale(1.1) !important; }
-.cropper-point.point-e:hover  { transform: translate(50%, -50%) scale(1.1) !important; }
-.cropper-point.point-w:hover  { transform: translate(-50%, -50%) scale(1.1) !important; }
+/* Hover */
+.cropper-point:hover {
+    transform: translate(-50%, -50%) scale(1.1) !important;
+}
 
 /* Cleanup */
 .cropper-point::before {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1220,7 +1220,6 @@ footer h6 {
    FIX: Image Cropper Drag Nodes Symmetry
    =================================================================== */
 
-/* All drag points (blue circles) are used for resizing */
 .cropper-point {
     width: 10px !important;
     height: 10px !important;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1299,15 +1299,13 @@ footer h6 {
 }
 
 /* Photo Preview - Cropper.js Customization */
-/* Make all corner handles mobile-friendly with large touch targets (48px minimum per WCAG) */
-/* but show as small, consistent circles for a polished appearance */
-/* Node sizes and symmetry */
+/* Node sizes and symmetry - 30px circular handles with perfect centering */
 .cropper-point {
-    width: 35px !important;
-    height: 35px !important;
+    width: 30px !important;
+    height: 30px !important;
     background-color: var(--primary-color) !important;
     opacity: 0.9 !important;
-    border-radius: 50%;
+    border-radius: 50% !important;
     transition: all 0.2s ease;
     z-index: 10;
     transform: translate(-50%, -50%) !important;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1301,19 +1301,74 @@ footer h6 {
 /* Photo Preview - Cropper.js Customization */
 /* Make all corner handles mobile-friendly with large touch targets (48px minimum per WCAG) */
 /* but show as small, consistent circles for a polished appearance */
-/* Clip handles to the crop-box so all four corners show a consistent quarter-arc on load */
-.cropper-crop-box {
-    overflow: hidden !important;
-}
+/* Node sizes and symmetry */
 .cropper-point {
-    width: 48px !important;
-    height: 48px !important;
-    margin-top: -24px !important;
-    margin-left: -24px !important;
-    background-color: transparent !important;
-    border: 3px solid var(--primary-color) !important;
-    border-radius: 50% !important;
-    opacity: 0.75 !important;
+    width: 35px !important;
+    height: 35px !important;
+    background-color: var(--primary-color) !important;
+    opacity: 0.9 !important;
+    border-radius: 50%;
+    transition: all 0.2s ease;
+    z-index: 10;
+    transform: translate(-50%, -50%) !important;
+    margin: 0 !important;
+}
+
+/* Bulletproof positioning using top/left percentages and translate */
+.cropper-point.point-e {
+    top: 50% !important;
+    left: 100% !important;
+    right: auto !important;
+}
+
+.cropper-point.point-n {
+    top: 0 !important;
+    left: 50% !important;
+}
+
+.cropper-point.point-w {
+    top: 50% !important;
+    left: 0 !important;
+}
+
+.cropper-point.point-s {
+    top: 100% !important;
+    left: 50% !important;
+    bottom: auto !important;
+}
+
+.cropper-point.point-ne {
+    top: 0 !important;
+    left: 100% !important;
+    right: auto !important;
+}
+
+.cropper-point.point-nw {
+    top: 0 !important;
+    left: 0 !important;
+}
+
+.cropper-point.point-sw {
+    top: 100% !important;
+    left: 0 !important;
+    bottom: auto !important;
+}
+
+.cropper-point.point-se {
+    top: 100% !important;
+    left: 100% !important;
+    right: auto !important;
+    bottom: auto !important;
+}
+
+/* Hover */
+.cropper-point:hover {
+    transform: translate(-50%, -50%) scale(1.1) !important;
+}
+
+/* Cleanup */
+.cropper-point::before {
+    display: none !important;
 }
 
 /* ============================================

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1260,6 +1260,7 @@ footer h6 {
 
 .drag-drop-zone .browse-btn {
     pointer-events: all;
+    cursor: pointer;
 }
 
 .drag-drop-zone .file-info {
@@ -2120,6 +2121,18 @@ html {
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
     gap: 0.75rem;
     margin-bottom: 0.5rem;
+}
+
+.multi-image-grid.drag-over {
+    outline: 2px dashed var(--primary-color);
+    outline-offset: 4px;
+    border-radius: var(--border-radius);
+}
+
+.multi-image-grid.drag-over .multi-image-add-btn {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+    background-color: #e6fffa;
 }
 
 .multi-image-thumb {

--- a/app/static/js/multi-image-upload.js
+++ b/app/static/js/multi-image-upload.js
@@ -51,6 +51,21 @@
     }
 
     // Build UI
+    var emptyDropZone = document.createElement('div');
+    emptyDropZone.className = 'drag-drop-zone mb-3';
+    emptyDropZone.innerHTML = '<div class="drag-drop-content">' +
+      '<i class="fas fa-cloud-upload-alt fa-3x mb-3 text-muted"></i>' +
+      '<p class="mb-2">Drop files to upload</p>' +
+      '<p class="text-muted small mb-3">or</p>' +
+      '<div class="browse-btn">Select files</div>' +
+      '<p class="text-muted small mt-3 mb-0">Maximum upload file size: ' + maxFileSizeLabel + '.</p>' +
+      '</div>';
+    imageContainer.appendChild(emptyDropZone);
+
+    emptyDropZone.addEventListener('click', function () {
+      fileInput.click();
+    });
+
     var grid = document.createElement('div');
     grid.className = 'multi-image-grid';
     imageContainer.appendChild(grid);
@@ -126,6 +141,15 @@
       var count = grid.querySelectorAll('.multi-image-thumb').length + pendingFilesCount;
       counter.textContent = count + ' / ' + maxImages;
       var atMax = count >= maxImages;
+      
+      if (count === 0) {
+        emptyDropZone.style.display = 'block';
+        grid.style.display = 'none';
+      } else {
+        emptyDropZone.style.display = 'none';
+        grid.style.display = '';
+      }
+
       addBtn.style.display = atMax ? 'none' : '';
       if (showCameraBtn) {
         cameraBtn.style.display = atMax ? 'none' : '';

--- a/app/static/js/multi-image-upload.js
+++ b/app/static/js/multi-image-upload.js
@@ -513,6 +513,29 @@
       handleFiles(captureInput.files, captureInput);
     });
 
+    // Drag and drop functionality
+    imageContainer.addEventListener('dragover', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      imageContainer.classList.add('drag-over');
+    });
+
+    imageContainer.addEventListener('dragleave', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      imageContainer.classList.remove('drag-over');
+    });
+
+    imageContainer.addEventListener('drop', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      imageContainer.classList.remove('drag-over');
+      
+      if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+        handleFiles(e.dataTransfer.files, fileInput);
+      }
+    });
+
     // Listen for cropped image from external modal
     container.addEventListener('multi-image:cropped', function (e) {
       var id = e.detail.id;

--- a/app/static/js/multi-image-upload.js
+++ b/app/static/js/multi-image-upload.js
@@ -165,8 +165,9 @@
       var count = grid.querySelectorAll('.multi-image-thumb').length + pendingFilesCount;
       counter.textContent = count + ' / ' + maxImages;
       var atMax = count >= maxImages;
+      var showEmptyDropZone = count === 0 && !isTouchDevice;
 
-      if (count === 0) {
+      if (showEmptyDropZone) {
         emptyDropZone.style.display = 'block';
         grid.style.display = 'none';
       } else {

--- a/app/static/js/multi-image-upload.js
+++ b/app/static/js/multi-image-upload.js
@@ -57,12 +57,20 @@
       '<i class="fas fa-cloud-upload-alt fa-3x mb-3 text-muted"></i>' +
       '<p class="mb-2">Drag and drop photos here</p>' +
       '<p class="text-muted small mb-3">or</p>' +
-      '<div class="browse-btn">Select files</div>' +
+      '<button type="button" class="browse-btn btn btn-sm btn-outline-primary">Select files</button>' +
       '<p class="text-muted small mt-3 mb-0">Maximum upload file size: ' + maxFileSizeLabel + '.</p>' +
       '</div>';
     imageContainer.appendChild(emptyDropZone);
 
+    var emptyBrowseBtn = emptyDropZone.querySelector('.browse-btn');
+
     emptyDropZone.addEventListener('click', function () {
+      fileInput.click();
+    });
+
+    emptyBrowseBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
       fileInput.click();
     });
 
@@ -137,11 +145,27 @@
       });
     }
 
+    var dragCounter = 0;
+
+    function clearDragOverState() {
+      emptyDropZone.classList.remove('drag-over');
+      grid.classList.remove('drag-over');
+    }
+
+    function setDragOverState() {
+      clearDragOverState();
+      if (emptyDropZone.style.display !== 'none') {
+        emptyDropZone.classList.add('drag-over');
+        return;
+      }
+      grid.classList.add('drag-over');
+    }
+
     function updateCounter() {
       var count = grid.querySelectorAll('.multi-image-thumb').length + pendingFilesCount;
       counter.textContent = count + ' / ' + maxImages;
       var atMax = count >= maxImages;
-      
+
       if (count === 0) {
         emptyDropZone.style.display = 'block';
         grid.style.display = 'none';
@@ -538,23 +562,34 @@
     });
 
     // Drag and drop functionality
+    imageContainer.addEventListener('dragenter', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      dragCounter += 1;
+      setDragOverState();
+    });
+
     imageContainer.addEventListener('dragover', function (e) {
       e.preventDefault();
       e.stopPropagation();
-      imageContainer.classList.add('drag-over');
+      setDragOverState();
     });
 
     imageContainer.addEventListener('dragleave', function (e) {
       e.preventDefault();
       e.stopPropagation();
-      imageContainer.classList.remove('drag-over');
+      dragCounter = Math.max(0, dragCounter - 1);
+      if (dragCounter === 0) {
+        clearDragOverState();
+      }
     });
 
     imageContainer.addEventListener('drop', function (e) {
       e.preventDefault();
       e.stopPropagation();
-      imageContainer.classList.remove('drag-over');
-      
+      dragCounter = 0;
+      clearDragOverState();
+
       if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length > 0) {
         handleFiles(e.dataTransfer.files, fileInput);
       }

--- a/app/static/js/multi-image-upload.js
+++ b/app/static/js/multi-image-upload.js
@@ -51,6 +51,21 @@
     }
 
     // Build UI
+    var emptyDropZone = document.createElement('div');
+    emptyDropZone.className = 'drag-drop-zone mb-3';
+    emptyDropZone.innerHTML = '<div class="drag-drop-content">' +
+      '<i class="fas fa-cloud-upload-alt fa-3x mb-3 text-muted"></i>' +
+      '<p class="mb-2">Drag and drop photos here</p>' +
+      '<p class="text-muted small mb-3">or</p>' +
+      '<div class="browse-btn">Select files</div>' +
+      '<p class="text-muted small mt-3 mb-0">Maximum upload file size: ' + maxFileSizeLabel + '.</p>' +
+      '</div>';
+    imageContainer.appendChild(emptyDropZone);
+
+    emptyDropZone.addEventListener('click', function () {
+      fileInput.click();
+    });
+
     var grid = document.createElement('div');
     grid.className = 'multi-image-grid';
     imageContainer.appendChild(grid);
@@ -126,6 +141,15 @@
       var count = grid.querySelectorAll('.multi-image-thumb').length + pendingFilesCount;
       counter.textContent = count + ' / ' + maxImages;
       var atMax = count >= maxImages;
+      
+      if (count === 0) {
+        emptyDropZone.style.display = 'block';
+        grid.style.display = 'none';
+      } else {
+        emptyDropZone.style.display = 'none';
+        grid.style.display = '';
+      }
+
       addBtn.style.display = atMax ? 'none' : '';
       if (showCameraBtn) {
         cameraBtn.style.display = atMax ? 'none' : '';
@@ -511,6 +535,29 @@
 
     captureInput.addEventListener('change', function () {
       handleFiles(captureInput.files, captureInput);
+    });
+
+    // Drag and drop functionality
+    imageContainer.addEventListener('dragover', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      imageContainer.classList.add('drag-over');
+    });
+
+    imageContainer.addEventListener('dragleave', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      imageContainer.classList.remove('drag-over');
+    });
+
+    imageContainer.addEventListener('drop', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      imageContainer.classList.remove('drag-over');
+      
+      if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+        handleFiles(e.dataTransfer.files, fileInput);
+      }
     });
 
     // Listen for cropped image from external modal

--- a/app/static/js/photo-preview.js
+++ b/app/static/js/photo-preview.js
@@ -36,7 +36,68 @@
                 else if (c) { node.appendChild(c); }
             });
         }
+<<<<<<< HEAD
         return node;
+=======
+        
+        const reader = new FileReader();
+        
+        reader.onerror = function() {
+            Notifications.error('Failed to read image file. Please try another file.');
+        };
+        
+        reader.onload = function(e) {
+            // Validate the result is a data URL
+            if (!e.target.result || !e.target.result.startsWith('data:image/')) {
+                Notifications.error('Failed to load image. Please try another file.');
+                return;
+            }
+            
+            // Destroy existing cropper instance
+            if (cropper) {
+                cropper.destroy();
+                cropper = null;
+            }
+
+            // Set image source
+            previewImage.src = e.target.result;
+            previewContainer.style.display = 'block';
+
+            // Clean up previous onload handler to prevent memory leaks
+            previewImage.onload = null;
+            
+            // Wait for image to load before initializing Cropper
+            previewImage.onload = function() {
+                // Initialize Cropper.js
+cropper = new Cropper(previewImage, {
+                    viewMode: 1,
+                    dragMode: 'move',
+                    aspectRatio: NaN,
+                    autoCropArea: 1,
+                    restore: false,
+                    guides: true,
+                    center: true,
+                    highlight: false,
+                    cropBoxMovable: true,
+                    cropBoxResizable: true,
+                    toggleDragModeOnDblclick: false,
+                    responsive: true,
+                    background: false,
+                    zoomable: true,
+                    zoomOnWheel: true,
+                    zoomOnTouch: true,
+                    rotatable: true,
+                    checkOrientation: false,
+                    checkCrossOrigin: false,
+                    minCropBoxWidth: 10,
+                    minCropBoxHeight: 10,
+                    minContainerWidth: 200,
+                    minContainerHeight: 200
+                });
+            };
+        };
+        reader.readAsDataURL(file);
+>>>>>>> 2727f37 (style: fix cropper initialization in photo-preview)
     }
 
     function icon(faClass) {

--- a/app/static/js/photo-preview.js
+++ b/app/static/js/photo-preview.js
@@ -187,7 +187,6 @@
         applyBtn.addEventListener('click', function(e) {
             e.preventDefault();
             if (!cropper) return;
-            
             cropper.getCroppedCanvas({
                 imageSmoothingEnabled: true,
                 imageSmoothingQuality: 'high'
@@ -205,6 +204,15 @@
                 hideModal();
             }, 'image/jpeg', 0.9);
         });
+
+        // ── modal hidden cleanup ────────────────────────────────────
+        modalEl.addEventListener('hidden.bs.modal', function() {
+            destroyCropper();
+            revokeUrl();
+            editId = null;
+            editContainer = null;
+            editThumbEl = null;
+        });
     }
 
     function showModal(srcUrl) {
@@ -213,7 +221,6 @@
         }
         
         cropImage.src = srcUrl;
-        
         // Wait until modal is visible so Cropper can measure the container
         modalEl.addEventListener('shown.bs.modal', function onShown() {
             modalEl.removeEventListener('shown.bs.modal', onShown);

--- a/app/static/js/photo-preview.js
+++ b/app/static/js/photo-preview.js
@@ -36,68 +36,7 @@
                 else if (c) { node.appendChild(c); }
             });
         }
-<<<<<<< HEAD
         return node;
-=======
-        
-        const reader = new FileReader();
-        
-        reader.onerror = function() {
-            Notifications.error('Failed to read image file. Please try another file.');
-        };
-        
-        reader.onload = function(e) {
-            // Validate the result is a data URL
-            if (!e.target.result || !e.target.result.startsWith('data:image/')) {
-                Notifications.error('Failed to load image. Please try another file.');
-                return;
-            }
-            
-            // Destroy existing cropper instance
-            if (cropper) {
-                cropper.destroy();
-                cropper = null;
-            }
-
-            // Set image source
-            previewImage.src = e.target.result;
-            previewContainer.style.display = 'block';
-
-            // Clean up previous onload handler to prevent memory leaks
-            previewImage.onload = null;
-            
-            // Wait for image to load before initializing Cropper
-            previewImage.onload = function() {
-                // Initialize Cropper.js
-cropper = new Cropper(previewImage, {
-                    viewMode: 1,
-                    dragMode: 'move',
-                    aspectRatio: NaN,
-                    autoCropArea: 1,
-                    restore: false,
-                    guides: true,
-                    center: true,
-                    highlight: false,
-                    cropBoxMovable: true,
-                    cropBoxResizable: true,
-                    toggleDragModeOnDblclick: false,
-                    responsive: true,
-                    background: false,
-                    zoomable: true,
-                    zoomOnWheel: true,
-                    zoomOnTouch: true,
-                    rotatable: true,
-                    checkOrientation: false,
-                    checkCrossOrigin: false,
-                    minCropBoxWidth: 10,
-                    minCropBoxHeight: 10,
-                    minContainerWidth: 200,
-                    minContainerHeight: 200
-                });
-            };
-        };
-        reader.readAsDataURL(file);
->>>>>>> 2727f37 (style: fix cropper initialization in photo-preview)
     }
 
     function icon(faClass) {
@@ -247,72 +186,140 @@ cropper = new Cropper(previewImage, {
 
         applyBtn.addEventListener('click', function(e) {
             e.preventDefault();
-            if (!cropper) return;
-            var canvas = cropper.getCroppedCanvas();
-            if (!canvas) return;
-            var id = editId;
-            canvas.toBlob(function(blob) {
-                if (!blob) return;
-                (editContainer || document).dispatchEvent(new CustomEvent('multi-image:cropped', {
-                    detail: { id: id, blob: blob }
-                }));
-                hideModal();
-            }, 'image/jpeg', 0.92);
+            fileInput.value = '';
+            currentFile = null;
+            hidePreview(previewContainer);
+            
+            // Trigger change event to update file info display
+            const event = new Event('change', { bubbles: true });
+            fileInput.dispatchEvent(event);
         });
+        
+        // Add form submit handler to ensure cropped image is used
+        const form = fileInput.closest('form');
+        if (form) {
+            // Track if we've already processed the image
+            let imageProcessed = false;
+            let pendingSubmitter = null;
 
-        // ── modal hidden cleanup ────────────────────────────────────
-        modalEl.addEventListener('hidden.bs.modal', function() {
-            destroyCropper();
-            revokeUrl();
-            editId = null;
-            editContainer = null;
-            editThumbEl = null;
-        });
-    }
-
-    // ── cropper init ────────────────────────────────────────────────
-
-    function initCropper(src) {
-        destroyCropper();
-        cropImage.onload = null;
-
-        cropImage.onload = function() {
-            cropper = new Cropper(cropImage, {
-                viewMode: 2,
-                dragMode: 'move',
-                aspectRatio: NaN,
-                autoCropArea: 1,
-                restore: false,
-                guides: true,
-                center: true,
-                highlight: false,
-                cropBoxMovable: true,
-                cropBoxResizable: true,
-                toggleDragModeOnDblclick: false,
-                responsive: true,
-                background: false,
-                zoomable: true,
-                zoomOnWheel: true,
-                zoomOnTouch: true,
-                rotatable: true,
-                checkOrientation: true,
-                minContainerWidth: 200,
-                minContainerHeight: 200
+            // Capture clicked submit button for browsers that don't support e.submitter
+            form.querySelectorAll('[type="submit"]').forEach(function(btn) {
+                btn.addEventListener('click', function() { pendingSubmitter = btn; });
             });
-        };
 
-        cropImage.src = src;
-        // Force onload if image is already cached
-        if (cropImage.complete) {
-            cropImage.onload();
+            form.addEventListener('submit', function(e) {
+                // e.submitter is more reliable than click tracking when available
+                if (e.submitter) pendingSubmitter = e.submitter;
+
+                if (cropper && currentFile && !imageProcessed) {
+                    // Prevent the form from submitting until we process the image
+                    e.preventDefault();
+                    // Capture now so the async callback uses the correct button
+                    const submitter = pendingSubmitter;
+
+                    // Update file input with final cropped/rotated version
+                    updateFileInputWithCroppedImage(fileInput, function() {
+                        imageProcessed = true;
+
+                        // requestSubmit preserves submitter identity and reruns validation
+                        if (typeof form.requestSubmit === 'function') {
+                            form.requestSubmit(submitter || undefined);
+                            return;
+                        }
+
+                        // Legacy fallback: inject button identity as a hidden field before raw submit
+                        if (submitter && submitter.name) {
+                            const hidden = document.createElement('input');
+                            hidden.type = 'hidden';
+                            hidden.name = submitter.name;
+                            hidden.value = submitter.value || '';
+                            form.appendChild(hidden);
+                        }
+
+                        HTMLFormElement.prototype.submit.call(form);
+                    });
+                }
+            });
         }
     }
 
-    // ── show / hide ─────────────────────────────────────────────────
+    /**
+     * Display an image in the preview
+     * @param {File} file - The image file to display
+     * @param {HTMLElement} previewImage - The preview image element
+     * @param {HTMLElement} previewContainer - The preview container element
+     */
+    function displayImage(file, previewImage, previewContainer) {
+        // Additional security check
+        if (!file || !file.type || !file.type.startsWith('image/')) {
+            return;
+        }
+        
+        const reader = new FileReader();
+        
+        reader.onerror = function() {
+            Notifications.error('Failed to read image file. Please try another file.');
+        };
+        
+        reader.onload = function(e) {
+            // Validate the result is a data URL
+            if (!e.target.result || !e.target.result.startsWith('data:image/')) {
+                Notifications.error('Failed to load image. Please try another file.');
+                return;
+            }
+            
+            // Destroy existing cropper instance
+            if (cropper) {
+                cropper.destroy();
+                cropper = null;
+            }
 
-    function showModal(src) {
-        if (!modalInstance) {
-            modalInstance = new bootstrap.Modal(modalEl);
+            // Set image source
+            previewImage.src = e.target.result;
+            previewContainer.style.display = 'block';
+
+            // Clean up previous onload handler to prevent memory leaks
+            previewImage.onload = null;
+            
+            // Wait for image to load before initializing Cropper
+            previewImage.onload = function() {
+                // Initialize Cropper.js
+                cropper = new Cropper(previewImage, {
+                    viewMode: 2, // Restrict canvas to container
+                    dragMode: 'move',
+                    aspectRatio: NaN, // Free aspect ratio
+                    autoCropArea: 1,
+                    restore: false,
+                    guides: true,
+                    center: true,
+                    highlight: false,
+                    cropBoxMovable: true,
+                    cropBoxResizable: true,
+                    toggleDragModeOnDblclick: false,
+                    responsive: true,
+                    background: false,
+                    zoomable: true,
+                    zoomOnWheel: true,
+                    zoomOnTouch: true,
+                    rotatable: true,
+                    checkOrientation: true,
+                    minContainerWidth: 200,
+                    minContainerHeight: 200
+                });
+            };
+        };
+        reader.readAsDataURL(file);
+    }
+
+    /**
+     * Hide the preview container
+     * @param {HTMLElement} previewContainer - The preview container element
+     */
+    function hidePreview(previewContainer) {
+        previewContainer.style.display = 'none';
+        if (cropper) {
+            cropper.destroy();
+            cropper = null;
         }
         modalInstance.show();
 

--- a/app/static/js/photo-preview.js
+++ b/app/static/js/photo-preview.js
@@ -186,150 +186,70 @@
 
         applyBtn.addEventListener('click', function(e) {
             e.preventDefault();
-            fileInput.value = '';
-            currentFile = null;
-            hidePreview(previewContainer);
+            if (!cropper) return;
             
-            // Trigger change event to update file info display
-            const event = new Event('change', { bubbles: true });
-            fileInput.dispatchEvent(event);
-        });
-        
-        // Add form submit handler to ensure cropped image is used
-        const form = fileInput.closest('form');
-        if (form) {
-            // Track if we've already processed the image
-            let imageProcessed = false;
-            let pendingSubmitter = null;
-
-            // Capture clicked submit button for browsers that don't support e.submitter
-            form.querySelectorAll('[type="submit"]').forEach(function(btn) {
-                btn.addEventListener('click', function() { pendingSubmitter = btn; });
-            });
-
-            form.addEventListener('submit', function(e) {
-                // e.submitter is more reliable than click tracking when available
-                if (e.submitter) pendingSubmitter = e.submitter;
-
-                if (cropper && currentFile && !imageProcessed) {
-                    // Prevent the form from submitting until we process the image
-                    e.preventDefault();
-                    // Capture now so the async callback uses the correct button
-                    const submitter = pendingSubmitter;
-
-                    // Update file input with final cropped/rotated version
-                    updateFileInputWithCroppedImage(fileInput, function() {
-                        imageProcessed = true;
-
-                        // requestSubmit preserves submitter identity and reruns validation
-                        if (typeof form.requestSubmit === 'function') {
-                            form.requestSubmit(submitter || undefined);
-                            return;
+            cropper.getCroppedCanvas({
+                imageSmoothingEnabled: true,
+                imageSmoothingQuality: 'high'
+            }).toBlob(function(blob) {
+                if (blob) {
+                    document.dispatchEvent(new CustomEvent('multi-image:cropped', {
+                        detail: {
+                            id: editId,
+                            container: editContainer,
+                            thumbEl: editThumbEl,
+                            blob: blob
                         }
-
-                        // Legacy fallback: inject button identity as a hidden field before raw submit
-                        if (submitter && submitter.name) {
-                            const hidden = document.createElement('input');
-                            hidden.type = 'hidden';
-                            hidden.name = submitter.name;
-                            hidden.value = submitter.value || '';
-                            form.appendChild(hidden);
-                        }
-
-                        HTMLFormElement.prototype.submit.call(form);
-                    });
+                    }));
                 }
-            });
-        }
+                hideModal();
+            }, 'image/jpeg', 0.9);
+        });
     }
 
-    /**
-     * Display an image in the preview
-     * @param {File} file - The image file to display
-     * @param {HTMLElement} previewImage - The preview image element
-     * @param {HTMLElement} previewContainer - The preview container element
-     */
-    function displayImage(file, previewImage, previewContainer) {
-        // Additional security check
-        if (!file || !file.type || !file.type.startsWith('image/')) {
-            return;
+    function showModal(srcUrl) {
+        if (!modalInstance) {
+            modalInstance = new bootstrap.Modal(modalEl);
         }
         
-        const reader = new FileReader();
+        cropImage.src = srcUrl;
         
-        reader.onerror = function() {
-            Notifications.error('Failed to read image file. Please try another file.');
-        };
-        
-        reader.onload = function(e) {
-            // Validate the result is a data URL
-            if (!e.target.result || !e.target.result.startsWith('data:image/')) {
-                Notifications.error('Failed to load image. Please try another file.');
-                return;
-            }
-            
-            // Destroy existing cropper instance
-            if (cropper) {
-                cropper.destroy();
-                cropper = null;
-            }
-
-            // Set image source
-            previewImage.src = e.target.result;
-            previewContainer.style.display = 'block';
-
-            // Clean up previous onload handler to prevent memory leaks
-            previewImage.onload = null;
-            
-            // Wait for image to load before initializing Cropper
-            previewImage.onload = function() {
-                // Initialize Cropper.js
-cropper = new Cropper(previewImage, {
-                    viewMode: 1,
-                    dragMode: 'move',
-                    aspectRatio: NaN,
-                    autoCropArea: 1,
-                    restore: false,
-                    guides: true,
-                    center: true,
-                    highlight: false,
-                    cropBoxMovable: true,
-                    cropBoxResizable: true,
-                    toggleDragModeOnDblclick: false,
-                    responsive: true,
-                    background: false,
-                    zoomable: true,
-                    zoomOnWheel: true,
-                    zoomOnTouch: true,
-                    rotatable: true,
-                    checkOrientation: false,
-                    checkCrossOrigin: false,
-                    minCropBoxWidth: 10,
-                    minCropBoxHeight: 10,
-                    minContainerWidth: 200,
-                    minContainerHeight: 200
-                });
-            };
-        };
-        reader.readAsDataURL(file);
-    }
-
-    /**
-     * Hide the preview container
-     * @param {HTMLElement} previewContainer - The preview container element
-     */
-    function hidePreview(previewContainer) {
-        previewContainer.style.display = 'none';
-        if (cropper) {
-            cropper.destroy();
-            cropper = null;
-        }
-        modalInstance.show();
-
         // Wait until modal is visible so Cropper can measure the container
         modalEl.addEventListener('shown.bs.modal', function onShown() {
             modalEl.removeEventListener('shown.bs.modal', onShown);
-            initCropper(src);
+            initCropper(srcUrl);
+        });
+        
+        modalInstance.show();
+    }
+
+    function initCropper(src) {
+        destroyCropper();
+        
+        cropper = new Cropper(cropImage, {
+            viewMode: 1,
+            dragMode: 'move',
+            aspectRatio: NaN,
+            autoCropArea: 1,
+            restore: false,
+            guides: true,
+            center: true,
+            highlight: false,
+            cropBoxMovable: true,
+            cropBoxResizable: true,
+            toggleDragModeOnDblclick: false,
+            responsive: true,
+            background: false,
+            zoomable: true,
+            zoomOnWheel: true,
+            zoomOnTouch: true,
+            rotatable: true,
+            checkOrientation: false,
+            checkCrossOrigin: false,
+            minCropBoxWidth: 10,
+            minCropBoxHeight: 10,
+            minContainerWidth: 200,
+            minContainerHeight: 200
         });
     }
 

--- a/app/static/js/photo-preview.js
+++ b/app/static/js/photo-preview.js
@@ -284,10 +284,10 @@
             // Wait for image to load before initializing Cropper
             previewImage.onload = function() {
                 // Initialize Cropper.js
-                cropper = new Cropper(previewImage, {
-                    viewMode: 2, // Restrict canvas to container
+cropper = new Cropper(previewImage, {
+                    viewMode: 1,
                     dragMode: 'move',
-                    aspectRatio: NaN, // Free aspect ratio
+                    aspectRatio: NaN,
                     autoCropArea: 1,
                     restore: false,
                     guides: true,
@@ -302,7 +302,10 @@
                     zoomOnWheel: true,
                     zoomOnTouch: true,
                     rotatable: true,
-                    checkOrientation: true,
+                    checkOrientation: false,
+                    checkCrossOrigin: false,
+                    minCropBoxWidth: 10,
+                    minCropBoxHeight: 10,
                     minContainerWidth: 200,
                     minContainerHeight: 200
                 });


### PR DESCRIPTION
 @sfirke 
 Title:
Fix #315: Adjust cropper handle size for symmetry

Description
Problem

The cropper handles (.cropper-point) were set to an odd pixel size (9px). This caused sub-pixel rounding issues in browsers, leading to handles appearing slightly misaligned or "cut off" on certain screens.

Solution
Updated handle size from 9px → 10px (even dimension)
Applied negative margins of -5px (margin-top and margin-left) to properly center the handles

Why this works:
Using an even-sized element (10px) allows precise centering by offsetting exactly half its size (5px), eliminating sub-pixel rendering inconsistencies.

Changes
Modified app/static/css/style.css
Ensured all cropper handles render symmetrically across devices and browsers
###before
<img width="505" height="209" alt="Screenshot 2026-04-08 231136" src="https://github.com/user-attachments/assets/480f24aa-73b8-41fd-b7ff-35546f29bfe4" />

###after
<img width="586" height="263" alt="Screenshot 2026-04-08 231116" src="https://github.com/user-attachments/assets/6c6d5966-905c-4fb9-beae-693202d45c36" />

