### PR TITLE
fix: action buttons for giveaway now available from conversation with interested parties + recipient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Allow users to upload up to eight images per item listed, with associated enhancements ([#316](https://github.com/sfirke/meutch/pull/316)).
 
 **Minor**
-- `share/` pages get the aesthetic and the "how/why" content from the main landing page ([#323](https://github.com/sfirke/meutch/pull/323)).
+- Surface giveaway actions in the owner-recipient conversation, both for recipient assignment and handoff confirmation. Also add item deletion modal that stops pending-pickup items from being deleted ([#329](https://github.com/sfirke/meutch/pull/329)).
 
 ### Developer Experience
 - Seeded loan data now includes messages, `./dev-start seed` can run when alembic table is missing/hasn't been initialized yet ([#307](https://github.com/sfirke/meutch/pull/307)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Convert unauthenticated landing page to a modern vertical long-scrolling page ([#298](https://github.com/sfirke/meutch/pull/298)).
 
 **Minor**
-- Let borrowers request loan extensions by proposing a new due date with a required message, and let owners approve or deny requests directly in the conversation view. Borrower due-soon/due-today/overdue reminder emails now include a direct "Request Extension" link.
 - Hide pending-pickup claimed giveaways from view of users other than owner and recipient, create item-unavailable page, improve formatting of rehomed item ([#215](https://github.com/sfirke/meutch/pull/215)).
 - Add search bar for own items ([#252](https://github.com/sfirke/meutch/pull/252)).
 - Requests feed now defaults to an "All" view that combines public requests and shared-circle requests, keeps a "My Circles" filter, and defaults new requests to public visibility ([#255](https://github.com/sfirke/meutch/pull/255)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Allow users to upload up to eight images per item listed, with associated enhancements ([#316](https://github.com/sfirke/meutch/pull/316)).
 
 **Minor**
-- Surface giveaway actions in the owner-recipient conversation, both for recipient assignment and handoff confirmation. Also add item deletion modal that stops pending-pickup items from being deleted ([#329](https://github.com/sfirke/meutch/pull/329)).
+- `share/` pages get the aesthetic and the "how/why" content from the main landing page ([#323](https://github.com/sfirke/meutch/pull/323)).
+- Surface giveaway actions in the owner-recipient conversation, both for recipient assignment and handoff confirmation. Also add item deletion modal that stops pending-pickup items and active loans from being deleted ([#329](https://github.com/sfirke/meutch/pull/329)).
 
 ### Developer Experience
 - Seeded loan data now includes messages, `./dev-start seed` can run when alembic table is missing/hasn't been initialized yet ([#307](https://github.com/sfirke/meutch/pull/307)).

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1222,7 +1222,7 @@ def confirm_handoff(item_id):
         
         db.session.commit()
         
-        recipient_name = item.claimed_by.full_name if item.claimed_by else 'the recipient'
+        recipient_name = item.claimed_by_name
         flash(f'Handoff complete! The giveaway has been successfully given to {recipient_name}.', 'success')
         return redirect(url_for('main.item_detail', item_id=item.id))
         

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -2,6 +2,7 @@ import json
 import os
 import random
 import re
+from uuid import UUID
 from urllib.parse import urlparse
 import requests as http_client
 from flask import render_template, current_app, request, flash, redirect, url_for, abort, session, make_response
@@ -89,6 +90,40 @@ def _generated_item_share_link(item_id):
         session.pop(f'generated-item-share-link:{item_id}', None)
         return None
     return entry['url']
+
+
+def _conversation_other_user_id(message, viewer_id):
+    if message.sender_id == viewer_id:
+        return message.recipient_id
+    if message.recipient_id == viewer_id:
+        return message.sender_id
+    return None
+
+
+def _select_giveaway_recipient(item, selected_interest, sender_id):
+    item.claim_status = 'pending_pickup'
+    item.claimed_by_id = selected_interest.user_id
+    item.claimed_at = None
+    item.available = False
+    selected_interest.status = 'selected'
+
+    notification_message = Message(
+        sender_id=sender_id,
+        recipient_id=selected_interest.user_id,
+        item_id=item.id,
+        body=f"Good news! You've been selected for the giveaway '{item.name}'! Please coordinate pickup with the owner."
+    )
+    db.session.add(notification_message)
+    db.session.commit()
+
+    try:
+        send_message_notification_email(notification_message)
+    except Exception as exc:
+        current_app.logger.error(
+            f"Failed to send email notification for giveaway selection: {str(exc)}"
+        )
+
+    return notification_message
 
 
 def _shares_circle_or_has_item_token_access(item, share_token=None):
@@ -734,32 +769,7 @@ def select_recipient(item_id):
             return redirect(url_for('main.select_recipient', item_id=item.id))
         
         try:
-            # Update item status
-            item.claim_status = 'pending_pickup'
-            item.claimed_by_id = selected_interest.user_id
-            item.available = False
-            # claimed_at remains NULL until handoff is confirmed
-            
-            # Update the selected interest status
-            selected_interest.status = 'selected'
-            
-            # Create notification message to selected user
-            notification_message = Message(
-                sender_id=current_user.id,
-                recipient_id=selected_interest.user_id,
-                item_id=item.id,
-                body=f"Good news! You've been selected for the giveaway '{item.name}'! Please coordinate pickup with the owner."
-            )
-            db.session.add(notification_message)
-            
-            db.session.commit()
-            
-            # Send email notification
-            try:
-                send_message_notification_email(notification_message)
-            except Exception as e:
-                current_app.logger.error(f"Failed to send email notification for giveaway selection: {str(e)}")
-            
+            _select_giveaway_recipient(item, selected_interest, current_user.id)
             flash(f'{selected_interest.user.full_name} has been selected! They will be notified.', 'success')
             return redirect(url_for('main.item_detail', item_id=item.id))
             
@@ -829,6 +839,75 @@ def select_recipient(item_id):
                          next_form=next_form,
                          random_reassign_form=random_reassign_form,
                          manual_reassign_form=manual_reassign_form)
+
+
+@main_bp.route('/item/<uuid:item_id>/give-to-user/<uuid:user_id>', methods=['POST'])
+@login_required
+def give_to_user(item_id, user_id):
+    """Owner selects an interested user directly from their conversation."""
+    item = db.get_or_404(Item, item_id)
+    form = EmptyForm()
+
+    conversation_message = None
+    conversation_message_id = request.form.get('message_id')
+    if conversation_message_id:
+        try:
+            conversation_message = db.session.get(Message, UUID(conversation_message_id))
+        except (TypeError, ValueError):
+            conversation_message = None
+
+    if not form.validate_on_submit():
+        flash('Invalid request.', 'danger')
+        if conversation_message:
+            return redirect(url_for('main.view_conversation', message_id=conversation_message.id))
+        return redirect(url_for('main.item_detail', item_id=item.id))
+
+    if item.owner_id != current_user.id:
+        flash('You do not have permission to manage this giveaway.', 'danger')
+        if conversation_message:
+            return redirect(url_for('main.view_conversation', message_id=conversation_message.id))
+        return redirect(url_for('main.item_detail', item_id=item.id))
+
+    if not item.is_giveaway:
+        flash('This item is not a giveaway.', 'danger')
+        if conversation_message:
+            return redirect(url_for('main.view_conversation', message_id=conversation_message.id))
+        return redirect(url_for('main.item_detail', item_id=item.id))
+
+    if item.claim_status not in [None, 'unclaimed']:
+        flash('This giveaway is no longer awaiting recipient selection.', 'warning')
+        if conversation_message:
+            return redirect(url_for('main.view_conversation', message_id=conversation_message.id))
+        return redirect(url_for('main.item_detail', item_id=item.id))
+
+    if conversation_message is None or conversation_message.item_id != item.id:
+        flash('Invalid conversation context.', 'danger')
+        return redirect(url_for('main.item_detail', item_id=item.id))
+
+    other_user_id = _conversation_other_user_id(conversation_message, current_user.id)
+    if other_user_id != user_id:
+        flash('This conversation does not match that interested user.', 'danger')
+        return redirect(url_for('main.view_conversation', message_id=conversation_message.id))
+
+    selected_interest = GiveawayInterest.query.filter_by(
+        item_id=item.id,
+        user_id=user_id,
+        status='active'
+    ).first()
+
+    if not selected_interest:
+        flash('This user is not currently in the interested-user pool.', 'warning')
+        return redirect(url_for('main.view_conversation', message_id=conversation_message.id))
+
+    try:
+        _select_giveaway_recipient(item, selected_interest, current_user.id)
+        flash(f'{selected_interest.user.full_name} has been selected! They will be notified.', 'success')
+    except Exception as exc:
+        db.session.rollback()
+        current_app.logger.error(f"Error selecting giveaway recipient from conversation {conversation_message.id}: {str(exc)}")
+        flash('An error occurred. Please try again.', 'danger')
+
+    return redirect(url_for('main.view_conversation', message_id=conversation_message.id))
 
 
 @main_bp.route('/item/<uuid:item_id>/message-requester/<uuid:user_id>', methods=['GET', 'POST'])
@@ -2398,10 +2477,8 @@ def messages():
 def view_conversation(message_id):
     message = db.get_or_404(Message, message_id)
 
-    if message.sender_id == current_user.id:
-        other_user = db.session.get(User, message.recipient_id)
-    else:
-        other_user = db.session.get(User, message.sender_id)
+    other_user_id = _conversation_other_user_id(message, current_user.id)
+    other_user = db.session.get(User, other_user_id)
 
     # Ensure that only the recipient can view the message
     if message.recipient_id != current_user.id and message.sender_id != current_user.id:
@@ -2484,6 +2561,28 @@ def view_conversation(message_id):
                 active_loan = msg.loan_request
                 break
 
+    giveaway_selection_item = None
+    giveaway_selection_form = None
+    giveaway_selection_interested_count = 0
+    if (
+        message.item
+        and message.item.is_giveaway
+        and message.item.claim_status in [None, 'unclaimed']
+        and current_user.id == message.item.owner_id
+    ):
+        active_interest = GiveawayInterest.query.filter_by(
+            item_id=message.item.id,
+            user_id=other_user.id,
+            status='active'
+        ).first()
+        if active_interest:
+            giveaway_selection_item = message.item
+            giveaway_selection_form = EmptyForm()
+            giveaway_selection_interested_count = GiveawayInterest.query.filter_by(
+                item_id=message.item.id,
+                status='active'
+            ).count()
+
     giveaway_handoff_item = None
     giveaway_handoff_form = None
     giveaway_release_form = None
@@ -2533,6 +2632,9 @@ def view_conversation(message_id):
                          thread_messages=thread_messages, 
                          form=form, 
                          active_loan=active_loan,
+                         giveaway_selection_item=giveaway_selection_item,
+                         giveaway_selection_form=giveaway_selection_form,
+                         giveaway_selection_interested_count=giveaway_selection_interested_count,
                          giveaway_handoff_item=giveaway_handoff_item,
                          giveaway_handoff_form=giveaway_handoff_form,
                          giveaway_release_form=giveaway_release_form,

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1364,6 +1364,10 @@ def delete_item(item_id):
     if item.owner != current_user:
         flash('You can only delete your own items.', 'danger')
         return redirect(url_for('main.profile'))
+
+    if item.is_giveaway and item.claim_status == 'pending_pickup':
+        flash('This giveaway is still pending pickup. Mark the handoff complete or release it instead of deleting the item.', 'warning')
+        return redirect(url_for('main.item_detail', item_id=item.id))
     
     # Prevent deletion of claimed giveaways (completed transactions)
     if item.is_giveaway and item.claim_status == 'claimed':
@@ -1942,8 +1946,13 @@ def profile():
     items_pagination = items_query.order_by(Item.created_at.desc()).paginate(page=page, per_page=per_page, error_out=False)
     user_items = items_pagination.items
     
-    # Create a DeleteItemForm for each item (exclude claimed giveaways since they can't be deleted)
+    # Create action forms for owner item controls.
     delete_forms = {item.id: DeleteItemForm() for item in active_giveaways_pagination.items + user_items}
+    confirm_handoff_forms = {
+        item.id: ConfirmHandoffForm()
+        for item in active_giveaways_pagination.items
+        if item.claim_status == 'pending_pickup'
+    }
     
     borrowing = current_user.get_active_loans_as_borrower()
     lending = current_user.get_active_loans_as_owner()
@@ -1996,6 +2005,7 @@ def profile():
                          active_giveaways=active_giveaways_pagination.items,
                          past_giveaways=past_giveaways_pagination.items,
                          delete_forms=delete_forms,
+                         confirm_handoff_forms=confirm_handoff_forms,
                          borrowing=borrowing,
                          lending=lending,
                          pagination=items_pagination,
@@ -2236,6 +2246,7 @@ def user_profile(user_id):
     items = []
     items_pagination = None
     delete_forms = {}
+    confirm_handoff_forms = {}
     
     if can_view_items:
         # Pagination parameters
@@ -2248,7 +2259,16 @@ def user_profile(user_id):
         
         # Create DeleteItemForm for each item if the current user is the owner
         if current_user.id == user.id:
-            delete_forms = {item.id: DeleteItemForm() for item in items}
+            delete_forms = {
+                item.id: DeleteItemForm()
+                for item in items
+                if not (item.is_giveaway and item.claim_status == 'claimed')
+            }
+            confirm_handoff_forms = {
+                item.id: ConfirmHandoffForm()
+                for item in items
+                if item.is_giveaway and item.claim_status == 'pending_pickup'
+            }
     
     return render_template(
         'main/user_profile.html',
@@ -2256,6 +2276,7 @@ def user_profile(user_id):
         items=items,
         pagination=items_pagination,
         delete_forms=delete_forms,
+        confirm_handoff_forms=confirm_handoff_forms,
         can_view_items=can_view_items
     )
 
@@ -2463,6 +2484,21 @@ def view_conversation(message_id):
                 active_loan = msg.loan_request
                 break
 
+    giveaway_handoff_item = None
+    giveaway_handoff_form = None
+    giveaway_release_form = None
+    if (
+        message.item
+        and message.item.is_giveaway
+        and message.item.claim_status == 'pending_pickup'
+        and message.item.claimed_by_id
+        and {current_user.id, other_user.id} == {message.item.owner_id, message.item.claimed_by_id}
+    ):
+        giveaway_handoff_item = message.item
+        if current_user.id == message.item.owner_id:
+            giveaway_handoff_form = ConfirmHandoffForm()
+            giveaway_release_form = ReleaseToAllForm()
+
     # Handle reply form
     form = MessageForm()
     if form.validate_on_submit():
@@ -2497,6 +2533,9 @@ def view_conversation(message_id):
                          thread_messages=thread_messages, 
                          form=form, 
                          active_loan=active_loan,
+                         giveaway_handoff_item=giveaway_handoff_item,
+                         giveaway_handoff_form=giveaway_handoff_form,
+                         giveaway_release_form=giveaway_release_form,
                          loan_action_form=loan_action_form,
                          has_unread_messages=has_unread_messages)
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1444,6 +1444,16 @@ def delete_item(item_id):
         flash('You can only delete your own items.', 'danger')
         return redirect(url_for('main.profile'))
 
+    active_loan = LoanRequest.query.filter_by(
+        item_id=item.id,
+        status='approved'
+    ).first()
+    if active_loan:
+        flash('This item is currently out on loan. Mark it returned or cancel the loan before deleting the item.', 'warning')
+        if active_loan.messages:
+            return redirect(url_for('main.view_conversation', message_id=active_loan.messages[0].id))
+        return redirect(url_for('main.item_detail', item_id=item.id))
+
     if item.is_giveaway and item.claim_status == 'pending_pickup':
         flash('This giveaway is still pending pickup. Mark the handoff complete or release it instead of deleting the item.', 'warning')
         return redirect(url_for('main.item_detail', item_id=item.id))

--- a/app/models.py
+++ b/app/models.py
@@ -395,6 +395,13 @@ class Item(db.Model):
         """Returns owner name or 'Deleted User' if owner is None"""
         return self.owner.full_name if self.owner else "Deleted User"
 
+    @property
+    def claimed_by_name(self):
+        """Returns claimed giveaway recipient name or 'Deleted User' if unavailable."""
+        if self.claimed_by and not self.claimed_by.is_deleted:
+            return self.claimed_by.full_name
+        return "Deleted User"
+
     def __repr__(self):
         return f'<Item {self.name}>'
 

--- a/app/templates/main/_delete_item_modal.html
+++ b/app/templates/main/_delete_item_modal.html
@@ -1,8 +1,10 @@
 {% set is_pending_handoff = item.is_giveaway and item.claim_status == 'pending_pickup' %}
-{% set active_loan = item.current_loan if not is_pending_handoff else none %}
+{% set is_claimed_giveaway = item.is_giveaway and item.claim_status == 'claimed' %}
+{% set active_loan = item.current_loan if not item.is_giveaway else none %}
 {% set is_on_loan = active_loan is not none %}
 {% set message_count = item.messages|length %}
-{% set header_class = 'bg-warning text-dark' if is_pending_handoff or is_on_loan else 'bg-danger text-white' %}
+{% set is_blocked_delete = is_pending_handoff or is_claimed_giveaway or is_on_loan %}
+{% set header_class = 'bg-secondary text-white' if is_claimed_giveaway else ('bg-warning text-dark' if is_pending_handoff or is_on_loan else 'bg-danger text-white') %}
 
 <div class="modal fade" id="{{ delete_modal_id }}" tabindex="-1" aria-labelledby="{{ delete_modal_id }}Label" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
@@ -11,19 +13,26 @@
                 <h5 class="modal-title" id="{{ delete_modal_id }}Label">
                     {% if is_pending_handoff %}
                         This giveaway is still pending pickup
+                    {% elif is_claimed_giveaway %}
+                        This giveaway has already been handed off
                     {% elif is_on_loan %}
                         This item is currently out on loan
                     {% else %}
                         Delete {{ item.name }}?
                     {% endif %}
                 </h5>
-                <button type="button" class="btn-close {% if not is_pending_handoff and not is_on_loan %}btn-close-white{% endif %}" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close {% if is_claimed_giveaway or not is_blocked_delete %}btn-close-white{% endif %}" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
                 {% if is_pending_handoff %}
                     <p class="mb-3">
                         <strong>{{ item.claimed_by.full_name if item.claimed_by else 'A recipient' }}</strong> is still coordinating pickup for this giveaway.
                         Complete the handoff or release the item to everyone before deleting.
+                    </p>
+                {% elif is_claimed_giveaway %}
+                    <p class="mb-3">
+                        <strong>{{ item.claimed_by.full_name if item.claimed_by else 'The recipient' }}</strong> has already received this giveaway.
+                        Completed giveaways cannot be deleted.
                     </p>
                 {% elif is_on_loan %}
                     <p class="mb-3">
@@ -34,14 +43,14 @@
                     <p class="mb-3">This will permanently delete <strong>{{ item.name }}</strong>.</p>
                 {% endif %}
 
-                {% if message_count > 0 and not is_pending_handoff and not is_on_loan %}
+                {% if message_count > 0 and not is_blocked_delete %}
                     <div class="alert alert-warning mb-3" role="alert">
                         <i class="fas fa-exclamation-triangle me-2"></i>
-                        Deleting this item will also permanently remove {{ message_count }} message{{ 's' if message_count != 1 else '' }} tied to it.
+                        Deleting this item will also permanently remove {{ message_count }} message{{ 's' if message_count != 1 else '' }} associated with it.
                     </div>
                 {% endif %}
 
-                {% if not is_pending_handoff and not is_on_loan %}
+                {% if not is_blocked_delete %}
                     <p class="text-muted small mb-0">This action cannot be undone.</p>
                 {% endif %}
             </div>
@@ -54,10 +63,12 @@
                             <i class="fas fa-check-circle me-1"></i>Mark Handoff Complete
                         </button>
                     </form>
-                {% elif is_on_loan and active_loan.messages %}
-                    <a href="{{ url_for('main.view_conversation', message_id=active_loan.messages[0].id) }}" class="btn btn-info">
-                        <i class="fas fa-exchange-alt me-1"></i>View Active Loan
-                    </a>
+                {% elif is_on_loan %}
+                    {% if active_loan.messages %}
+                        <a href="{{ url_for('main.view_conversation', message_id=active_loan.messages[0].id) }}" class="btn btn-info">
+                            <i class="fas fa-exchange-alt me-1"></i>View Active Loan
+                        </a>
+                    {% endif %}
                 {% else %}
                     <form action="{{ url_for('main.delete_item', item_id=item.id) }}" method="post" class="d-inline">
                         {{ item_delete_form.hidden_tag() }}

--- a/app/templates/main/_delete_item_modal.html
+++ b/app/templates/main/_delete_item_modal.html
@@ -1,0 +1,61 @@
+{% set is_pending_handoff = item.is_giveaway and item.claim_status == 'pending_pickup' %}
+{% set message_count = item.messages|length %}
+{% set header_class = 'bg-warning text-dark' if is_pending_handoff else 'bg-danger text-white' %}
+
+<div class="modal fade" id="{{ delete_modal_id }}" tabindex="-1" aria-labelledby="{{ delete_modal_id }}Label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header {{ header_class }}">
+                <h5 class="modal-title" id="{{ delete_modal_id }}Label">
+                    {% if is_pending_handoff %}
+                        This giveaway is still pending pickup
+                    {% else %}
+                        Delete {{ item.name }}?
+                    {% endif %}
+                </h5>
+                <button type="button" class="btn-close {% if not is_pending_handoff %}btn-close-white{% endif %}" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                {% if is_pending_handoff %}
+                    <p class="mb-3">
+                        <strong>{{ item.claimed_by.full_name if item.claimed_by else 'A recipient' }}</strong> is still coordinating pickup for this giveaway.
+                        Finish the handoff instead of deleting the item so the transaction closes cleanly.
+                    </p>
+                {% else %}
+                    <p class="mb-3">This will permanently delete <strong>{{ item.name }}</strong>.</p>
+                {% endif %}
+
+                {% if message_count > 0 %}
+                    <div class="alert alert-warning mb-3" role="alert">
+                        <i class="fas fa-exclamation-triangle me-2"></i>
+                        Deleting this item will also permanently remove {{ message_count }} message{{ 's' if message_count != 1 else '' }} tied to it.
+                    </div>
+                {% endif %}
+
+                {% if is_pending_handoff %}
+                    <p class="text-muted small mb-0">If plans changed, open the item page to choose a different recipient or release the giveaway back to everyone.</p>
+                {% else %}
+                    <p class="text-muted small mb-0">This action cannot be undone.</p>
+                {% endif %}
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                {% if is_pending_handoff %}
+                    <form action="{{ url_for('main.confirm_handoff', item_id=item.id) }}" method="post" class="d-inline">
+                        {{ item_confirm_handoff_form.hidden_tag() }}
+                        <button type="submit" class="btn btn-success">
+                            <i class="fas fa-check-circle me-1"></i>Mark Handoff Complete
+                        </button>
+                    </form>
+                {% else %}
+                    <form action="{{ url_for('main.delete_item', item_id=item.id) }}" method="post" class="d-inline">
+                        {{ item_delete_form.hidden_tag() }}
+                        <button type="submit" class="btn btn-danger">
+                            <i class="fas fa-trash me-1"></i>Delete Item
+                        </button>
+                    </form>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/templates/main/_delete_item_modal.html
+++ b/app/templates/main/_delete_item_modal.html
@@ -26,12 +26,12 @@
             <div class="modal-body">
                 {% if is_pending_handoff %}
                     <p class="mb-3">
-                        <strong>{{ item.claimed_by.full_name if item.claimed_by else 'A recipient' }}</strong> is still coordinating pickup for this giveaway.
+                        <strong>{{ item.claimed_by_name }}</strong> is still coordinating pickup for this giveaway.
                         Complete the handoff or release the item to everyone before deleting.
                     </p>
                 {% elif is_claimed_giveaway %}
                     <p class="mb-3">
-                        <strong>{{ item.claimed_by.full_name if item.claimed_by else 'The recipient' }}</strong> has already received this giveaway.
+                        <strong>{{ item.claimed_by_name }}</strong> has already received this giveaway.
                         Completed giveaways cannot be deleted.
                     </p>
                 {% elif is_on_loan %}

--- a/app/templates/main/_delete_item_modal.html
+++ b/app/templates/main/_delete_item_modal.html
@@ -19,22 +19,20 @@
                 {% if is_pending_handoff %}
                     <p class="mb-3">
                         <strong>{{ item.claimed_by.full_name if item.claimed_by else 'A recipient' }}</strong> is still coordinating pickup for this giveaway.
-                        Finish the handoff instead of deleting the item so the transaction closes cleanly.
+                        Complete the handoff or release the item to everyone before deleting.
                     </p>
                 {% else %}
                     <p class="mb-3">This will permanently delete <strong>{{ item.name }}</strong>.</p>
                 {% endif %}
 
-                {% if message_count > 0 %}
+                {% if message_count > 0 and not is_pending_handoff %}
                     <div class="alert alert-warning mb-3" role="alert">
                         <i class="fas fa-exclamation-triangle me-2"></i>
                         Deleting this item will also permanently remove {{ message_count }} message{{ 's' if message_count != 1 else '' }} tied to it.
                     </div>
                 {% endif %}
 
-                {% if is_pending_handoff %}
-                    <p class="text-muted small mb-0">If plans changed, open the item page to choose a different recipient or release the giveaway back to everyone.</p>
-                {% else %}
+                {% if not is_pending_handoff %}
                     <p class="text-muted small mb-0">This action cannot be undone.</p>
                 {% endif %}
             </div>

--- a/app/templates/main/_delete_item_modal.html
+++ b/app/templates/main/_delete_item_modal.html
@@ -1,6 +1,8 @@
 {% set is_pending_handoff = item.is_giveaway and item.claim_status == 'pending_pickup' %}
+{% set active_loan = item.current_loan if not is_pending_handoff else none %}
+{% set is_on_loan = active_loan is not none %}
 {% set message_count = item.messages|length %}
-{% set header_class = 'bg-warning text-dark' if is_pending_handoff else 'bg-danger text-white' %}
+{% set header_class = 'bg-warning text-dark' if is_pending_handoff or is_on_loan else 'bg-danger text-white' %}
 
 <div class="modal fade" id="{{ delete_modal_id }}" tabindex="-1" aria-labelledby="{{ delete_modal_id }}Label" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
@@ -9,11 +11,13 @@
                 <h5 class="modal-title" id="{{ delete_modal_id }}Label">
                     {% if is_pending_handoff %}
                         This giveaway is still pending pickup
+                    {% elif is_on_loan %}
+                        This item is currently out on loan
                     {% else %}
                         Delete {{ item.name }}?
                     {% endif %}
                 </h5>
-                <button type="button" class="btn-close {% if not is_pending_handoff %}btn-close-white{% endif %}" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close {% if not is_pending_handoff and not is_on_loan %}btn-close-white{% endif %}" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
                 {% if is_pending_handoff %}
@@ -21,18 +25,23 @@
                         <strong>{{ item.claimed_by.full_name if item.claimed_by else 'A recipient' }}</strong> is still coordinating pickup for this giveaway.
                         Complete the handoff or release the item to everyone before deleting.
                     </p>
+                {% elif is_on_loan %}
+                    <p class="mb-3">
+                        <strong>{{ active_loan.borrower_name }}</strong> still has this item on loan.
+                        Mark the item returned or cancel the loan before deleting it.
+                    </p>
                 {% else %}
                     <p class="mb-3">This will permanently delete <strong>{{ item.name }}</strong>.</p>
                 {% endif %}
 
-                {% if message_count > 0 and not is_pending_handoff %}
+                {% if message_count > 0 and not is_pending_handoff and not is_on_loan %}
                     <div class="alert alert-warning mb-3" role="alert">
                         <i class="fas fa-exclamation-triangle me-2"></i>
                         Deleting this item will also permanently remove {{ message_count }} message{{ 's' if message_count != 1 else '' }} tied to it.
                     </div>
                 {% endif %}
 
-                {% if not is_pending_handoff %}
+                {% if not is_pending_handoff and not is_on_loan %}
                     <p class="text-muted small mb-0">This action cannot be undone.</p>
                 {% endif %}
             </div>
@@ -45,6 +54,10 @@
                             <i class="fas fa-check-circle me-1"></i>Mark Handoff Complete
                         </button>
                     </form>
+                {% elif is_on_loan and active_loan.messages %}
+                    <a href="{{ url_for('main.view_conversation', message_id=active_loan.messages[0].id) }}" class="btn btn-info">
+                        <i class="fas fa-exchange-alt me-1"></i>View Active Loan
+                    </a>
                 {% else %}
                     <form action="{{ url_for('main.delete_item', item_id=item.id) }}" method="post" class="d-inline">
                         {{ item_delete_form.hidden_tag() }}

--- a/app/templates/main/_item_card.html
+++ b/app/templates/main/_item_card.html
@@ -97,7 +97,7 @@
         {% if show_owner_controls and delete_forms %}
             <!-- Owner controls: Loan (if active), Edit, Delete -->
             <div class="mt-auto d-flex gap-2 justify-content-end">
-                {% if item.current_loan %}
+                {% if not item.is_giveaway and item.current_loan %}
                     <a href="{{ url_for('main.view_conversation', message_id=item.current_loan.messages[0].id) }}" class="btn btn-sm btn-outline-info" data-bs-toggle="tooltip" title="View active loan">
                         <i class="fas fa-exchange-alt me-1"></i>Loan
                     </a>

--- a/app/templates/main/_item_card.html
+++ b/app/templates/main/_item_card.html
@@ -106,10 +106,13 @@
                     <a href="{{ url_for('main.edit_item', item_id=item.id) }}" class="btn btn-sm btn-outline-secondary">
                         <i class="fas fa-edit me-1"></i>Edit
                     </a>
-                    <form action="{{ url_for('main.delete_item', item_id=item.id) }}" method="post" style="display:inline;">
-                        {{ delete_forms[item.id].hidden_tag() }}
-                        {{ delete_forms[item.id].submit(class="btn btn-sm btn-outline-danger", onclick="return confirm('Are you sure you want to delete this item?');", **{'data-bs-toggle': 'tooltip', 'title': 'Delete item'}) }}
-                    </form>
+                    {% set delete_modal_id = 'deleteItemModal-' ~ item.id %}
+                    <button type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal" data-bs-target="#{{ delete_modal_id }}" title="Delete item">
+                        <i class="fas fa-trash me-1"></i>Delete
+                    </button>
+                    {% set item_delete_form = delete_forms[item.id] %}
+                    {% set item_confirm_handoff_form = confirm_handoff_forms[item.id] if confirm_handoff_forms is defined and item.id in confirm_handoff_forms else none %}
+                    {% include 'main/_delete_item_modal.html' %}
                 {% endif %}
             </div>
         {% endif %}

--- a/app/templates/main/item_detail.html
+++ b/app/templates/main/item_detail.html
@@ -249,15 +249,15 @@
                                                         Recipient: <strong class="text-dark">{{ item.claimed_by.full_name }}</strong>
                                                     </span>
                                                 </div>
+                                                <p class="text-muted mb-3">Once they have the item, mark the handoff complete so this giveaway closes out cleanly.</p>
                                                 
                                                 <!-- Primary action: Confirm Handoff -->
                                                 <form action="{{ url_for('main.confirm_handoff', item_id=item.id) }}" 
                                                       method="post" 
-                                                      class="mb-3"
-                                                      onsubmit="return confirm('Confirm that the handoff is complete? This action cannot be undone.');">
+                                                      class="mb-3">
                                                     {{ confirm_handoff_form.hidden_tag() }}
                                                     <button type="submit" class="btn btn-success btn-lg w-100">
-                                                        <i class="fas fa-check-circle me-2"></i>Confirm Handoff Complete
+                                                        <i class="fas fa-check-circle me-2"></i>Mark Handoff Complete
                                                     </button>
                                                 </form>
                                                 
@@ -336,16 +336,18 @@
                                     <i class="fas fa-exchange-alt me-1"></i>View Active Loan
                                 </a>
                             {% endif %}
-                            <form action="{{ url_for('main.delete_item', item_id=item.id) }}" method="post" class="d-inline">
-                                {{ delete_form.hidden_tag() }}
-                                <button type="submit" class="btn btn-sm btn-outline-danger"
-                                        onclick="return confirm('Are you sure you want to delete this item?');">
-                                    <i class="fas fa-trash me-1"></i>Delete Item
-                                </button>
-                            </form>
+                            {% set delete_modal_id = 'deleteItemModal-' ~ item.id %}
+                            <button type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal" data-bs-target="#{{ delete_modal_id }}">
+                                <i class="fas fa-trash me-1"></i>Delete Item
+                            </button>
                         </div>
                     {% endif %}
                 </div>
+                {% if current_user.is_authenticated and current_user.id == item.owner.id %}
+                    {% set item_delete_form = delete_form %}
+                    {% set item_confirm_handoff_form = confirm_handoff_form %}
+                    {% include 'main/_delete_item_modal.html' %}
+                {% endif %}
                 
                 <!-- Message Owner Card -->
                 {% if current_user.is_authenticated and current_user.id != item.owner.id %}

--- a/app/templates/main/item_detail.html
+++ b/app/templates/main/item_detail.html
@@ -246,7 +246,7 @@
                                                         <i class="fas fa-clock me-1"></i>Pending Pickup
                                                     </span>
                                                     <span class="text-muted">
-                                                        Recipient: <strong class="text-dark">{{ item.claimed_by.full_name }}</strong>
+                                                        Recipient: <strong class="text-dark">{{ item.claimed_by_name }}</strong>
                                                     </span>
                                                 </div>
                                                 <p class="text-muted mb-3">Once they have the item, mark the handoff complete so this giveaway closes out cleanly.</p>
@@ -281,7 +281,7 @@
                                         </div>
                                     {% elif item.claim_status == 'claimed' %}
                                         <div class="alert alert-success mb-3" role="alert">
-                                            <i class="fas fa-check-circle me-2"></i>Given to <strong>{{ item.claimed_by.full_name if item.claimed_by else 'a user' }}</strong>{% if item.claimed_at %} on {{ item.claimed_at|utc_timestamp('date') }}{% endif %}
+                                            <i class="fas fa-check-circle me-2"></i>Given to <strong>{{ item.claimed_by_name }}</strong>{% if item.claimed_at %} on {{ item.claimed_at|utc_timestamp('date') }}{% endif %}
                                         </div>
                                     {% endif %}
                                 {% else %}

--- a/app/templates/main/item_detail.html
+++ b/app/templates/main/item_detail.html
@@ -324,13 +324,14 @@
                             {% endif %}
                         </div>
                     </div>
-                    {% if current_user.is_authenticated and current_user.id == item.owner.id %}
+                    {% set is_claimed_giveaway = item.is_giveaway and item.claim_status == 'claimed' %}
+                    {% if current_user.is_authenticated and current_user.id == item.owner.id and not is_claimed_giveaway %}
                         <div class="card-footer d-flex align-items-center justify-content-between">
                             <a href="{{ url_for('main.edit_item', item_id=item.id) }}"
                                class="btn btn-sm btn-outline-secondary">
                                 <i class="fas fa-pencil-alt me-1"></i>Edit Item
                             </a>
-                            {% if item.current_loan %}
+                            {% if not item.is_giveaway and item.current_loan %}
                                 <a href="{{ url_for('main.view_conversation', message_id=item.current_loan.messages[0].id) }}"
                                    class="btn btn-sm btn-info">
                                     <i class="fas fa-exchange-alt me-1"></i>View Active Loan
@@ -343,7 +344,7 @@
                         </div>
                     {% endif %}
                 </div>
-                {% if current_user.is_authenticated and current_user.id == item.owner.id %}
+                {% if current_user.is_authenticated and current_user.id == item.owner.id and not is_claimed_giveaway %}
                     {% set item_delete_form = delete_form %}
                     {% set item_confirm_handoff_form = confirm_handoff_form %}
                     {% include 'main/_delete_item_modal.html' %}

--- a/app/templates/main/item_detail.html
+++ b/app/templates/main/item_detail.html
@@ -234,7 +234,7 @@
                                     {% if item.claim_status in [None, 'unclaimed'] and interested_count > 0 %}
                                         <a href="{{ url_for('main.select_recipient', item_id=item.id) }}" 
                                            class="btn btn-primary btn-lg">
-                                            <i class="fas fa-user-check me-2"></i>View & Select Recipient
+                                            <i class="fas fa-user-check me-2"></i>View Interested Users
                                             <span class="badge bg-light text-dark ms-2">{{ interested_count }}</span>
                                         </a>
                                     {% elif item.claim_status == 'pending_pickup' %}

--- a/app/templates/messaging/view_conversation.html
+++ b/app/templates/messaging/view_conversation.html
@@ -49,9 +49,11 @@
                     <div class="card-body">
                         <h5 class="card-title">{{ conversation_item.name }}</h5>
                         <p class="card-text">{{ conversation_item.description }}</p>
+                        {% if conversation_item.owner != current_user %}
                         <p class="card-text">
                             <strong>Owner:</strong> {{ conversation_item.owner.full_name }}
                         </p>
+                        {% endif %}
                         {% if conversation_item.current_loan and conversation_item.current_loan.borrower == current_user %}
                             <span class="badge bg-info">You are currently borrowing this item</span>
                         {% elif not conversation_item.available %}
@@ -88,6 +90,46 @@
                 </p>
             </div>
         </div>
+    {% endif %}
+
+    {% if giveaway_handoff_item %}
+    <div class="card mb-4 border-warning shadow-sm">
+        <div class="card-header bg-warning text-dark">
+            <h5 class="mb-0">
+                <i class="fas fa-gift me-2"></i>Giveaway Pickup
+            </h5>
+        </div>
+        <div class="card-body">
+            <p class="mb-2">
+                <strong>Recipient:</strong> {{ giveaway_handoff_item.claimed_by.full_name if giveaway_handoff_item.claimed_by else 'Selected recipient' }}
+            </p>
+            {% if giveaway_handoff_item.owner_id == current_user.id %}
+                <p class="text-muted mb-3">Once they have the item, mark the handoff complete here so this giveaway closes out instead of lingering in pending pickup.</p>
+                <div class="d-flex flex-wrap gap-2">
+                    <form method="POST" action="{{ url_for('main.confirm_handoff', item_id=giveaway_handoff_item.id) }}" class="d-inline">
+                        {{ giveaway_handoff_form.hidden_tag() }}
+                        <button type="submit" class="btn btn-success">
+                            <i class="fas fa-check-circle me-1"></i>Mark Handoff Complete
+                        </button>
+                    </form>
+                    <a href="{{ url_for('main.select_recipient', item_id=giveaway_handoff_item.id) }}" class="btn btn-outline-secondary">
+                        <i class="fas fa-exchange-alt me-1"></i>Change Recipient
+                    </a>
+                    <form method="POST" action="{{ url_for('main.release_to_all', item_id=giveaway_handoff_item.id) }}" class="d-inline" onsubmit="return confirm('Release this giveaway back to everyone? The item will reappear in the feed and all interested users will remain in the pool.');">
+                        {{ giveaway_release_form.hidden_tag() }}
+                        <button type="submit" class="btn btn-outline-secondary">
+                            <i class="fas fa-undo me-1"></i>Release to Everyone
+                        </button>
+                    </form>
+                </div>
+            {% elif giveaway_handoff_item.claimed_by_id == current_user.id %}
+                <div class="alert alert-info mb-0">
+                    <i class="fas fa-info-circle me-2"></i>
+                    You are the selected recipient for this giveaway. Use this conversation to coordinate pickup, and the owner will mark the handoff complete once you have the item.
+                </div>
+            {% endif %}
+        </div>
+    </div>
     {% endif %}
 
     <!-- Active Loan Management Panel -->
@@ -171,6 +213,31 @@
                     {% elif active_loan.status == 'approved' %}
                         {% if thread_messages[0].item.owner == current_user %}
                             <h6 class="mb-3">Item Owner Actions:</h6>
+                            {% if pending_extension_request %}
+                                <div class="alert alert-warning mb-3">
+                                    <div class="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+                                        <div>
+                                            <strong>Extension request pending</strong><br>
+                                            Proposed due date: {{ pending_extension_request.proposed_end_date.strftime('%B %d, %Y') }}<br>
+                                            <small>{{ pending_extension_request.message }}</small>
+                                        </div>
+                                        <div class="d-flex gap-2 flex-wrap">
+                                            <form method="POST" action="{{ url_for('main.process_extension_request', extension_id=pending_extension_request.id, action='approve') }}" class="d-inline">
+                                                {{ loan_action_form.hidden_tag() }}
+                                                <button type="submit" class="btn btn-success btn-sm">
+                                                    <i class="fas fa-check me-1"></i>Approve
+                                                </button>
+                                            </form>
+                                            <form method="POST" action="{{ url_for('main.process_extension_request', extension_id=pending_extension_request.id, action='deny') }}" class="d-inline">
+                                                {{ loan_action_form.hidden_tag() }}
+                                                <button type="submit" class="btn btn-danger btn-sm">
+                                                    <i class="fas fa-times me-1"></i>Deny
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </div>
+                                </div>
+                            {% endif %}
                             <div class="d-flex flex-wrap gap-2">
                                 <a href="{{ url_for('main.extend_loan', loan_id=active_loan.id) }}" class="btn btn-primary">
                                     <i class="fas fa-calendar-plus me-1"></i>Extend Loan Period
@@ -189,6 +256,19 @@
                                 </form>
                             </div>
                         {% elif active_loan.borrower_id == current_user.id %}
+                            {% if pending_extension_request %}
+                                <div class="alert alert-secondary mb-3">
+                                    <i class="fas fa-hourglass-half me-2"></i>
+                                    <strong>Extension request pending:</strong>
+                                    Proposed due date {{ pending_extension_request.proposed_end_date.strftime('%B %d, %Y') }}.
+                                </div>
+                            {% else %}
+                                <div class="mb-3">
+                                    <a href="{{ url_for('main.request_extension', loan_id=active_loan.id) }}" class="btn btn-outline-primary">
+                                        <i class="fas fa-calendar-plus me-1"></i>Request Extension
+                                    </a>
+                                </div>
+                            {% endif %}
                             {% if active_loan.is_overdue() %}
                                 <div class="alert alert-danger mb-0">
                                     <i class="fas fa-exclamation-triangle me-2"></i>
@@ -263,7 +343,7 @@
                         {% endif %}
                     </div>
                 {% endif %}                                        
-                    <p>{{ msg.body }}</p>
+                    <p>{{ msg.body | replace('\n', '<br>') | safe }}</p>
                 </div>
             </div>
         {% endfor %}

--- a/app/templates/messaging/view_conversation.html
+++ b/app/templates/messaging/view_conversation.html
@@ -246,31 +246,6 @@
                     {% elif active_loan.status == 'approved' %}
                         {% if thread_messages[0].item.owner == current_user %}
                             <h6 class="mb-3">Item Owner Actions:</h6>
-                            {% if pending_extension_request %}
-                                <div class="alert alert-warning mb-3">
-                                    <div class="d-flex justify-content-between align-items-start gap-3 flex-wrap">
-                                        <div>
-                                            <strong>Extension request pending</strong><br>
-                                            Proposed due date: {{ pending_extension_request.proposed_end_date.strftime('%B %d, %Y') }}<br>
-                                            <small>{{ pending_extension_request.message }}</small>
-                                        </div>
-                                        <div class="d-flex gap-2 flex-wrap">
-                                            <form method="POST" action="{{ url_for('main.process_extension_request', extension_id=pending_extension_request.id, action='approve') }}" class="d-inline">
-                                                {{ loan_action_form.hidden_tag() }}
-                                                <button type="submit" class="btn btn-success btn-sm">
-                                                    <i class="fas fa-check me-1"></i>Approve
-                                                </button>
-                                            </form>
-                                            <form method="POST" action="{{ url_for('main.process_extension_request', extension_id=pending_extension_request.id, action='deny') }}" class="d-inline">
-                                                {{ loan_action_form.hidden_tag() }}
-                                                <button type="submit" class="btn btn-danger btn-sm">
-                                                    <i class="fas fa-times me-1"></i>Deny
-                                                </button>
-                                            </form>
-                                        </div>
-                                    </div>
-                                </div>
-                            {% endif %}
                             <div class="d-flex flex-wrap gap-2">
                                 <a href="{{ url_for('main.extend_loan', loan_id=active_loan.id) }}" class="btn btn-primary">
                                     <i class="fas fa-calendar-plus me-1"></i>Extend Loan Period
@@ -289,19 +264,6 @@
                                 </form>
                             </div>
                         {% elif active_loan.borrower_id == current_user.id %}
-                            {% if pending_extension_request %}
-                                <div class="alert alert-secondary mb-3">
-                                    <i class="fas fa-hourglass-half me-2"></i>
-                                    <strong>Extension request pending:</strong>
-                                    Proposed due date {{ pending_extension_request.proposed_end_date.strftime('%B %d, %Y') }}.
-                                </div>
-                            {% else %}
-                                <div class="mb-3">
-                                    <a href="{{ url_for('main.request_extension', loan_id=active_loan.id) }}" class="btn btn-outline-primary">
-                                        <i class="fas fa-calendar-plus me-1"></i>Request Extension
-                                    </a>
-                                </div>
-                            {% endif %}
                             {% if active_loan.is_overdue() %}
                                 <div class="alert alert-danger mb-0">
                                     <i class="fas fa-exclamation-triangle me-2"></i>

--- a/app/templates/messaging/view_conversation.html
+++ b/app/templates/messaging/view_conversation.html
@@ -92,6 +92,39 @@
         </div>
     {% endif %}
 
+    {% if giveaway_selection_item %}
+    <div class="card mb-4 border-success shadow-sm">
+        <div class="card-header bg-success text-white">
+            <h5 class="mb-0">
+                <i class="fas fa-user-check me-2"></i>Choose Recipient
+            </h5>
+        </div>
+        <div class="card-body">
+            {% if giveaway_selection_interested_count == 1 %}
+                <p class="mb-3">
+                    <strong>{{ thread_messages[0].other_user.full_name }}</strong> is currently the only interested user for this giveaway. You can give it to them here without leaving the conversation.
+                </p>
+            {% else %}
+                <p class="mb-3">
+                    <strong>{{ giveaway_selection_interested_count }} people are interested in this giveaway.</strong> You can give it to {{ thread_messages[0].other_user.full_name }} now or review everyone first.
+                </p>
+            {% endif %}
+            <div class="d-flex flex-wrap gap-2">
+                <form method="POST" action="{{ url_for('main.give_to_user', item_id=giveaway_selection_item.id, user_id=thread_messages[0].other_user.id) }}" class="d-inline">
+                    {{ giveaway_selection_form.hidden_tag() }}
+                    <input type="hidden" name="message_id" value="{{ message.id }}">
+                    <button type="submit" class="btn btn-success">
+                        <i class="fas fa-gift me-1"></i>Give Item to This User
+                    </button>
+                </form>
+                <a href="{{ url_for('main.select_recipient', item_id=giveaway_selection_item.id) }}" class="btn btn-outline-secondary">
+                    <i class="fas fa-users me-1"></i>View Interested Users
+                </a>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
     {% if giveaway_handoff_item %}
     <div class="card mb-4 border-warning shadow-sm">
         <div class="card-header bg-warning text-dark">

--- a/app/templates/messaging/view_conversation.html
+++ b/app/templates/messaging/view_conversation.html
@@ -134,7 +134,7 @@
         </div>
         <div class="card-body">
             <p class="mb-2">
-                <strong>Recipient:</strong> {{ giveaway_handoff_item.claimed_by.full_name if giveaway_handoff_item.claimed_by else 'Selected recipient' }}
+                <strong>Recipient:</strong> {{ giveaway_handoff_item.claimed_by_name }}
             </p>
             {% if giveaway_handoff_item.owner_id == current_user.id %}
                 <p class="text-muted mb-3">Once they have the item, mark the handoff complete here to close out this giveaway.</p>

--- a/app/templates/messaging/view_conversation.html
+++ b/app/templates/messaging/view_conversation.html
@@ -137,7 +137,7 @@
                 <strong>Recipient:</strong> {{ giveaway_handoff_item.claimed_by.full_name if giveaway_handoff_item.claimed_by else 'Selected recipient' }}
             </p>
             {% if giveaway_handoff_item.owner_id == current_user.id %}
-                <p class="text-muted mb-3">Once they have the item, mark the handoff complete here so this giveaway closes out instead of lingering in pending pickup.</p>
+                <p class="text-muted mb-3">Once they have the item, mark the handoff complete here to close out this giveaway.</p>
                 <div class="d-flex flex-wrap gap-2">
                     <form method="POST" action="{{ url_for('main.confirm_handoff', item_id=giveaway_handoff_item.id) }}" class="d-inline">
                         {{ giveaway_handoff_form.hidden_tag() }}

--- a/tests/integration/test_giveaway_routes.py
+++ b/tests/integration/test_giveaway_routes.py
@@ -2,7 +2,7 @@
 import pytest
 from app import db
 from app.models import Item, GiveawayInterest, Message
-from tests.factories import UserFactory, ItemFactory, CategoryFactory, CircleFactory
+from tests.factories import UserFactory, ItemFactory, CategoryFactory, CircleFactory, MessageFactory
 from conftest import login_user
 from datetime import datetime, UTC, timedelta
 from sqlalchemy import text
@@ -1084,11 +1084,184 @@ class TestRecipientSelection:
             
             assert response.status_code == 200
             assert b'not a giveaway' in response.data
+class TestConversationGiveawaySelection:
+    """Test selecting a giveaway recipient directly from a conversation."""
+
+    def test_owner_can_select_recipient_from_conversation(self, client, app, auth_user):
+        """Owner can promote an interested conversation partner into pending pickup."""
+        with app.app_context():
+            owner = auth_user()
+            requester = UserFactory(first_name='Alex')
+            category = CategoryFactory()
+
+            giveaway = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                claim_status='unclaimed',
+                available=True,
+            )
+            interest = GiveawayInterest(
+                item_id=giveaway.id,
+                user_id=requester.id,
+                status='active',
+            )
+            first_message = MessageFactory(
+                sender=requester,
+                recipient=owner,
+                item=giveaway,
+                body='Interested if it is still available.',
+            )
+            db.session.add(interest)
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.post(
+                f'/item/{giveaway.id}/give-to-user/{requester.id}',
+                data={'message_id': str(first_message.id)},
+                follow_redirects=True,
+            )
+
+            assert response.status_code == 200
+            assert b'Giveaway Pickup' in response.data
+            assert b'Mark Handoff Complete' in response.data
+
+            db.session.refresh(giveaway)
+            db.session.refresh(interest)
+            assert giveaway.claim_status == 'pending_pickup'
+            assert giveaway.claimed_by_id == requester.id
+            assert giveaway.available is False
+            assert interest.status == 'selected'
+
+            notification_message = Message.query.filter(
+                Message.item_id == giveaway.id,
+                Message.recipient_id == requester.id,
+                Message.body.contains("selected for the giveaway")
+            ).order_by(Message.timestamp.desc()).first()
+            assert notification_message is not None
+
+    def test_non_owner_cannot_select_recipient_from_conversation(self, client, app, auth_user):
+        """Non-owners should be blocked from the conversation quick-select route."""
+        with app.app_context():
+            owner = UserFactory()
+            requester = auth_user()
+            category = CategoryFactory()
+
+            giveaway = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                claim_status='unclaimed',
+                available=True,
+            )
+            interest = GiveawayInterest(
+                item_id=giveaway.id,
+                user_id=requester.id,
+                status='active',
+            )
+            first_message = MessageFactory(
+                sender=requester,
+                recipient=owner,
+                item=giveaway,
+                body='Can I have this?',
+            )
+            db.session.add(interest)
+            db.session.commit()
+
+            login_user(client, requester.email)
+            response = client.post(
+                f'/item/{giveaway.id}/give-to-user/{requester.id}',
+                data={'message_id': str(first_message.id)},
+                follow_redirects=True,
+            )
+
+            assert response.status_code == 200
+            assert b'do not have permission' in response.data
+            db.session.refresh(giveaway)
+            assert giveaway.claim_status == 'unclaimed'
+            assert giveaway.claimed_by_id is None
+
+    def test_cannot_select_non_interested_user_from_conversation(self, client, app, auth_user):
+        """Conversation quick-select should reject users who are not active in the pool."""
+        with app.app_context():
+            owner = auth_user()
+            requester = UserFactory()
+            category = CategoryFactory()
+
+            giveaway = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                claim_status='unclaimed',
+                available=True,
+            )
+            first_message = MessageFactory(
+                sender=requester,
+                recipient=owner,
+                item=giveaway,
+                body='Checking whether this is still around.',
+            )
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.post(
+                f'/item/{giveaway.id}/give-to-user/{requester.id}',
+                data={'message_id': str(first_message.id)},
+                follow_redirects=True,
+            )
+
+            assert response.status_code == 200
+            assert b'not currently in the interested-user pool' in response.data
+            db.session.refresh(giveaway)
+            assert giveaway.claim_status == 'unclaimed'
+            assert giveaway.claimed_by_id is None
+
+    def test_cannot_select_from_conversation_once_pickup_is_pending(self, client, app, auth_user):
+        """Quick-select route should refuse giveaways that already moved past selection."""
+        with app.app_context():
+            owner = auth_user()
+            requester = UserFactory()
+            category = CategoryFactory()
+
+            giveaway = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                claim_status='pending_pickup',
+                claimed_by=requester,
+                available=False,
+            )
+            interest = GiveawayInterest(
+                item_id=giveaway.id,
+                user_id=requester.id,
+                status='selected',
+            )
+            first_message = MessageFactory(
+                sender=requester,
+                recipient=owner,
+                item=giveaway,
+                body='Still planning to come by later today.',
+            )
+            db.session.add(interest)
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.post(
+                f'/item/{giveaway.id}/give-to-user/{requester.id}',
+                data={'message_id': str(first_message.id)},
+                follow_redirects=True,
+            )
+
+            assert response.status_code == 200
+            assert b'no longer awaiting recipient selection' in response.data
+            db.session.refresh(giveaway)
+            assert giveaway.claim_status == 'pending_pickup'
+            assert giveaway.claimed_by_id == requester.id
 
 
 class TestGiveawayOwnerMessaging:
     """Test giveaway owner messaging functionality."""
-    
+
     def test_owner_can_message_requester(self, client, app, auth_user):
         """Test that owner can initiate a message with a giveaway requester."""
         with app.app_context():

--- a/tests/integration/test_giveaway_routes.py
+++ b/tests/integration/test_giveaway_routes.py
@@ -2255,7 +2255,7 @@ class TestItemDetailPageForGiveaways:
             response = client.get(f'/item/{giveaway.id}')
 
             assert response.status_code == 200
-            assert b'Deleting this item will also permanently remove 1 message tied to it.' in response.data
+            assert b'Deleting this item will also permanently remove 1 message associated with it.' in response.data
 
     def test_delete_modal_omits_message_warning_without_item_messages(self, client, app, auth_user):
         """Delete modal should stay simpler when there are no item messages to lose."""
@@ -2308,6 +2308,9 @@ class TestItemDetailPageForGiveaways:
             assert b'Change Recipient' not in response.data
             assert b'Release to Everyone' not in response.data
             assert b'Mark Handoff Complete' not in response.data
+            assert b'Edit Item' not in response.data
+            assert b'Delete Item' not in response.data
+            assert b'View Active Loan' not in response.data
 
 
 class TestDataIntegrity:

--- a/tests/integration/test_giveaway_routes.py
+++ b/tests/integration/test_giveaway_routes.py
@@ -2229,6 +2229,33 @@ class TestItemDetailPageForGiveaways:
             assert b'Recipient:' in response.data
             assert b'John Doe' in response.data
 
+    def test_owner_sees_deleted_user_when_pending_pickup_recipient_soft_deleted(self, client, app, auth_user):
+        """Pending-pickup giveaway UI should not expose a soft-deleted recipient's name."""
+        with app.app_context():
+            owner = auth_user()
+            requester = UserFactory(first_name='Jane', last_name='Smith')
+            category = CategoryFactory()
+
+            giveaway = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                claim_status='pending_pickup',
+                claimed_by=requester,
+            )
+            requester.is_deleted = True
+            requester.deleted_at = datetime.now(UTC)
+            db.session.commit()
+
+            login_user(client, owner.email)
+
+            response = client.get(f'/item/{giveaway.id}')
+
+            assert response.status_code == 200
+            assert b'Recipient:' in response.data
+            assert b'Deleted User' in response.data
+            assert b'Jane Smith' not in response.data
+
     def test_delete_modal_warns_when_item_messages_will_be_lost(self, client, app, auth_user):
         """Delete modal should warn when item messages would be removed."""
         with app.app_context():

--- a/tests/integration/test_giveaway_routes.py
+++ b/tests/integration/test_giveaway_routes.py
@@ -2052,9 +2052,57 @@ class TestItemDetailPageForGiveaways:
             assert response.status_code == 200
             assert b'Change Recipient' in response.data
             assert b'Release to Everyone' in response.data
-            assert b'Confirm Handoff Complete' in response.data
+            assert b'Mark Handoff Complete' in response.data
             assert b'Recipient:' in response.data
             assert b'John Doe' in response.data
+
+    def test_delete_modal_warns_when_item_messages_will_be_lost(self, client, app, auth_user):
+        """Delete modal should warn when item messages would be removed."""
+        with app.app_context():
+            owner = auth_user()
+            requester = UserFactory()
+            category = CategoryFactory()
+
+            giveaway = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                claim_status='unclaimed'
+            )
+            message = Message(
+                sender_id=requester.id,
+                recipient_id=owner.id,
+                item_id=giveaway.id,
+                body='Could I claim this?'
+            )
+            db.session.add(message)
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.get(f'/item/{giveaway.id}')
+
+            assert response.status_code == 200
+            assert b'Deleting this item will also permanently remove 1 message tied to it.' in response.data
+
+    def test_delete_modal_omits_message_warning_without_item_messages(self, client, app, auth_user):
+        """Delete modal should stay simpler when there are no item messages to lose."""
+        with app.app_context():
+            owner = auth_user()
+            category = CategoryFactory()
+
+            giveaway = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                claim_status='unclaimed'
+            )
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.get(f'/item/{giveaway.id}')
+
+            assert response.status_code == 200
+            assert b'permanently remove 1 message tied to it' not in response.data
     
     def test_owner_sees_claimed_badge(self, client, app, auth_user):
         """Test owner sees claimed badge with recipient name and date."""
@@ -2086,11 +2134,43 @@ class TestItemDetailPageForGiveaways:
             # Should NOT show action buttons for claimed items
             assert b'Change Recipient' not in response.data
             assert b'Release to Everyone' not in response.data
-            assert b'Confirm Handoff Complete' not in response.data
+            assert b'Mark Handoff Complete' not in response.data
 
 
 class TestDataIntegrity:
     """Test data integrity and edge cases for giveaways."""
+
+    def test_pending_pickup_giveaway_cannot_be_deleted(self, client, app, auth_user):
+        """Pending-pickup giveaways should be resolved, not deleted."""
+        with app.app_context():
+            owner = auth_user()
+            requester = UserFactory()
+            category = CategoryFactory()
+
+            giveaway = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                claim_status='pending_pickup',
+                claimed_by=requester,
+                available=False,
+            )
+            message = Message(
+                sender_id=requester.id,
+                recipient_id=owner.id,
+                item_id=giveaway.id,
+                body='I can pick it up this afternoon.'
+            )
+            db.session.add(message)
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.post(f'/item/{giveaway.id}/delete', follow_redirects=True)
+
+            assert response.status_code == 200
+            assert b'still pending pickup' in response.data
+            assert db.session.get(Item, giveaway.id) is not None
+            assert db.session.get(Message, message.id) is not None
     
     def test_claimed_by_persists_when_user_soft_deleted(self, client, app, auth_user):
         """Test claimed_by_id persists when claiming user soft deletes account."""

--- a/tests/integration/test_profile_giveaways.py
+++ b/tests/integration/test_profile_giveaways.py
@@ -102,6 +102,30 @@ class TestProfileGiveawaysSeparation:
             assert response.status_code == 200
             assert b'My Active Giveaways' in response.data
             assert b'Pending Pickup Item' in response.data
+
+    def test_profile_pending_pickup_delete_modal_offers_handoff_completion(self, client, app, auth_user):
+        """Pending-pickup giveaway cards should steer owners to complete the handoff instead of deleting."""
+        with app.app_context():
+            user = auth_user()
+            recipient = UserFactory()
+            category = CategoryFactory()
+
+            ItemFactory(
+                owner=user,
+                category=category,
+                is_giveaway=True,
+                claim_status='pending_pickup',
+                claimed_by=recipient,
+                name='Pending Pickup Item'
+            )
+            db.session.commit()
+
+            login_user(client, user.email)
+            response = client.get('/profile')
+
+            assert response.status_code == 200
+            assert b'This giveaway is still pending pickup' in response.data
+            assert b'Mark Handoff Complete' in response.data
     
     def test_profile_shows_recently_claimed_in_past(self, client, app, auth_user):
         """Test that profile displays recently claimed giveaways in past section."""

--- a/tests/integration/test_request_routes.py
+++ b/tests/integration/test_request_routes.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import datetime, UTC, timedelta
 from unittest.mock import patch
 from app import db
-from app.models import ItemRequest, Circle, Message
+from app.models import ItemRequest, Circle, Message, GiveawayInterest
 from tests.factories import UserFactory, ItemFactory, ItemRequestFactory, CircleFactory, MessageFactory
 from conftest import login_user
 
@@ -838,6 +838,129 @@ class TestRequestConversations:
             assert b'Mark Handoff Complete' in response.data
             assert b'Change Recipient' in response.data
             assert b'Release to Everyone' in response.data
+
+    def test_view_conversation_unclaimed_giveaway_owner_sees_quick_select_actions(self, client, app):
+        """Owners should get the direct recipient-selection CTA in an interested user's conversation."""
+        with app.app_context():
+            owner = UserFactory()
+            requester = UserFactory()
+            giveaway = ItemFactory(
+                owner=owner,
+                is_giveaway=True,
+                claim_status='unclaimed',
+                available=True,
+            )
+            interest = GiveawayInterest(
+                item_id=giveaway.id,
+                user_id=requester.id,
+                status='active',
+            )
+            first_message = MessageFactory(
+                sender=requester,
+                recipient=owner,
+                item=giveaway,
+                body='I would love to pick this up.',
+            )
+            db.session.add(interest)
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.get(f'/message/{first_message.id}')
+
+            assert response.status_code == 200
+            assert b'Choose Recipient' in response.data
+            assert b'Give Item to This User' in response.data
+            assert b'View Interested Users' in response.data
+            assert b'Mark Handoff Complete' not in response.data
+
+    def test_view_conversation_unclaimed_giveaway_shows_interested_count_guidance(self, client, app):
+        """Owner quick-select panel should call out when multiple users are interested."""
+        with app.app_context():
+            owner = UserFactory()
+            requester = UserFactory()
+            another_requester = UserFactory()
+            giveaway = ItemFactory(
+                owner=owner,
+                is_giveaway=True,
+                claim_status='unclaimed',
+                available=True,
+            )
+            db.session.add_all([
+                GiveawayInterest(item_id=giveaway.id, user_id=requester.id, status='active'),
+                GiveawayInterest(item_id=giveaway.id, user_id=another_requester.id, status='active'),
+            ])
+            first_message = MessageFactory(
+                sender=requester,
+                recipient=owner,
+                item=giveaway,
+                body='Happy to collect it this week.',
+            )
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.get(f'/message/{first_message.id}')
+
+            assert response.status_code == 200
+            assert b'2 people are interested in this giveaway.' in response.data
+            assert b'View Interested Users' in response.data
+
+    def test_view_conversation_unclaimed_giveaway_recipient_does_not_see_quick_select_actions(self, client, app):
+        """Recipients should not see owner-only quick-select actions."""
+        with app.app_context():
+            owner = UserFactory()
+            requester = UserFactory()
+            giveaway = ItemFactory(
+                owner=owner,
+                is_giveaway=True,
+                claim_status='unclaimed',
+                available=True,
+            )
+            interest = GiveawayInterest(
+                item_id=giveaway.id,
+                user_id=requester.id,
+                status='active',
+            )
+            first_message = MessageFactory(
+                sender=owner,
+                recipient=requester,
+                item=giveaway,
+                body='Thanks for reaching out.',
+            )
+            db.session.add(interest)
+            db.session.commit()
+
+            login_user(client, requester.email)
+            response = client.get(f'/message/{first_message.id}')
+
+            assert response.status_code == 200
+            assert b'Choose Recipient' not in response.data
+            assert b'Give Item to This User' not in response.data
+
+    def test_view_conversation_unclaimed_giveaway_hides_quick_select_when_user_not_interested(self, client, app):
+        """Owner should not get the quick-select CTA if the conversation partner is not in the pool."""
+        with app.app_context():
+            owner = UserFactory()
+            chatter = UserFactory()
+            giveaway = ItemFactory(
+                owner=owner,
+                is_giveaway=True,
+                claim_status='unclaimed',
+                available=True,
+            )
+            first_message = MessageFactory(
+                sender=chatter,
+                recipient=owner,
+                item=giveaway,
+                body='Is this still available?',
+            )
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.get(f'/message/{first_message.id}')
+
+            assert response.status_code == 200
+            assert b'Choose Recipient' not in response.data
+            assert b'Give Item to This User' not in response.data
 
 
 class TestRequestNavigation:

--- a/tests/integration/test_request_routes.py
+++ b/tests/integration/test_request_routes.py
@@ -790,6 +790,7 @@ class TestRequestConversations:
                 owner=owner,
                 is_giveaway=True,
                 claim_status='pending_pickup',
+                claimed_by=claimant,
                 available=False,
             )
             first_message = MessageFactory(
@@ -806,6 +807,37 @@ class TestRequestConversations:
             assert response.status_code == 200
             assert b'Pending Pickup' in response.data
             assert b'Borrowed' not in response.data
+            assert b'You are the selected recipient for this giveaway.' in response.data
+            assert b'Mark Handoff Complete' not in response.data
+
+    def test_view_conversation_pending_pickup_giveaway_owner_sees_handoff_actions(self, client, app):
+        """Owners should get the handoff-complete CTA in the recipient conversation."""
+        with app.app_context():
+            owner = UserFactory()
+            claimant = UserFactory()
+            giveaway = ItemFactory(
+                owner=owner,
+                is_giveaway=True,
+                claim_status='pending_pickup',
+                claimed_by=claimant,
+                available=False,
+            )
+            first_message = MessageFactory(
+                sender=owner,
+                recipient=claimant,
+                item=giveaway,
+                body='Let me know when you are on your way.',
+            )
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.get(f'/message/{first_message.id}')
+
+            assert response.status_code == 200
+            assert b'Giveaway Pickup' in response.data
+            assert b'Mark Handoff Complete' in response.data
+            assert b'Change Recipient' in response.data
+            assert b'Release to Everyone' in response.data
 
 
 class TestRequestNavigation:

--- a/tests/integration/test_routes.py
+++ b/tests/integration/test_routes.py
@@ -1,4 +1,5 @@
 """Integration tests for main routes."""
+from datetime import date, timedelta
 import json
 import pytest
 from app import db
@@ -645,6 +646,68 @@ class TestItemRoutes:
             response = client.post(f'/item/{item.id}/delete', follow_redirects=True)
             assert response.status_code == 200
             assert b'You can only delete your own items.' in response.data
+
+    def test_delete_item_with_active_loan_is_blocked(self, client, app, auth_user):
+        """Owners must resolve active loans before deleting an item."""
+        with app.app_context():
+            owner = auth_user()
+            borrower = UserFactory()
+            item = ItemFactory(owner=owner, available=False)
+            loan = LoanRequestFactory(
+                item=item,
+                borrower=borrower,
+                status='approved',
+                start_date=date.today() - timedelta(days=2),
+                end_date=date.today() + timedelta(days=5),
+            )
+            loan_message = MessageFactory(
+                sender=borrower,
+                recipient=owner,
+                item=item,
+                loan_request=loan,
+                body='I still have this item and can return it this weekend.',
+            )
+            item_id = item.id
+            loan_message_id = loan_message.id
+            db.session.commit()
+
+            login_user(client, owner.email)
+
+            response = client.post(f'/item/{item.id}/delete', follow_redirects=False)
+
+            assert response.status_code == 302
+            assert response.headers['Location'].endswith(f'/message/{loan_message_id}')
+            assert db.session.get(Item, item_id) is not None
+
+    def test_delete_modal_for_active_loan_shows_resolution_guidance(self, client, app, auth_user):
+        """Delete modal should send owners to the active loan instead of offering deletion."""
+        with app.app_context():
+            owner = auth_user()
+            borrower = UserFactory(first_name='Taylor', last_name='Borrower')
+            item = ItemFactory(owner=owner, available=False)
+            loan = LoanRequestFactory(
+                item=item,
+                borrower=borrower,
+                status='approved',
+                start_date=date.today() - timedelta(days=1),
+                end_date=date.today() + timedelta(days=7),
+            )
+            MessageFactory(
+                sender=borrower,
+                recipient=owner,
+                item=item,
+                loan_request=loan,
+                body='Thanks again for lending this to me.',
+            )
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.get(f'/item/{item.id}')
+
+            assert response.status_code == 200
+            assert b'This item is currently out on loan' in response.data
+            assert b'Mark the item returned or cancel the loan before deleting it.' in response.data
+            assert b'View Active Loan' in response.data
     
     def test_add_item_image_upload_failure(self, app, client, auth_user):
         """Test adding item when image upload fails."""

--- a/tests/unit/test_giveaway_models.py
+++ b/tests/unit/test_giveaway_models.py
@@ -34,3 +34,29 @@ class TestItemGiveawayFields:
             assert item.claim_status == 'pending_pickup'
             assert item.claimed_by_id == user.id
             assert item.claimed_at is None  # Not set until handoff confirmed
+
+    def test_claimed_by_name_uses_recipient_full_name(self, app):
+        """Claimed giveaway recipient name should come from the selected user."""
+        with app.app_context():
+            recipient = UserFactory(first_name='Jordan', last_name='Lee')
+            item = ItemFactory(
+                is_giveaway=True,
+                claim_status='pending_pickup',
+                claimed_by=recipient,
+            )
+            db.session.commit()
+
+            assert item.claimed_by_name == 'Jordan Lee'
+
+    def test_claimed_by_name_falls_back_for_soft_deleted_recipient(self, app):
+        """Soft-deleted recipients should render as Deleted User."""
+        with app.app_context():
+            recipient = UserFactory(first_name='Jordan', last_name='Lee', is_deleted=True, deleted_at=datetime.now(UTC))
+            item = ItemFactory(
+                is_giveaway=True,
+                claim_status='claimed',
+                claimed_by=recipient,
+            )
+            db.session.commit()
+
+            assert item.claimed_by_name == 'Deleted User'


### PR DESCRIPTION
Fix #326, a bad UX path that surfaced recently.

This adds action buttons to manage a giveaway in the conversation about it. Both for assigning a giveaway item from the conversation and marking the handoff complete.

It also adds a new item delete modal and restricts users from giving away an item that is in the giveaway process or out on loan, forcing them to resolve the activity before deleting. A little bit of scope creep, but related in that users were deleting the giveaway b/c they couldn't figure out how to mark it complete.

## AFTER

**With only one interested user**

<img width="1488" height="956" alt="Screenshot from 2026-04-21 22-13-40" src="https://github.com/user-attachments/assets/598a41ba-2628-488f-b424-b4d15ad35a4d" />

**With two interested users**

<img width="1488" height="956" alt="Screenshot from 2026-04-21 22-14-49" src="https://github.com/user-attachments/assets/7fee9e53-f7dd-4cb8-bb1c-4c425719e8dc" />

**While item is pending pickup**

<img width="1492" height="959" alt="image" src="https://github.com/user-attachments/assets/f77b72e6-59f0-4c6a-813b-e806a48735c7" />

**Modal that blocks deletion of item if on loan**

<img width="857" height="532" alt="image" src="https://github.com/user-attachments/assets/5c99bc87-6eac-447f-b971-2c673225bf14" />

**Similar modal that blocks deletion of item pending pickup**
<img width="857" height="532" alt="image" src="https://github.com/user-attachments/assets/d9afd32a-9c67-4cb4-82aa-1a6b547ab9ee" />

