### PR TITLE
fix(photo-upload): add Take Photo button for Chrome/iOS mobile, hide on Firefox

### DIFF
--- a/app/static/js/multi-image-upload.js
+++ b/app/static/js/multi-image-upload.js
@@ -83,14 +83,20 @@
     captureInput.style.display = 'none';
     container.appendChild(captureInput);
 
-    // Camera button – only rendered on touch devices
+    // Camera button – only rendered on touch devices where capture="environment" gives a
+    // meaningfully different experience from the regular gallery picker.
+    // Firefox already includes a camera option in its standard file chooser, so the
+    // button would be redundant there. No feature-detection API exists for this
+    // distinction; targeted UA detection is the pragmatic best practice here.
     var isTouchDevice = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+    var isFirefox = /Firefox\//.test(navigator.userAgent);
+    var showCameraBtn = isTouchDevice && !isFirefox;
     var cameraBtn = document.createElement('div');
     cameraBtn.className = 'multi-image-add-btn';
     cameraBtn.setAttribute('role', 'button');
     cameraBtn.setAttribute('tabindex', '0');
     cameraBtn.setAttribute('aria-label', 'Take photo');
-    if (!isTouchDevice) {
+    if (!showCameraBtn) {
       cameraBtn.style.display = 'none';
     }
     var cameraIcon = document.createElement('i');
@@ -121,7 +127,7 @@
       counter.textContent = count + ' / ' + maxImages;
       var atMax = count >= maxImages;
       addBtn.style.display = atMax ? 'none' : '';
-      if (isTouchDevice) {
+      if (showCameraBtn) {
         cameraBtn.style.display = atMax ? 'none' : '';
       }
     }

--- a/app/static/js/multi-image-upload.js
+++ b/app/static/js/multi-image-upload.js
@@ -75,6 +75,32 @@
 
     grid.appendChild(addBtn);
 
+    // Hidden capture input: opens camera directly on mobile (capture attr ignored on desktop)
+    var captureInput = document.createElement('input');
+    captureInput.type = 'file';
+    captureInput.accept = 'image/*';
+    captureInput.setAttribute('capture', 'environment');
+    captureInput.style.display = 'none';
+    container.appendChild(captureInput);
+
+    // Camera button – only rendered on touch devices
+    var isTouchDevice = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+    var cameraBtn = document.createElement('div');
+    cameraBtn.className = 'multi-image-add-btn';
+    cameraBtn.setAttribute('role', 'button');
+    cameraBtn.setAttribute('tabindex', '0');
+    cameraBtn.setAttribute('aria-label', 'Take photo');
+    if (!isTouchDevice) {
+      cameraBtn.style.display = 'none';
+    }
+    var cameraIcon = document.createElement('i');
+    cameraIcon.className = 'fas fa-camera fa-2x';
+    cameraBtn.appendChild(cameraIcon);
+    var cameraLabel = document.createElement('span');
+    cameraLabel.textContent = 'Take Photo';
+    cameraBtn.appendChild(cameraLabel);
+    grid.appendChild(cameraBtn);
+
     // Aria-live region for screen readers
     var liveRegion = document.createElement('div');
     liveRegion.setAttribute('aria-live', 'polite');
@@ -93,7 +119,11 @@
     function updateCounter() {
       var count = grid.querySelectorAll('.multi-image-thumb').length + pendingFilesCount;
       counter.textContent = count + ' / ' + maxImages;
-      addBtn.style.display = count >= maxImages ? 'none' : '';
+      var atMax = count >= maxImages;
+      addBtn.style.display = atMax ? 'none' : '';
+      if (isTouchDevice) {
+        cameraBtn.style.display = atMax ? 'none' : '';
+      }
     }
 
     function updateBadges() {
@@ -372,24 +402,12 @@
       });
     }
 
-    // Add button click / keyboard
-    addBtn.addEventListener('click', function () {
-      fileInput.click();
-    });
-
-    addBtn.addEventListener('keydown', function (e) {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        fileInput.click();
-      }
-    });
-
-    // File selection
-    fileInput.addEventListener('change', function () {
-      if (!fileInput.files || fileInput.files.length === 0) return;
+    // Shared file processing used by both gallery and camera inputs
+    function handleFiles(files, inputEl) {
+      if (!files || files.length === 0) return;
 
       var currentCount = grid.querySelectorAll('.multi-image-thumb').length + pendingFilesCount;
-      var filesToAdd = Array.from(fileInput.files);
+      var filesToAdd = Array.from(files);
       var available = maxImages - currentCount;
 
       if (filesToAdd.length > available) {
@@ -413,8 +431,8 @@
         candidateFiles.push(file);
       });
 
-      // Reset file input so same file can be re-selected
-      fileInput.value = '';
+      // Reset input so same file can be re-selected
+      inputEl.value = '';
 
       if (candidateFiles.length === 0) {
         updateCounter();
@@ -454,6 +472,39 @@
         updateBadges();
         updateHiddenFields();
       });
+    }
+
+    // Add button click / keyboard
+    addBtn.addEventListener('click', function () {
+      fileInput.click();
+    });
+
+    addBtn.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        fileInput.click();
+      }
+    });
+
+    // Camera button click / keyboard
+    cameraBtn.addEventListener('click', function () {
+      captureInput.click();
+    });
+
+    cameraBtn.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        captureInput.click();
+      }
+    });
+
+    // File selection
+    fileInput.addEventListener('change', function () {
+      handleFiles(fileInput.files, fileInput);
+    });
+
+    captureInput.addEventListener('change', function () {
+      handleFiles(captureInput.files, captureInput);
     });
 
     // Listen for cropped image from external modal


### PR DESCRIPTION
Fix #311 

Introduces a "Take Photo" button for Chrome and iOS mobile, hides it from Firefox.

- Added a hidden `<input capture="environment">` and a "Take Photo" tile button that triggers it directly, opening the rear camera
- Both buttons did the same thing on Firefox Android, opening a choice dialog, so the button is suppressed there (via UserAgent detection) to avoid showing two buttons that do the same thing. Feels like a bit of a hack but there's no way to do it with feature detection right now
- On iOS Safari the new "Take Photo"  button provides a useful shortcut to the camera, distinct from the "Add Photo" button which opens the full share sheet so I'm keeping it. Not as critical for Safari as for Chrome, though
- Button is hidden on desktop (non-touch devices) where capture has no effect
- Moves file processing into a shared pipeline `handleFiles()` used by both buttons