### PR TITLE
fix: consolidate circle joins in digest

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1158,7 +1158,7 @@ def confirm_handoff(item_id):
 @login_required
 def request_item(item_id):
     item = db.get_or_404(Item, item_id)
-    share_token = (request.args.get('share_token') or '').strip() or None
+    share_token = request.args.get('share_token', '').strip() or None
     
     if item.owner == current_user:
         flash('You cannot request your own items.', 'warning')

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -150,10 +150,20 @@ def send_message_notification_email(message):
 
     # Determine the subject and email content based on message type
     if message.is_loan_request_message:
+        message_body_lower = (message.body or '').lower()
         # Check if this is a loan extension message (owner extending the due date)
-        if message.loan_request.status == 'approved' and 'has been extended' in message.body:
+        if 'extension requested' in message_body_lower:
+            subject = f"Meutch - Extension Request for {message.item.name}"
+            email_type = "extension request"
+        elif message.loan_request.status == 'approved' and 'extension request' in message_body_lower and 'approved' in message_body_lower:
+            subject = f"Meutch - Extension Approved for {message.item.name}"
+            email_type = "extension approval"
+        elif message.loan_request.status == 'approved' and ('has been extended' in message_body_lower or 'due date has been updated' in message_body_lower):
             subject = f"Meutch - Loan Extended for {message.item.name}"
             email_type = "loan extension"
+        elif message.loan_request.status == 'approved' and 'extension request' in message_body_lower and 'denied' in message_body_lower:
+            subject = f"Meutch - Extension Denied for {message.item.name}"
+            email_type = "extension denial"
         elif message.loan_request.status == 'pending':
             subject = f"Meutch - New Loan Request for {message.item.name}"
             email_type = "loan request"
@@ -476,6 +486,33 @@ def _digest_cadence_label(user):
     return 'off'
 
 
+def _format_names_list(names):
+    """Format ['Alice', 'Bob', 'Celeste'] as 'Alice, Bob, and Celeste'."""
+    if len(names) == 1:
+        return names[0]
+    if len(names) == 2:
+        return f'{names[0]} and {names[1]}'
+    return ', '.join(names[:-1]) + f', and {names[-1]}'
+
+
+def _group_circle_joins_for_digest(circle_joins):
+    """Group per-person circle-join events into per-circle groups for compact rendering."""
+    groups = {}
+    order = []
+    for event in circle_joins:
+        cid = event.get('circle_id')
+        if cid not in groups:
+            groups[cid] = {
+                'event': event,
+                'circle_name': event.get('circle_name') or event.get('title') or 'Unknown Circle',
+                'image_url': event.get('image_url'),
+                'actors': [],
+            }
+            order.append(cid)
+        groups[cid]['actors'].append(event.get('actor_name') or 'Someone')
+    return [groups[cid] for cid in order]
+
+
 def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url):
     giveaways = digest_payload.get('giveaways', [])
     requests = digest_payload.get('requests', [])
@@ -528,7 +565,18 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
 
     append_text_section('Giveaways', giveaways, include_description=True)
     append_text_section('Requests', requests, include_description=True)
-    append_text_section('Circle Joins', circle_joins)
+
+    if circle_joins:
+        grouped_joins = _group_circle_joins_for_digest(circle_joins)
+        text_lines.append('Circle Joins:')
+        for group in grouped_joins:
+            count = len(group['actors'])
+            label = f"{count} {'person' if count == 1 else 'people'}"
+            names = _format_names_list(group['actors'])
+            text_lines.append(f"- {label} joined {group['circle_name']}: {names}")
+            text_lines.append(f"  {_digest_event_url(group['event'])}")
+        text_lines.append('')
+
     append_text_section('Loans', loans)
 
     text_lines.extend([
@@ -581,6 +629,40 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         </ul>
         """
 
+    def _build_circle_joins_html_section(circle_join_events):
+        if not circle_join_events:
+            return ''
+        grouped = _group_circle_joins_for_digest(circle_join_events)
+        items_html = []
+        for group in grouped:
+            count = len(group['actors'])
+            label = f"{count} {'person' if count == 1 else 'people'}"
+            names = _format_names_list(group['actors'])
+            link = _digest_event_url(group['event'])
+            image_html = ''
+            if group['image_url']:
+                image_html = (
+                    f"<div style=\"margin: 8px 0;\">"
+                    f"<img src=\"{group['image_url']}\" alt=\"Circle image\" "
+                    f"style=\"max-width: 100%; width: 220px; height: auto; border-radius: 8px;\">"
+                    f"</div>"
+                )
+            items_html.append(
+                f"""
+                <li style=\"margin-bottom: 10px;\">
+                    <strong>{label}</strong> joined {group['circle_name']}: {names}<br>
+                    {image_html}
+                    <a href=\"{link}\" style=\"color: #007bff; text-decoration: none;\">View circle</a>
+                </li>
+                """
+            )
+        return f"""
+        <h3 style=\"margin-top: 24px; color: #333;\">Circle Joins</h3>
+        <ul style=\"padding-left: 20px;\">
+            {''.join(items_html)}
+        </ul>
+        """
+
     summary_html = ''
     if summary_lines:
         summary_items_html = ''.join(
@@ -604,7 +686,7 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
 
         {build_html_section('Giveaways', giveaways, include_description=True)}
         {build_html_section('Requests', requests, include_description=True)}
-        {build_html_section('Circle Joins', circle_joins)}
+        {_build_circle_joins_html_section(circle_joins)}
         {build_html_section('Loans', loans)}
 
         <hr style=\"margin: 28px 0; border: none; border-top: 1px solid #ddd;\">
@@ -655,6 +737,7 @@ def send_loan_due_soon_email(loan):
     
     # Generate the item URL
     item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
+    extension_url = url_for('main.request_extension', loan_id=loan.id, _external=True)
     
     subject = f"Meutch - Reminder: {loan.item.name} is due in 3 days"
     
@@ -668,6 +751,9 @@ Owner: {owner.first_name} {owner.last_name}
 Due Date: {loan.end_date.strftime('%B %d, %Y')} (in 3 days)
 
 Please make arrangements to return the item by the due date. If you need more time, please contact the owner to discuss extending the loan.
+
+Need more time? Request an extension here:
+{extension_url}
 
 You can view the item details here:
 {item_url}
@@ -698,7 +784,11 @@ The Meutch Team
             Please make arrangements to return the item by the due date. If you need more time, please contact the owner to discuss extending the loan.
         </p>
         
-        <div style="text-align: center; margin: 30px 0;">
+        <div style="text-align: center; margin: 30px 0; display:flex; gap:12px; justify-content:center; flex-wrap:wrap;">
+            <a href="{extension_url}" 
+               style="background-color: #28a745; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
+                Request Extension
+            </a>
             <a href="{item_url}" 
                style="background-color: #007bff; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details
@@ -735,6 +825,7 @@ def send_loan_due_today_borrower_email(loan):
     
     # Generate the item URL
     item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
+    extension_url = url_for('main.request_extension', loan_id=loan.id, _external=True)
     
     subject = f"Meutch - {loan.item.name} is due back today"
     
@@ -748,6 +839,9 @@ Owner: {owner.first_name} {owner.last_name}
 Due Date: Today, {loan.end_date.strftime('%B %d, %Y')}
 
 Please return the item to the owner as soon as possible. If you need more time or have already returned it, please contact the owner to coordinate.
+
+If you need more time, you can request an extension here:
+{extension_url}
 
 You can view the item details here:
 {item_url}
@@ -778,7 +872,11 @@ The Meutch Team
             Please return the item to the owner as soon as possible. If you need more time or have already returned it, please contact the owner to coordinate.
         </p>
         
-        <div style="text-align: center; margin: 30px 0;">
+        <div style="text-align: center; margin: 30px 0; display:flex; gap:12px; justify-content:center; flex-wrap:wrap;">
+            <a href="{extension_url}" 
+               style="background-color: #28a745; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
+                Request Extension
+            </a>
             <a href="{item_url}" 
                style="background-color: #007bff; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details
@@ -902,6 +1000,7 @@ def send_loan_overdue_borrower_email(loan, days_overdue):
     
     # Generate the item URL
     item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
+    extension_url = url_for('main.request_extension', loan_id=loan.id, _external=True)
     
     subject = f"Meutch - Reminder: {loan.item.name} is {days_overdue} day{'s' if days_overdue != 1 else ''} overdue"
     
@@ -916,6 +1015,9 @@ Due Date: {loan.end_date.strftime('%B %d, %Y')}
 Days Overdue: {days_overdue}
 
 Please return the item to the owner as soon as possible. If you need more time, please contact the owner immediately to request an extension or discuss the situation.
+
+Need additional time? Request an extension here:
+{extension_url}
 
 You can view the item details here:
 {item_url}
@@ -947,7 +1049,11 @@ The Meutch Team
             Please return the item to the owner as soon as possible. If you need more time, please contact the owner immediately to request an extension or discuss the situation.
         </p>
         
-        <div style="text-align: center; margin: 30px 0;">
+        <div style="text-align: center; margin: 30px 0; display:flex; gap:12px; justify-content:center; flex-wrap:wrap;">
+            <a href="{extension_url}" 
+               style="background-color: #28a745; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
+                Request Extension
+            </a>
             <a href="{item_url}" 
                style="background-color: #dc3545; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -504,12 +504,12 @@ def _group_circle_joins_for_digest(circle_joins):
         if cid not in groups:
             groups[cid] = {
                 'event': event,
-                'circle_name': event.get('circle_name') or event.get('title') or 'Unknown Circle',
+                'circle_name': event['title'],
                 'image_url': event.get('image_url'),
                 'actors': [],
             }
             order.append(cid)
-        groups[cid]['actors'].append(event.get('actor_name') or 'Someone')
+        groups[cid]['actors'].append(event['actor_name'])
     return [groups[cid] for cid in order]
 
 

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -150,20 +150,10 @@ def send_message_notification_email(message):
 
     # Determine the subject and email content based on message type
     if message.is_loan_request_message:
-        message_body_lower = (message.body or '').lower()
         # Check if this is a loan extension message (owner extending the due date)
-        if 'extension requested' in message_body_lower:
-            subject = f"Meutch - Extension Request for {message.item.name}"
-            email_type = "extension request"
-        elif message.loan_request.status == 'approved' and 'extension request' in message_body_lower and 'approved' in message_body_lower:
-            subject = f"Meutch - Extension Approved for {message.item.name}"
-            email_type = "extension approval"
-        elif message.loan_request.status == 'approved' and ('has been extended' in message_body_lower or 'due date has been updated' in message_body_lower):
+        if message.loan_request.status == 'approved' and 'has been extended' in message.body:
             subject = f"Meutch - Loan Extended for {message.item.name}"
             email_type = "loan extension"
-        elif message.loan_request.status == 'approved' and 'extension request' in message_body_lower and 'denied' in message_body_lower:
-            subject = f"Meutch - Extension Denied for {message.item.name}"
-            email_type = "extension denial"
         elif message.loan_request.status == 'pending':
             subject = f"Meutch - New Loan Request for {message.item.name}"
             email_type = "loan request"
@@ -734,7 +724,6 @@ def send_loan_due_soon_email(loan):
     
     # Generate the item URL
     item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
-    extension_url = url_for('main.request_extension', loan_id=loan.id, _external=True)
     
     subject = f"Meutch - Reminder: {loan.item.name} is due in 3 days"
     
@@ -748,9 +737,6 @@ Owner: {owner.first_name} {owner.last_name}
 Due Date: {loan.end_date.strftime('%B %d, %Y')} (in 3 days)
 
 Please make arrangements to return the item by the due date. If you need more time, please contact the owner to discuss extending the loan.
-
-Need more time? Request an extension here:
-{extension_url}
 
 You can view the item details here:
 {item_url}
@@ -781,11 +767,7 @@ The Meutch Team
             Please make arrangements to return the item by the due date. If you need more time, please contact the owner to discuss extending the loan.
         </p>
         
-        <div style="text-align: center; margin: 30px 0; display:flex; gap:12px; justify-content:center; flex-wrap:wrap;">
-            <a href="{extension_url}" 
-               style="background-color: #28a745; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
-                Request Extension
-            </a>
+        <div style="text-align: center; margin: 30px 0;">
             <a href="{item_url}" 
                style="background-color: #007bff; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details
@@ -822,7 +804,6 @@ def send_loan_due_today_borrower_email(loan):
     
     # Generate the item URL
     item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
-    extension_url = url_for('main.request_extension', loan_id=loan.id, _external=True)
     
     subject = f"Meutch - {loan.item.name} is due back today"
     
@@ -836,9 +817,6 @@ Owner: {owner.first_name} {owner.last_name}
 Due Date: Today, {loan.end_date.strftime('%B %d, %Y')}
 
 Please return the item to the owner as soon as possible. If you need more time or have already returned it, please contact the owner to coordinate.
-
-If you need more time, you can request an extension here:
-{extension_url}
 
 You can view the item details here:
 {item_url}
@@ -869,11 +847,7 @@ The Meutch Team
             Please return the item to the owner as soon as possible. If you need more time or have already returned it, please contact the owner to coordinate.
         </p>
         
-        <div style="text-align: center; margin: 30px 0; display:flex; gap:12px; justify-content:center; flex-wrap:wrap;">
-            <a href="{extension_url}" 
-               style="background-color: #28a745; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
-                Request Extension
-            </a>
+        <div style="text-align: center; margin: 30px 0;">
             <a href="{item_url}" 
                style="background-color: #007bff; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details
@@ -997,7 +971,6 @@ def send_loan_overdue_borrower_email(loan, days_overdue):
     
     # Generate the item URL
     item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
-    extension_url = url_for('main.request_extension', loan_id=loan.id, _external=True)
     
     subject = f"Meutch - Reminder: {loan.item.name} is {days_overdue} day{'s' if days_overdue != 1 else ''} overdue"
     
@@ -1012,9 +985,6 @@ Due Date: {loan.end_date.strftime('%B %d, %Y')}
 Days Overdue: {days_overdue}
 
 Please return the item to the owner as soon as possible. If you need more time, please contact the owner immediately to request an extension or discuss the situation.
-
-Need additional time? Request an extension here:
-{extension_url}
 
 You can view the item details here:
 {item_url}
@@ -1046,11 +1016,7 @@ The Meutch Team
             Please return the item to the owner as soon as possible. If you need more time, please contact the owner immediately to request an extension or discuss the situation.
         </p>
         
-        <div style="text-align: center; margin: 30px 0; display:flex; gap:12px; justify-content:center; flex-wrap:wrap;">
-            <a href="{extension_url}" 
-               style="background-color: #28a745; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
-                Request Extension
-            </a>
+        <div style="text-align: center; margin: 30px 0;">
             <a href="{item_url}" 
                style="background-color: #dc3545; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -471,10 +471,7 @@ def _digest_event_url(event):
 
 
 def _digest_event_title(event):
-    event_type = event.get('event_type')
-    if event_type == 'circle_join':
-        return event.get('title') or 'Circle activity'
-    return event.get('title') or 'Community activity'
+    return event['title']
 
 
 def _digest_cadence_label(user):
@@ -552,9 +549,9 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
             return
         text_lines.append(f"{section_title}:")
         for event in events:
-            actor = event.get('actor_name') or 'Someone'
+            actor = event['actor_name']
             title = _digest_event_title(event)
-            action = event.get('action') or 'shared'
+            action = event['action']
             text_lines.append(f"- {actor} {action}: {title}")
             if include_description and event.get('description'):
                 text_lines.append(f"  {event['description']}")
@@ -594,9 +591,9 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
 
         items_html = []
         for event in events:
-            actor = event.get('actor_name') or 'Someone'
+            actor = event['actor_name']
             item_title = _digest_event_title(event)
-            action = event.get('action') or 'shared'
+            action = event['action']
             link = _digest_event_url(event)
             description_html = ''
             if include_description and event.get('description'):

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -528,12 +528,12 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
     subject = f"Meutch Digest - {total_activities} new activities"
 
     summary_entries = [
-        ("giveaways", len(giveaways)),
-        ("requests", len(requests)),
-        ("circle joins", len(circle_joins)),
-        ("loans", len(loans)),
+        ("giveaway", "giveaways", len(giveaways)),
+        ("request", "requests", len(requests)),
+        ("circle join", "circle joins", len(circle_joins)),
+        ("loan", "loans", len(loans)),
     ]
-    summary_lines = [f"- {count} {label}" for label, count in summary_entries if count > 0]
+    summary_lines = [f"- {count} {singular if count == 1 else plural}" for singular, plural, count in summary_entries if count > 0]
 
     text_lines = [
         f"Hello {user.first_name},",

--- a/app/utils/home_feed.py
+++ b/app/utils/home_feed.py
@@ -485,6 +485,9 @@ def _digest_included_event_types(user):
 def build_digest_payload(user, since=None, until=None, max_events=200):
     window_end = _utc(until) or datetime.now(UTC)
     window_start = _utc(since) or _utc(user.digest_last_sent_at) or (window_end - timedelta(days=7))
+    # Guard against an inverted window (e.g. digest_last_sent_at is in the future relative to until)
+    if window_start >= window_end:
+        window_start = window_end - timedelta(days=7)
 
     included_event_types = _digest_included_event_types(user)
     events = _assemble_feed_events(

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -120,6 +120,53 @@ class TestEmailUtils:
             assert '0 circle joins' not in content['text']
             assert '3 new activities' not in content['text']
 
+    def test_digest_circle_joins_consolidated_per_circle(self, app):
+        """Multiple people joining the same circle appear as one item per circle, not per person.
+
+        Also verifies the link reads 'View circle' (not 'View activity') and appears once per circle.
+        """
+        with app.app_context():
+            user = UserFactory(first_name='Subscriber', digest_frequency='weekly')
+            circle_x_id = uuid.uuid4()
+            circle_y_id = uuid.uuid4()
+            payload = {
+                'summary_stats': {'total_new_items': 0, 'giveaways_count': 0, 'borrow_requests_count': 0},
+                'giveaways': [],
+                'requests': [],
+                'loans': [],
+                'circle_joins': [
+                    {'event_type': 'circle_join', 'circle_id': circle_x_id, 'title': 'Circle X', 'actor_name': 'Alice',   'action': 'joined', 'image_url': None},
+                    {'event_type': 'circle_join', 'circle_id': circle_x_id, 'title': 'Circle X', 'actor_name': 'Bob',     'action': 'joined', 'image_url': None},
+                    {'event_type': 'circle_join', 'circle_id': circle_x_id, 'title': 'Circle X', 'actor_name': 'Celeste', 'action': 'joined', 'image_url': None},
+                    {'event_type': 'circle_join', 'circle_id': circle_y_id, 'title': 'Circle Y', 'actor_name': 'Alice',   'action': 'joined', 'image_url': None},
+                ],
+            }
+            content = build_digest_email_content(
+                user, payload,
+                manage_url='https://example.com/digest/manage/token',
+                unsubscribe_url='https://example.com/digest/unsubscribe/token',
+            )
+
+            text = content['text']
+            html = content['html']
+
+            # Circle names should appear once each, not once per joiner
+            assert text.count('Circle X') == 1, "Circle X should not be repeated per joiner"
+            assert text.count('Circle Y') == 1, "Circle Y should not be repeated per joiner"
+
+            # Should show correct plural/singular phrasing
+            assert '3 people' in text
+            assert '1 person' in text
+
+            # All joiner names should be listed
+            assert 'Alice' in text
+            assert 'Bob' in text
+            assert 'Celeste' in text
+
+            # HTML should say "View circle", not "View activity", for circle joins
+            assert 'View circle' in html
+            assert 'View activity' not in html
+
     def test_send_digest_email_returns_false_when_no_events(self, app):
         """Test that send_digest_email returns False and skips sending when payload has no events."""
         with app.app_context():


### PR DESCRIPTION
Fix #322 

In the process, I was testing and used the functionality to force a digest send as of a past date. Neat to have that! But it left the test DB in a weird state, thus the small fix here that if the window length for events in that function is negative, it should revert to 7 days.

Also fixes small bug where the digest was always plural, e.g., `1 giveaways`

Lastly the email link now says "View circle" not "view activity"