### PR TITLE
fix: giveaway with activity can't be converted to loan item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 
 ### Bug fixes
 - Items can no longer be converted to giveaways while they still have pending or approved loan requests ([#334](https://github.com/sfirke/meutch/pull/334)).
+- Giveaways can no longer be converted back into loan items once people have expressed interest, pickup is pending, or the handoff is complete.
 
 
 ### Developer Experience

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 
 ### Bug fixes
 - Items can no longer be converted to giveaways while they still have pending or approved loan requests ([#334](https://github.com/sfirke/meutch/pull/334)).
-- Giveaways can no longer be converted back into loan items once people have expressed interest, pickup is pending, or the handoff is complete.
+- Giveaways can no longer be converted back into loan items once people have expressed interest, pickup is pending, or the handoff is complete([#335](https://github.com/sfirke/meutch/pull/335)).
 
 
 ### Developer Experience

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -159,6 +159,23 @@ def _giveaway_conversion_blocker(item):
     return None, None
 
 
+def _loan_conversion_blocker(item):
+    if item.claim_status == 'claimed':
+        return 'claimed'
+
+    if item.claim_status == 'pending_pickup':
+        return 'pending_pickup'
+
+    active_interest = GiveawayInterest.query.filter(
+        GiveawayInterest.item_id == item.id,
+        GiveawayInterest.status.in_(['active', 'selected'])
+    ).first()
+    if active_interest:
+        return 'interested_users'
+
+    return None
+
+
 def _parse_homepage_feed_filters(user):
     scope = request.args.get('scope', 'all')
     if scope not in {'all', 'circles'}:
@@ -1356,6 +1373,23 @@ def edit_item(item_id):
                     form.is_giveaway.errors.append(
                         'This item has a pending loan request. Resolve the request before converting it to a giveaway.'
                     )
+                return render_template('main/edit_item.html', form=form, item=item)
+        elif item.is_giveaway:
+            conversion_blocker = _loan_conversion_blocker(item)
+            if conversion_blocker == 'interested_users':
+                form.is_giveaway.errors.append(
+                    'This giveaway already has interested users. It cannot be converted back into a loan item.'
+                )
+                return render_template('main/edit_item.html', form=form, item=item)
+            if conversion_blocker == 'pending_pickup':
+                form.is_giveaway.errors.append(
+                    'This giveaway is pending pickup. Complete the handoff or release it back to everyone before converting it to a loan item.'
+                )
+                return render_template('main/edit_item.html', form=form, item=item)
+            if conversion_blocker == 'claimed':
+                form.is_giveaway.errors.append(
+                    'This giveaway has already been handed off. Completed giveaways cannot be converted back into loan items.'
+                )
                 return render_template('main/edit_item.html', form=form, item=item)
 
         try:

--- a/tests/integration/test_giveaway_routes.py
+++ b/tests/integration/test_giveaway_routes.py
@@ -2,7 +2,7 @@
 import pytest
 from app import db
 from app.models import Item, GiveawayInterest, Message
-from tests.factories import UserFactory, ItemFactory, CategoryFactory, CircleFactory, MessageFactory, LoanRequestFactory
+from tests.factories import UserFactory, ItemFactory, CategoryFactory, CircleFactory, MessageFactory, LoanRequestFactory, GiveawayInterestFactory
 from conftest import login_user
 from datetime import datetime, UTC, timedelta
 from sqlalchemy import text
@@ -210,6 +210,108 @@ class TestGiveawayItemCreation:
             assert updated_item.is_giveaway is False
             assert updated_item.giveaway_visibility is None
             assert updated_item.claim_status is None
+
+    def test_edit_giveaway_to_loan_with_interested_users_is_blocked(self, client, app, auth_user):
+        """Giveaways with interested users cannot be converted back into loan items."""
+        with app.app_context():
+            owner = auth_user()
+            interested_user = UserFactory()
+            category = CategoryFactory()
+            item = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                giveaway_visibility='default',
+                claim_status='unclaimed'
+            )
+            GiveawayInterestFactory(item=item, user=interested_user, status='active')
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.post(f'/item/{item.id}/edit', data={
+                'name': item.name,
+                'description': item.description,
+                'category': str(category.id),
+                'tags': ''
+            }, follow_redirects=True)
+
+            assert response.status_code == 200
+            assert b'This giveaway already has interested users. It cannot be converted back into a loan item.' in response.data
+
+            updated_item = db.session.get(Item, item.id)
+            assert updated_item.is_giveaway is True
+            assert updated_item.giveaway_visibility == 'default'
+            assert updated_item.claim_status == 'unclaimed'
+
+    def test_edit_pending_pickup_giveaway_to_loan_is_blocked(self, client, app, auth_user):
+        """Pending-pickup giveaways cannot be converted back into loan items."""
+        with app.app_context():
+            owner = auth_user()
+            recipient = UserFactory()
+            category = CategoryFactory()
+            item = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                giveaway_visibility='default',
+                claim_status='pending_pickup',
+                claimed_by=recipient,
+                available=False
+            )
+            GiveawayInterestFactory(item=item, user=recipient, status='selected')
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.post(f'/item/{item.id}/edit', data={
+                'name': item.name,
+                'description': item.description,
+                'category': str(category.id),
+                'tags': ''
+            }, follow_redirects=True)
+
+            assert response.status_code == 200
+            assert b'This giveaway is pending pickup. Complete the handoff or release it back to everyone before converting it to a loan item.' in response.data
+
+            updated_item = db.session.get(Item, item.id)
+            assert updated_item.is_giveaway is True
+            assert updated_item.giveaway_visibility == 'default'
+            assert updated_item.claim_status == 'pending_pickup'
+            assert updated_item.claimed_by_id == recipient.id
+
+    def test_edit_claimed_giveaway_to_loan_is_blocked(self, client, app, auth_user):
+        """Claimed giveaways cannot be converted back into loan items."""
+        with app.app_context():
+            owner = auth_user()
+            recipient = UserFactory()
+            category = CategoryFactory()
+            item = ItemFactory(
+                owner=owner,
+                category=category,
+                is_giveaway=True,
+                giveaway_visibility='default',
+                claim_status='claimed',
+                claimed_by=recipient,
+                available=False
+            )
+            GiveawayInterestFactory(item=item, user=recipient, status='selected')
+            db.session.commit()
+
+            login_user(client, owner.email)
+            response = client.post(f'/item/{item.id}/edit', data={
+                'name': item.name,
+                'description': item.description,
+                'category': str(category.id),
+                'tags': ''
+            }, follow_redirects=True)
+
+            assert response.status_code == 200
+            assert b'This giveaway has already been handed off. Completed giveaways cannot be converted back into loan items.' in response.data
+
+            updated_item = db.session.get(Item, item.id)
+            assert updated_item.is_giveaway is True
+            assert updated_item.giveaway_visibility == 'default'
+            assert updated_item.claim_status == 'claimed'
+            assert updated_item.claimed_by_id == recipient.id
 
 
 class TestGiveawayPublicVisibilityLocationRequirement:


### PR DESCRIPTION
The counterpoint to #334 - stops active giveaway -> loan-type item conversion.