### PR TITLE
feat(feed, digests): show two-step event resolutions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,9 @@ jobs:
     - name: Fetch pull request base branch
       run: git fetch origin ${{ github.base_ref }}
 
-    - name: Compute pull request merge base
-      id: diff-base
-      run: echo "sha=$(git merge-base HEAD FETCH_HEAD)" >> "$GITHUB_OUTPUT"
-
     - name: Run pre-commit on changed files
       run: |
-        pre-commit run -v --show-diff-on-failure --color=always --from-ref ${{ steps.diff-base.outputs.sha }} --to-ref HEAD
+        ./scripts/run_precommit_diff.sh origin/${{ github.base_ref }}
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,15 @@ repos:
           - python
           - pyi
 
+      - id: pre-commit-diff
+        name: Run diff-scoped pre-commit
+        entry: ./scripts/run_precommit_diff.sh
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages:
+          - pre-push
+
       - id: alembic-revision-ids
         name: Validate Alembic revision IDs
         entry: python scripts/check_alembic_revision_ids.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Stay up on what's happening with Meutch. Improvements are constantly pushed to the main instance at https://meutch.com - this lets you know what changed since the last time you logged in.
 
+## May 2026
+
+### Features
+
+**Minor**:
+- Digest emails now surface fulfilled requests and claimed giveaways, including clear labels when an item is both created and resolved within the same digest window ([#339](https://github.com/sfirke/meutch/pull/339)).
+
+### Developer Experience
+- Align local pre-push linting with CI by sharing the same branch-diff `pre-commit` runner and documenting the diff-scoped command ([#339](https://github.com/sfirke/meutch/pull/339)).
+
 ## Apr 2026
 
 ### Features
@@ -12,7 +22,6 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 **Minor**
 - `share/` pages get the aesthetic and the "how/why" content from the main landing page ([#323](https://github.com/sfirke/meutch/pull/323)).
 - Surface giveaway actions in the owner-recipient conversation, both for recipient assignment and handoff confirmation. Also add item deletion modal that stops pending-pickup items and active loans from being deleted ([#329](https://github.com/sfirke/meutch/pull/329)).
-- Digest emails now surface fulfilled requests and claimed giveaways, including clear labels when an item is both created and resolved within the same digest window.
 
 ### Bug fixes
 - Items can no longer be converted to giveaways while they still have pending or approved loan requests ([#334](https://github.com/sfirke/meutch/pull/334)).
@@ -24,7 +33,6 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 ### Developer Experience
 - Seeded loan data now includes messages, `./dev-start seed` can run when alembic table is missing/hasn't been initialized yet ([#307](https://github.com/sfirke/meutch/pull/307)).
 - Add shared `pre-commit` linting with `ruff` and `pylint --errors-only`, plus GitHub PR enforcement for the same hooks ([#338](https://github.com/sfirke/meutch/pull/338)).
-- Align local pre-push linting with CI by sharing the same branch-diff `pre-commit` runner and documenting the diff-scoped command.
 
 ## Mar 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 **Minor**
 - `share/` pages get the aesthetic and the "how/why" content from the main landing page ([#323](https://github.com/sfirke/meutch/pull/323)).
 - Surface giveaway actions in the owner-recipient conversation, both for recipient assignment and handoff confirmation. Also add item deletion modal that stops pending-pickup items and active loans from being deleted ([#329](https://github.com/sfirke/meutch/pull/329)).
+- Digest emails now surface fulfilled requests and claimed giveaways, including clear labels when an item is both created and resolved within the same digest window.
 
 ### Bug fixes
 - Items can no longer be converted to giveaways while they still have pending or approved loan requests ([#334](https://github.com/sfirke/meutch/pull/334)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 ### Developer Experience
 - Seeded loan data now includes messages, `./dev-start seed` can run when alembic table is missing/hasn't been initialized yet ([#307](https://github.com/sfirke/meutch/pull/307)).
 - Add shared `pre-commit` linting with `ruff` and `pylint --errors-only`, plus GitHub PR enforcement for the same hooks ([#338](https://github.com/sfirke/meutch/pull/338)).
+- Align local pre-push linting with CI by sharing the same branch-diff `pre-commit` runner and documenting the diff-scoped command.
 
 ## Mar 2026
 

--- a/README.md
+++ b/README.md
@@ -116,14 +116,15 @@ Install the hooks once per clone:
 That script force-replaces any older custom git hook for this repo, so you do not need to manually uninstall the legacy hook first.
 What runs where:
 - `pre-commit` on commit: fast checks only, against the files you are changing. That includes `ruff` linting, `ruff format`, `pylint --errors-only`, and basic YAML/whitespace checks.
-- `pre-push` on push: the Alembic revision ID check and the unit test suite.
-- GitHub Actions on pull requests: the same `pre-commit` checks run against the PR diff so contributors and CI stay aligned.
+- `pre-push` on push: the same diff-scoped `pre-commit` lint that CI uses, plus the Alembic revision ID check and the unit test suite.
+- GitHub Actions on pull requests: that same diff-scoped `pre-commit` run executes against the PR diff.
 
 Useful commands:
 
 ```bash
-pre-commit run --all-files
+./scripts/run_precommit_diff.sh
 pre-commit run ruff-check --files path/to/file.py
+pre-commit run ruff-format --files path/to/file.py
 pre-commit run pylint-errors-only --files path/to/file.py
 ```
 

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -132,8 +132,14 @@
                                     <h2 class="h5 mb-1 d-inline">{{ event.title }}</h2>
                                     {% if event.event_type == 'request' %}
                                         <span class="badge rounded-pill text-bg-light border text-primary ms-1" style="font-size: 0.65rem; vertical-align: middle;"><i class="fas fa-hand-holding-heart me-1"></i>Request</span>
+                                        {% if event.status == 'fulfilled' %}
+                                            <span class="badge bg-success ms-1" style="font-size: 0.65rem; vertical-align: middle;"><i class="fas fa-check-circle me-1"></i>Fulfilled</span>
+                                        {% endif %}
                                     {% elif event.event_type == 'giveaway' %}
                                         <span class="badge rounded-pill text-bg-light border text-success ms-1" style="font-size: 0.65rem; vertical-align: middle;"><i class="fas fa-gift me-1"></i>Giveaway</span>
+                                        {% if event.claim_status == 'claimed' %}
+                                            <span class="badge bg-success ms-1" style="font-size: 0.65rem; vertical-align: middle;"><i class="fas fa-check-circle me-1"></i>Claimed</span>
+                                        {% endif %}
                                     {% elif event.event_type == 'lent' %}
                                         <span class="badge rounded-pill text-bg-light border text-secondary ms-1" style="font-size: 0.65rem; vertical-align: middle;"><i class="fas fa-handshake me-1"></i>Lent</span>
                                     {% elif event.event_type == 'circle_join' %}

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -18,7 +18,7 @@
                 </a>
             </div>
         </div>
-        
+
         <div class="d-flex justify-content-between align-items-center">
             <p class="text-muted mb-0 small">Recent requests, giveaways, and lending activity.</p>
             <button class="btn btn-link btn-sm text-decoration-none p-0 d-flex align-items-center gap-1" type="button" data-bs-toggle="collapse" data-bs-target="#feedFiltersCollapse" aria-expanded="false" aria-controls="feedFiltersCollapse">
@@ -118,7 +118,7 @@
                                 <span class="activity-feed-avatar-fallback flex-shrink-0" style="width: 28px; height: 28px; font-size: 0.8rem;" aria-hidden="true">{{ actor_initials or 'CM' }}</span>
                             {% endif %}
                             <div class="text-truncate">
-                                <strong class="text-body">{{ event.actor_name }}</strong> 
+                                <strong class="text-body">{{ event.actor_name }}</strong>
                                 {{ event.action }}
                             </div>
                             <div class="ms-auto text-nowrap" style="font-size: 0.8rem;">
@@ -149,7 +149,7 @@
                                         <span class="badge bg-info ms-1" style="font-size: 0.65rem; vertical-align: middle;"><i class="fas fa-map-marker-alt me-1"></i>{{ event.distance }}</span>
                                     {% endif %}
                                 </div>
-                                
+
                                 {% if event.description %}
                                     <p class="text-muted small mb-2 text-break" style="display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;">
                                         {{ event.description }}

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -521,7 +521,8 @@ def _digest_resolution_only_text(event):
     if event["event_type"] == "request":
         return f"{title} was marked fulfilled"
     if event["event_type"] == "giveaway":
-        return f"{title} was claimed"
+        actor = event.get("actor_name", "Unknown")
+        return f"{title} offered by {actor} was claimed"
     return title
 
 
@@ -607,7 +608,11 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
             actor = event["actor_name"]
             is_resolution_only = event.get("digest_variant") == "resolved-in-window"
             if is_resolution_only:
-                text_lines.append(f"- {actor}: {_digest_resolution_only_text(event)}")
+                # For giveaways, the message already includes the actor name
+                if event["event_type"] == "giveaway":
+                    text_lines.append(f"- {_digest_resolution_only_text(event)}")
+                else:
+                    text_lines.append(f"- {actor}: {_digest_resolution_only_text(event)}")
             else:
                 title = _digest_event_title(event)
                 action = event["action"]
@@ -619,6 +624,8 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
             if include_description and not is_resolution_only and event.get("description"):
                 text_lines.append(f"  {event['description']}")
             if not is_resolution_only and event.get("image_url"):
+                text_lines.append(f"  Image: {event['image_url']}")
+            if is_resolution_only and event.get("image_url"):
                 text_lines.append(f"  Image: {event['image_url']}")
             text_lines.append(f"  {_digest_event_url(event)}")
         text_lines.append("")
@@ -666,7 +673,7 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
                 )
 
             image_html = ""
-            if not is_resolution_only and event.get("image_url"):
+            if event.get("image_url"):
                 image_html = (
                     f"<div style=\"margin: 8px 0;\">"
                     f"<img src=\"{event['image_url']}\" alt=\"Activity image\" "
@@ -675,9 +682,13 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
                 )
 
             if is_resolution_only:
-                activity_html = (
-                    f"<strong>{actor}</strong>: {_digest_resolution_only_text(event)}<br>"
-                )
+                # For giveaways, the message already includes the actor name
+                if event["event_type"] == "giveaway":
+                    activity_html = f"{_digest_resolution_only_text(event)}<br>"
+                else:
+                    activity_html = (
+                        f"<strong>{actor}</strong>: {_digest_resolution_only_text(event)}<br>"
+                    )
             else:
                 item_title = _digest_event_title(event)
                 action = event["action"]

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -464,6 +464,25 @@ def _digest_event_title(event):
     return event['title']
 
 
+def _digest_resolution_label(event):
+    if event.get('digest_variant') != 'new-resolved-in-window':
+        return None
+    if event['event_type'] == 'request' and event.get('resolution_status') == 'fulfilled':
+        return 'Fulfilled'
+    if event['event_type'] == 'giveaway' and event.get('resolution_status') == 'claimed':
+        return 'Claimed'
+    return None
+
+
+def _digest_resolution_only_text(event):
+    title = _digest_event_title(event)
+    if event['event_type'] == 'request':
+        return f'{title} was marked fulfilled'
+    if event['event_type'] == 'giveaway':
+        return f'{title} was claimed'
+    return title
+
+
 def _digest_cadence_label(user):
     cadence = (getattr(user, 'digest_frequency', None) or '').lower()
     if cadence == 'daily':
@@ -540,12 +559,20 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         text_lines.append(f"{section_title}:")
         for event in events:
             actor = event['actor_name']
-            title = _digest_event_title(event)
-            action = event['action']
-            text_lines.append(f"- {actor} {action}: {title}")
-            if include_description and event.get('description'):
+            is_resolution_only = event.get('digest_variant') == 'resolved-in-window'
+            if is_resolution_only:
+                text_lines.append(f"- {actor}: {_digest_resolution_only_text(event)}")
+            else:
+                title = _digest_event_title(event)
+                action = event['action']
+                resolution_label = _digest_resolution_label(event)
+                line = f"- {actor} {action}: {title}"
+                if resolution_label:
+                    line = f"{line} [{resolution_label}]"
+                text_lines.append(line)
+            if include_description and not is_resolution_only and event.get('description'):
                 text_lines.append(f"  {event['description']}")
-            if event.get('image_url'):
+            if not is_resolution_only and event.get('image_url'):
                 text_lines.append(f"  Image: {event['image_url']}")
             text_lines.append(f"  {_digest_event_url(event)}")
         text_lines.append("")
@@ -582,15 +609,14 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         items_html = []
         for event in events:
             actor = event['actor_name']
-            item_title = _digest_event_title(event)
-            action = event['action']
             link = _digest_event_url(event)
+            is_resolution_only = event.get('digest_variant') == 'resolved-in-window'
             description_html = ''
-            if include_description and event.get('description'):
+            if include_description and not is_resolution_only and event.get('description'):
                 description_html = f"<p style=\"margin: 6px 0 0 0; color: #555;\">{event['description']}</p>"
 
             image_html = ''
-            if event.get('image_url'):
+            if not is_resolution_only and event.get('image_url'):
                 image_html = (
                     f"<div style=\"margin: 8px 0;\">"
                     f"<img src=\"{event['image_url']}\" alt=\"Activity image\" "
@@ -598,10 +624,25 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
                     f"</div>"
                 )
 
+            if is_resolution_only:
+                activity_html = f"<strong>{actor}</strong>: {_digest_resolution_only_text(event)}<br>"
+            else:
+                item_title = _digest_event_title(event)
+                action = event['action']
+                resolution_label = _digest_resolution_label(event)
+                label_html = ''
+                if resolution_label:
+                    label_html = (
+                        f" <span style=\"display: inline-block; margin-left: 6px; padding: 1px 8px; "
+                        f"background-color: #198754; color: #fff; border-radius: 999px; font-size: 12px;\">"
+                        f"{resolution_label}</span>"
+                    )
+                activity_html = f"<strong>{actor}</strong> {action}: {item_title}{label_html}<br>"
+
             items_html.append(
                 f"""
                 <li style=\"margin-bottom: 10px;\">
-                    <strong>{actor}</strong> {action}: {item_title}<br>
+                    {activity_html}
                     {description_html}
                     {image_html}
                     <a href=\"{link}\" style=\"color: #007bff; text-decoration: none;\">View activity</a>

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -1,51 +1,48 @@
 import requests
-import os
 from flask import current_app, url_for
+
 from app.utils.digest_tokens import generate_digest_manage_token
 
 
 def send_email(to_email, subject, text_content, html_content=None):
     """Send email using Mailgun API"""
     try:
-        api_key = current_app.config.get('MAILGUN_API_KEY')
-        domain = current_app.config.get('MAILGUN_DOMAIN')
-        
+        api_key = current_app.config.get("MAILGUN_API_KEY")
+        domain = current_app.config.get("MAILGUN_DOMAIN")
+
         if not api_key or not domain:
             current_app.logger.error("Mailgun configuration missing")
             return False
-        
+
         # Check email allowlist (for staging/testing environments)
-        allowlist = current_app.config.get('EMAIL_ALLOWLIST')
+        allowlist = current_app.config.get("EMAIL_ALLOWLIST")
         if allowlist is not None:  # Allowlist is configured
             if to_email.lower() not in allowlist:
-                current_app.logger.info(f"Email to {to_email} blocked by allowlist. Subject: {subject}")
+                current_app.logger.info(
+                    f"Email to {to_email} blocked by allowlist. Subject: {subject}"
+                )
                 return True  # Return True since this is not an error - just filtered
-        
+
         from_email = f"Meutch <postmaster@{domain}>"
-        
-        data = {
-            "from": from_email,
-            "to": to_email,
-            "subject": subject,
-            "text": text_content
-        }
-        
+
+        data = {"from": from_email, "to": to_email, "subject": subject, "text": text_content}
+
         if html_content:
             data["html"] = html_content
-            
+
         response = requests.post(
-            f"https://api.mailgun.net/v3/{domain}/messages",
-            auth=("api", api_key),
-            data=data
+            f"https://api.mailgun.net/v3/{domain}/messages", auth=("api", api_key), data=data
         )
-        
+
         if response.status_code == 200:
             current_app.logger.info(f"Email sent successfully to {to_email}")
             return True
         else:
-            current_app.logger.error(f"Failed to send email: {response.status_code} - {response.text}")
+            current_app.logger.error(
+                f"Failed to send email: {response.status_code} - {response.text}"
+            )
             return False
-            
+
     except Exception as e:
         current_app.logger.error(f"Error sending email: {str(e)}")
         return False
@@ -54,20 +51,20 @@ def send_email(to_email, subject, text_content, html_content=None):
 def send_confirmation_email(user, next_url=None):
     """Send email confirmation to user"""
     from app import db  # Import db here to avoid circular imports
-    
+
     token = user.generate_confirmation_token()
-    
+
     db.session.commit()
-    
+
     url_kwargs = dict(token=token, _external=True)
     if next_url:
-        url_kwargs['next'] = next_url
-    confirmation_url = url_for('auth.confirm_email', **url_kwargs)
-    
+        url_kwargs["next"] = next_url
+    confirmation_url = url_for("auth.confirm_email", **url_kwargs)
+
     print(f"Confirmation URL: {confirmation_url}")
-    
+
     subject = "Welcome to Meutch - Please confirm your email"
-    
+
     text_content = f"""
 Hello {user.first_name},
 
@@ -82,21 +79,22 @@ This link will expire in 24 hours. If you didn't create an account with Meutch, 
 Best regards,
 The Meutch Team
     """.strip()
-    
+
     return send_email(user.email, subject, text_content)
+
 
 def send_password_reset_email(user):
     """Send password reset email to user"""
     from app import db  # Import db here to avoid circular imports
-    
+
     token = user.generate_password_reset_token()
-    
+
     db.session.commit()
-    
-    reset_url = url_for('auth.reset_password', token=token, _external=True)
-    
+
+    reset_url = url_for("auth.reset_password", token=token, _external=True)
+
     subject = "Meutch - Reset Your Password"
-    
+
     text_content = f"""
 Hello {user.first_name},
 
@@ -113,26 +111,28 @@ If you continue to have trouble accessing your account, please contact our suppo
 Best regards,
 The Meutch Team
     """.strip()
-    
+
     return send_email(user.email, subject, text_content)
 
 
 def send_message_notification_email(message):
     """Send email notification for new messages"""
-    from app.models import User  # Import here to avoid circular imports
     from app import db
-    
+    from app.models import User  # Import here to avoid circular imports
+
     # Get the recipient user
     recipient = db.session.get(User, message.recipient_id)
     sender = db.session.get(User, message.sender_id)
-    
+
     if not recipient or not sender:
-        current_app.logger.error(f"User not found for message notification: recipient={message.recipient_id}, sender={message.sender_id}")
+        current_app.logger.error(
+            f"User not found for message notification: recipient={message.recipient_id}, sender={message.sender_id}"
+        )
         return False
-    
+
     # Generate the conversation URL
-    conversation_url = url_for('main.view_conversation', message_id=message.id, _external=True)
-    
+    conversation_url = url_for("main.view_conversation", message_id=message.id, _external=True)
+
     context_label = None
     context_type_label = None  # User-facing label for email
     if message.item is not None:
@@ -151,32 +151,34 @@ def send_message_notification_email(message):
     # Determine the subject and email content based on message type
     if message.is_loan_request_message:
         # Check if this is a loan extension message (owner extending the due date)
-        if message.loan_request.status == 'approved' and 'has been extended' in message.body:
+        if message.loan_request.status == "approved" and "has been extended" in message.body:
             subject = f"Meutch - Loan Extended for {message.item.name}"
             email_type = "loan extension"
-        elif message.loan_request.status == 'pending':
+        elif message.loan_request.status == "pending":
             subject = f"Meutch - New Loan Request for {message.item.name}"
             email_type = "loan request"
-        elif message.loan_request.status == 'approved':
+        elif message.loan_request.status == "approved":
             subject = f"Meutch - Loan Request Approved for {message.item.name}"
             email_type = "loan approval"
-        elif message.loan_request.status == 'denied':
+        elif message.loan_request.status == "denied":
             subject = f"Meutch - Loan Request Denied for {message.item.name}"
             email_type = "loan denial"
-        elif message.loan_request.status == 'completed':
+        elif message.loan_request.status == "completed":
             subject = f"Meutch - Loan Completed for {message.item.name}"
             email_type = "loan completion"
-        elif message.loan_request.status == 'canceled':
+        elif message.loan_request.status == "canceled":
             subject = f"Meutch - Loan Request Canceled for {message.item.name}"
             email_type = "loan cancellation"
         else:
             # Strict validation: raise exception for unknown statuses
-            raise ValueError(f"Unknown loan request status '{message.loan_request.status}' for message {message.id}. "
-                           f"Valid statuses are: pending, approved, denied, completed, canceled")
+            raise ValueError(
+                f"Unknown loan request status '{message.loan_request.status}' for message {message.id}. "
+                f"Valid statuses are: pending, approved, denied, completed, canceled"
+            )
     else:
         subject = f"Meutch - New Message about {context_label}"
         email_type = "message"
-    
+
     text_content = f"""
 Hello {recipient.first_name},
 
@@ -196,34 +198,34 @@ You can also log into your Meutch account to view all your messages at any time.
 Best regards,
 The Meutch Team
     """.strip()
-    
+
     # Create HTML content for better presentation
     html_content = f"""
     <html>
     <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h2 style="color: #333;">You have a new {email_type} on Meutch</h2>
-        
+
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>From:</strong> {sender.first_name} {sender.last_name}</p>
             <p>{context_type_label}</p>
         </div>
-        
+
         <div style="background-color: white; padding: 20px; border-left: 4px solid #007bff; margin: 20px 0;">
             <h3>Message:</h3>
             <p style="white-space: pre-line;">{message.body}</p>
         </div>
-        
+
         <div style="text-align: center; margin: 30px 0;">
-            <a href="{conversation_url}" 
+            <a href="{conversation_url}"
                style="background-color: #007bff; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Conversation & Respond
             </a>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             You can also log into your Meutch account to view all your messages at any time.
         </p>
-        
+
         <hr style="margin-top: 30px; border: none; border-top: 1px solid #ddd;">
         <p style="color: #999; font-size: 12px;">
             Best regards,<br>
@@ -232,48 +234,52 @@ The Meutch Team
     </body>
     </html>
     """
-    
+
     return send_email(recipient.email, subject, text_content, html_content)
 
 
 def send_circle_join_request_notification_email(join_request):
     """Send email notification to circle admins when a user requests to join"""
-    from app.models import User, circle_members  # Import here to avoid circular imports
     from sqlalchemy import and_
-    
+
+    from app.models import User, circle_members  # Import here to avoid circular imports
+
     # Get the circle and requesting user
     circle = join_request.circle
     requesting_user = join_request.user
-    
+
     if not circle or not requesting_user:
-        current_app.logger.error(f"Circle or user not found for join request notification: circle={join_request.circle_id}, user={join_request.user_id}")
+        current_app.logger.error(
+            f"Circle or user not found for join request notification: circle={join_request.circle_id}, user={join_request.user_id}"
+        )
         return False
-    
+
     # Get all admins of the circle
     admin_users = User.query.join(
         circle_members,
         and_(
             User.id == circle_members.c.user_id,
             circle_members.c.circle_id == circle.id,
-            circle_members.c.is_admin == True
-        )
+            circle_members.c.is_admin.is_(True),
+        ),
     ).all()
-    
+
     if not admin_users:
         current_app.logger.error(f"No admins found for circle {circle.id}")
         return False
-    
+
     # Generate the circle details URL
-    circle_url = url_for('circles.view_circle', circle_id=circle.id, _external=True)
-    
+    circle_url = url_for("circles.view_circle", circle_id=circle.id, _external=True)
+
     subject = f"Meutch - New Join Request for {circle.name}"
-    
+
     success_count = 0
     for admin in admin_users:
         # Link to the requesting user's profile for quick review context
-        profile_url = url_for('main.user_profile', user_id=requesting_user.id, _external=True)
+        profile_url = url_for("main.user_profile", user_id=requesting_user.id, _external=True)
 
-        text_content = f"""
+        text_content = (
+            f"""
 Hello {admin.first_name},
 
 You have received a new request to join your circle "{circle.name}" on Meutch.
@@ -281,10 +287,16 @@ You have received a new request to join your circle "{circle.name}" on Meutch.
 Requesting User: {requesting_user.first_name} {requesting_user.last_name}
 Profile: {profile_url}
 Circle: {circle.name}
-""" + (f"""
+"""
+            + (
+                f"""
 Request Message:
 {join_request.message}
-""" if join_request.message else "") + f"""
+"""
+                if join_request.message
+                else ""
+            )
+            + f"""
 To review this request and take action, visit your circle:
 {circle_url}
 
@@ -293,34 +305,42 @@ You can approve or reject the request from your circle's management page.
 Best regards,
 The Meutch Team
         """.strip()
-        
+        )
+
         # Create HTML content for better presentation
-        html_content = f"""
+        html_content = (
+            f"""
         <html>
         <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
             <h2 style="color: #333;">New Join Request for Your Circle</h2>
-            
+
             <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
                 <p><strong>Requesting User:</strong> <a href="{profile_url}" style="color: #007bff; text-decoration: none;">{requesting_user.first_name} {requesting_user.last_name}</a></p>
                 <p><strong>Circle:</strong> {circle.name}</p>
             </div>
-            """ + (f"""
+            """
+            + (
+                f"""
             <div style="background-color: white; padding: 20px; border-left: 4px solid #007bff; margin: 20px 0;">
                 <h3>Request Message:</h3>
                 <p style="white-space: pre-line;">{join_request.message}</p>
             </div>
-            """ if join_request.message else "") + f"""
+            """
+                if join_request.message
+                else ""
+            )
+            + f"""
             <div style="text-align: center; margin: 30px 0;">
-                <a href="{circle_url}" 
+                <a href="{circle_url}"
                    style="background-color: #007bff; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                     Review Join Request
                 </a>
             </div>
-            
+
             <p style="color: #666; font-size: 14px;">
                 You can approve or reject the request from your circle's management page.
             </p>
-            
+
             <hr style="margin-top: 30px; border: none; border-top: 1px solid #ddd;">
             <p style="color: #999; font-size: 12px;">
                 Best regards,<br>
@@ -329,90 +349,111 @@ The Meutch Team
         </body>
         </html>
         """
-        
+        )
+
         if send_email(admin.email, subject, text_content, html_content):
             success_count += 1
         else:
-            current_app.logger.error(f"Failed to send circle join request notification to admin {admin.id}")
-    
+            current_app.logger.error(
+                f"Failed to send circle join request notification to admin {admin.id}"
+            )
+
     return success_count > 0
 
 
 def send_circle_join_request_decision_email(join_request):
     """Send email notification to user when their join request is acted upon"""
-    from app.models import User  # Import here to avoid circular imports
-    
+
     # Get the circle and requesting user
     circle = join_request.circle
     requesting_user = join_request.user
-    
+
     if not circle or not requesting_user:
-        current_app.logger.error(f"Circle or user not found for join request decision notification: circle={join_request.circle_id}, user={join_request.user_id}")
+        current_app.logger.error(
+            f"Circle or user not found for join request decision notification: circle={join_request.circle_id}, user={join_request.user_id}"
+        )
         return False
-    
+
     # Generate the circle details URL
-    circle_url = url_for('circles.view_circle', circle_id=circle.id, _external=True)
-    
+    circle_url = url_for("circles.view_circle", circle_id=circle.id, _external=True)
+
     # Determine the subject and email content based on status
-    if join_request.status == 'approved':
+    if join_request.status == "approved":
         subject = f"Meutch - Join Request Approved for {circle.name}"
         decision_text = "approved"
         button_text = "View Circle"
         html_color = "#28a745"
-    elif join_request.status == 'rejected':
+    elif join_request.status == "rejected":
         subject = f"Meutch - Join Request Denied for {circle.name}"
         decision_text = "denied"
         button_text = "Browse Other Circles"
         html_color = "#dc3545"
     else:
-        current_app.logger.error(f"Unknown join request status '{join_request.status}' for request {join_request.id}")
+        current_app.logger.error(
+            f"Unknown join request status '{join_request.status}' for request {join_request.id}"
+        )
         return False
-    
-    text_content = f"""
+
+    text_content = (
+        f"""
 Hello {requesting_user.first_name},
 
 Your request to join the circle "{circle.name}" has been {decision_text}.
 
 Circle: {circle.name}
 Status: {decision_text.title()}
-""" + (f"""
+"""
+        + (
+            f"""
 To view the circle, visit:
 {circle_url}
-""" if join_request.status == 'approved' else f"""
+"""
+            if join_request.status == "approved"
+            else """
 You can search for other circles to join by visiting your Meutch account.
-""") + f"""
+"""
+        )
+        + """
 Thank you for using Meutch!
 
 Best regards,
 The Meutch Team
     """.strip()
-    
+    )
+
     # Create HTML content for better presentation
-    html_content = f"""
+    html_content = (
+        f"""
     <html>
     <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h2 style="color: #333;">Circle Join Request {decision_text.title()}</h2>
-        
+
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Circle:</strong> {circle.name}</p>
             <p><strong>Status:</strong> <span style="color: {html_color}; font-weight: bold;">{decision_text.title()}</span></p>
         </div>
-        """ + (f"""
+        """
+        + (
+            f"""
         <div style="text-align: center; margin: 30px 0;">
-            <a href="{circle_url}" 
+            <a href="{circle_url}"
                style="background-color: {html_color}; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 {button_text}
             </a>
         </div>
-        """ if join_request.status == 'approved' else f"""
+        """
+            if join_request.status == "approved"
+            else """
         <p style="color: #666; font-size: 14px;">
             You can search for other circles to join by visiting your Meutch account.
         </p>
-        """) + f"""
+        """
+        )
+        + """
         <p style="color: #666; font-size: 14px;">
             Thank you for using Meutch!
         </p>
-        
+
         <hr style="margin-top: 30px; border: none; border-top: 1px solid #ddd;">
         <p style="color: #999; font-size: 12px;">
             Best regards,<br>
@@ -421,14 +462,15 @@ The Meutch Team
     </body>
     </html>
     """
-    
+    )
+
     return send_email(requesting_user.email, subject, text_content, html_content)
 
 
 def send_account_deletion_email(user_email, user_first_name):
     """Send account deletion confirmation email"""
     subject = "Meutch - Account Successfully Deleted"
-    
+
     text_content = f"""
 Hello {user_first_name},
 
@@ -445,51 +487,51 @@ Thank you for being part of the Meutch community. We're sorry to see you go!
 Best regards,
 The Meutch Team
     """.strip()
-    
+
     return send_email(user_email, subject, text_content)
 
 
 def _digest_event_url(event):
-    event_type = event.get('event_type')
-    if event_type in {'giveaway', 'lent'} and event.get('item_id'):
-        return url_for('main.item_detail', item_id=event['item_id'], _external=True)
-    if event_type == 'request' and event.get('request_id'):
-        return url_for('requests.detail', request_id=event['request_id'], _external=True)
-    if event_type == 'circle_join' and event.get('circle_id'):
-        return url_for('circles.view_circle', circle_id=event['circle_id'], _external=True)
-    return url_for('main.index', _external=True)
+    event_type = event.get("event_type")
+    if event_type in {"giveaway", "lent"} and event.get("item_id"):
+        return url_for("main.item_detail", item_id=event["item_id"], _external=True)
+    if event_type == "request" and event.get("request_id"):
+        return url_for("requests.detail", request_id=event["request_id"], _external=True)
+    if event_type == "circle_join" and event.get("circle_id"):
+        return url_for("circles.view_circle", circle_id=event["circle_id"], _external=True)
+    return url_for("main.index", _external=True)
 
 
 def _digest_event_title(event):
-    return event['title']
+    return event["title"]
 
 
 def _digest_resolution_label(event):
-    if event.get('digest_variant') != 'new-resolved-in-window':
+    if event.get("digest_variant") != "new-resolved-in-window":
         return None
-    if event['event_type'] == 'request' and event.get('resolution_status') == 'fulfilled':
-        return 'Fulfilled'
-    if event['event_type'] == 'giveaway' and event.get('resolution_status') == 'claimed':
-        return 'Claimed'
+    if event["event_type"] == "request" and event.get("resolution_status") == "fulfilled":
+        return "Fulfilled"
+    if event["event_type"] == "giveaway" and event.get("resolution_status") == "claimed":
+        return "Claimed"
     return None
 
 
 def _digest_resolution_only_text(event):
     title = _digest_event_title(event)
-    if event['event_type'] == 'request':
-        return f'{title} was marked fulfilled'
-    if event['event_type'] == 'giveaway':
-        return f'{title} was claimed'
+    if event["event_type"] == "request":
+        return f"{title} was marked fulfilled"
+    if event["event_type"] == "giveaway":
+        return f"{title} was claimed"
     return title
 
 
 def _digest_cadence_label(user):
-    cadence = (getattr(user, 'digest_frequency', None) or '').lower()
-    if cadence == 'daily':
-        return 'daily'
-    if cadence == 'weekly':
-        return 'weekly'
-    return 'off'
+    cadence = (getattr(user, "digest_frequency", None) or "").lower()
+    if cadence == "daily":
+        return "daily"
+    if cadence == "weekly":
+        return "weekly"
+    return "off"
 
 
 def _format_names_list(names):
@@ -497,8 +539,8 @@ def _format_names_list(names):
     if len(names) == 1:
         return names[0]
     if len(names) == 2:
-        return f'{names[0]} and {names[1]}'
-    return ', '.join(names[:-1]) + f', and {names[-1]}'
+        return f"{names[0]} and {names[1]}"
+    return ", ".join(names[:-1]) + f", and {names[-1]}"
 
 
 def _group_circle_joins_for_digest(circle_joins):
@@ -506,26 +548,26 @@ def _group_circle_joins_for_digest(circle_joins):
     groups = {}
     order = []
     for event in circle_joins:
-        cid = event.get('circle_id')
+        cid = event.get("circle_id")
         if cid not in groups:
             groups[cid] = {
-                'event': event,
-                'circle_name': event['title'],
-                'image_url': event.get('image_url'),
-                'actors': [],
+                "event": event,
+                "circle_name": event["title"],
+                "image_url": event.get("image_url"),
+                "actors": [],
             }
             order.append(cid)
-        groups[cid]['actors'].append(event['actor_name'])
+        groups[cid]["actors"].append(event["actor_name"])
     return [groups[cid] for cid in order]
 
 
 def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url):
-    giveaways = digest_payload.get('giveaways', [])
-    requests = digest_payload.get('requests', [])
-    circle_joins = digest_payload.get('circle_joins', [])
-    loans = digest_payload.get('loans', [])
+    giveaways = digest_payload.get("giveaways", [])
+    requests = digest_payload.get("requests", [])
+    circle_joins = digest_payload.get("circle_joins", [])
+    loans = digest_payload.get("loans", [])
 
-    events = digest_payload.get('events')
+    events = digest_payload.get("events")
     if events is None:
         events = giveaways + requests + circle_joins + loans
 
@@ -539,7 +581,11 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         ("circle join", "circle joins", len(circle_joins)),
         ("loan", "loans", len(loans)),
     ]
-    summary_lines = [f"- {count} {singular if count == 1 else plural}" for singular, plural, count in summary_entries if count > 0]
+    summary_lines = [
+        f"- {count} {singular if count == 1 else plural}"
+        for singular, plural, count in summary_entries
+        if count > 0
+    ]
 
     text_lines = [
         f"Hello {user.first_name},",
@@ -558,65 +604,69 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
             return
         text_lines.append(f"{section_title}:")
         for event in events:
-            actor = event['actor_name']
-            is_resolution_only = event.get('digest_variant') == 'resolved-in-window'
+            actor = event["actor_name"]
+            is_resolution_only = event.get("digest_variant") == "resolved-in-window"
             if is_resolution_only:
                 text_lines.append(f"- {actor}: {_digest_resolution_only_text(event)}")
             else:
                 title = _digest_event_title(event)
-                action = event['action']
+                action = event["action"]
                 resolution_label = _digest_resolution_label(event)
                 line = f"- {actor} {action}: {title}"
                 if resolution_label:
                     line = f"{line} [{resolution_label}]"
                 text_lines.append(line)
-            if include_description and not is_resolution_only and event.get('description'):
+            if include_description and not is_resolution_only and event.get("description"):
                 text_lines.append(f"  {event['description']}")
-            if not is_resolution_only and event.get('image_url'):
+            if not is_resolution_only and event.get("image_url"):
                 text_lines.append(f"  Image: {event['image_url']}")
             text_lines.append(f"  {_digest_event_url(event)}")
         text_lines.append("")
 
-    append_text_section('Giveaways', giveaways, include_description=True)
-    append_text_section('Requests', requests, include_description=True)
+    append_text_section("Giveaways", giveaways, include_description=True)
+    append_text_section("Requests", requests, include_description=True)
 
     if circle_joins:
         grouped_joins = _group_circle_joins_for_digest(circle_joins)
-        text_lines.append('Circle Joins:')
+        text_lines.append("Circle Joins:")
         for group in grouped_joins:
-            count = len(group['actors'])
+            count = len(group["actors"])
             label = f"{count} {'person' if count == 1 else 'people'}"
-            names = _format_names_list(group['actors'])
+            names = _format_names_list(group["actors"])
             text_lines.append(f"- {label} joined {group['circle_name']}: {names}")
             text_lines.append(f"  {_digest_event_url(group['event'])}")
-        text_lines.append('')
+        text_lines.append("")
 
-    append_text_section('Loans', loans)
+    append_text_section("Loans", loans)
 
-    text_lines.extend([
-        "Manage your digest emails:",
-        f"- Manage settings: {manage_url}",
-        f"- One-click unsubscribe: {unsubscribe_url}",
-        "",
-        "Best regards,",
-        "The Meutch Team",
-    ])
+    text_lines.extend(
+        [
+            "Manage your digest emails:",
+            f"- Manage settings: {manage_url}",
+            f"- One-click unsubscribe: {unsubscribe_url}",
+            "",
+            "Best regards,",
+            "The Meutch Team",
+        ]
+    )
 
     def build_html_section(title, events, include_description=False):
         if not events:
-            return ''
+            return ""
 
         items_html = []
         for event in events:
-            actor = event['actor_name']
+            actor = event["actor_name"]
             link = _digest_event_url(event)
-            is_resolution_only = event.get('digest_variant') == 'resolved-in-window'
-            description_html = ''
-            if include_description and not is_resolution_only and event.get('description'):
-                description_html = f"<p style=\"margin: 6px 0 0 0; color: #555;\">{event['description']}</p>"
+            is_resolution_only = event.get("digest_variant") == "resolved-in-window"
+            description_html = ""
+            if include_description and not is_resolution_only and event.get("description"):
+                description_html = (
+                    f"<p style=\"margin: 6px 0 0 0; color: #555;\">{event['description']}</p>"
+                )
 
-            image_html = ''
-            if not is_resolution_only and event.get('image_url'):
+            image_html = ""
+            if not is_resolution_only and event.get("image_url"):
                 image_html = (
                     f"<div style=\"margin: 8px 0;\">"
                     f"<img src=\"{event['image_url']}\" alt=\"Activity image\" "
@@ -625,16 +675,18 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
                 )
 
             if is_resolution_only:
-                activity_html = f"<strong>{actor}</strong>: {_digest_resolution_only_text(event)}<br>"
+                activity_html = (
+                    f"<strong>{actor}</strong>: {_digest_resolution_only_text(event)}<br>"
+                )
             else:
                 item_title = _digest_event_title(event)
-                action = event['action']
+                action = event["action"]
                 resolution_label = _digest_resolution_label(event)
-                label_html = ''
+                label_html = ""
                 if resolution_label:
                     label_html = (
-                        f" <span style=\"display: inline-block; margin-left: 6px; padding: 1px 8px; "
-                        f"background-color: #198754; color: #fff; border-radius: 999px; font-size: 12px;\">"
+                        f' <span style="display: inline-block; margin-left: 6px; padding: 1px 8px; '
+                        f'background-color: #198754; color: #fff; border-radius: 999px; font-size: 12px;">'
                         f"{resolution_label}</span>"
                     )
                 activity_html = f"<strong>{actor}</strong> {action}: {item_title}{label_html}<br>"
@@ -659,16 +711,16 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
 
     def _build_circle_joins_html_section(circle_join_events):
         if not circle_join_events:
-            return ''
+            return ""
         grouped = _group_circle_joins_for_digest(circle_join_events)
         items_html = []
         for group in grouped:
-            count = len(group['actors'])
+            count = len(group["actors"])
             label = f"{count} {'person' if count == 1 else 'people'}"
-            names = _format_names_list(group['actors'])
-            link = _digest_event_url(group['event'])
-            image_html = ''
-            if group['image_url']:
+            names = _format_names_list(group["actors"])
+            link = _digest_event_url(group["event"])
+            image_html = ""
+            if group["image_url"]:
                 image_html = (
                     f"<div style=\"margin: 8px 0;\">"
                     f"<img src=\"{group['image_url']}\" alt=\"Circle image\" "
@@ -691,10 +743,10 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         </ul>
         """
 
-    summary_html = ''
+    summary_html = ""
     if summary_lines:
-        summary_items_html = ''.join(
-            [f"<li style=\"margin: 0 0 4px 16px;\">{line[2:]}</li>" for line in summary_lines]
+        summary_items_html = "".join(
+            [f'<li style="margin: 0 0 4px 16px;">{line[2:]}</li>' for line in summary_lines]
         )
         summary_html = f"""
         <div style=\"background-color: #f8f9fa; padding: 16px; border-radius: 8px; margin: 18px 0;\">
@@ -728,46 +780,48 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
     """
 
     return {
-        'subject': subject,
-        'text': '\n'.join(text_lines),
-        'html': html_content,
+        "subject": subject,
+        "text": "\n".join(text_lines),
+        "html": html_content,
     }
 
 
 def send_digest_email(user, digest_payload):
     """Send digest email only if there are events to report.
-    
+
     Returns False if payload has no events (should not send).
     """
-    events = digest_payload.get('events', [])
+    events = digest_payload.get("events", [])
     if not events:
-        current_app.logger.debug(f'Digest email skipped for user {user.id}: no events')
+        current_app.logger.debug(f"Digest email skipped for user {user.id}: no events")
         return False
-    
+
     token = generate_digest_manage_token(user)
-    manage_url = url_for('main.digest_manage', token=token, _external=True)
-    unsubscribe_url = url_for('main.digest_unsubscribe', token=token, _external=True)
+    manage_url = url_for("main.digest_manage", token=token, _external=True)
+    unsubscribe_url = url_for("main.digest_unsubscribe", token=token, _external=True)
     content = build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url)
-    return send_email(user.email, content['subject'], content['text'], content['html'])
+    return send_email(user.email, content["subject"], content["text"], content["html"])
 
 
 def send_loan_due_soon_email(loan):
     """Send 3-day reminder email to borrower that loan is due soon"""
-    from app.models import User  # Import here to avoid circular imports
     from app import db
-    
+    from app.models import User  # Import here to avoid circular imports
+
     borrower = db.session.get(User, loan.borrower_id)
     owner = db.session.get(User, loan.item.owner_id)
-    
+
     if not borrower or not owner:
-        current_app.logger.error(f"User not found for loan due soon email: borrower={loan.borrower_id}, owner={loan.item.owner_id}")
+        current_app.logger.error(
+            f"User not found for loan due soon email: borrower={loan.borrower_id}, owner={loan.item.owner_id}"
+        )
         return False
-    
+
     # Generate the item URL
-    item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
-    
+    item_url = url_for("main.item_detail", item_id=loan.item_id, _external=True)
+
     subject = f"Meutch - Reminder: {loan.item.name} is due in 3 days"
-    
+
     text_content = f"""
 Hello {borrower.first_name},
 
@@ -787,38 +841,38 @@ Thank you for being a responsible borrower!
 Best regards,
 The Meutch Team
     """.strip()
-    
+
     # Create HTML content
     html_content = f"""
     <html>
     <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h2 style="color: #333;">Loan Due Soon Reminder</h2>
-        
+
         <div style="background-color: #fff3cd; padding: 20px; border-radius: 8px; border-left: 4px solid #ffc107; margin: 20px 0;">
             <p style="margin: 0;"><strong>⏰ Your borrowed item is due back in 3 days</strong></p>
         </div>
-        
+
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Item:</strong> {loan.item.name}</p>
             <p><strong>Owner:</strong> {owner.first_name} {owner.last_name}</p>
             <p><strong>Due Date:</strong> {loan.end_date.strftime('%B %d, %Y')}</p>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             Please make arrangements to return the item by the due date. If you need more time, please contact the owner to discuss extending the loan.
         </p>
-        
+
         <div style="text-align: center; margin: 30px 0;">
-            <a href="{item_url}" 
+            <a href="{item_url}"
                style="background-color: #007bff; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details
             </a>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             Thank you for being a responsible borrower!
         </p>
-        
+
         <hr style="margin-top: 30px; border: none; border-top: 1px solid #ddd;">
         <p style="color: #999; font-size: 12px;">
             Best regards,<br>
@@ -827,27 +881,29 @@ The Meutch Team
     </body>
     </html>
     """
-    
+
     return send_email(borrower.email, subject, text_content, html_content)
 
 
 def send_loan_due_today_borrower_email(loan):
     """Send due date reminder email to borrower"""
-    from app.models import User  # Import here to avoid circular imports
     from app import db
-    
+    from app.models import User  # Import here to avoid circular imports
+
     borrower = db.session.get(User, loan.borrower_id)
     owner = db.session.get(User, loan.item.owner_id)
-    
+
     if not borrower or not owner:
-        current_app.logger.error(f"User not found for loan due today email: borrower={loan.borrower_id}, owner={loan.item.owner_id}")
+        current_app.logger.error(
+            f"User not found for loan due today email: borrower={loan.borrower_id}, owner={loan.item.owner_id}"
+        )
         return False
-    
+
     # Generate the item URL
-    item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
-    
+    item_url = url_for("main.item_detail", item_id=loan.item_id, _external=True)
+
     subject = f"Meutch - {loan.item.name} is due back today"
-    
+
     text_content = f"""
 Hello {borrower.first_name},
 
@@ -867,38 +923,38 @@ Thank you for your prompt attention!
 Best regards,
 The Meutch Team
     """.strip()
-    
+
     # Create HTML content
     html_content = f"""
     <html>
     <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h2 style="color: #333;">Item Due Today</h2>
-        
+
         <div style="background-color: #fff3cd; padding: 20px; border-radius: 8px; border-left: 4px solid #ffc107; margin: 20px 0;">
             <p style="margin: 0;"><strong>📅 Your borrowed item is due back today</strong></p>
         </div>
-        
+
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Item:</strong> {loan.item.name}</p>
             <p><strong>Owner:</strong> {owner.first_name} {owner.last_name}</p>
             <p><strong>Due Date:</strong> Today, {loan.end_date.strftime('%B %d, %Y')}</p>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             Please return the item to the owner as soon as possible. If you need more time or have already returned it, please contact the owner to coordinate.
         </p>
-        
+
         <div style="text-align: center; margin: 30px 0;">
-            <a href="{item_url}" 
+            <a href="{item_url}"
                style="background-color: #007bff; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details
             </a>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             Thank you for your prompt attention!
         </p>
-        
+
         <hr style="margin-top: 30px; border: none; border-top: 1px solid #ddd;">
         <p style="color: #999; font-size: 12px;">
             Best regards,<br>
@@ -907,29 +963,31 @@ The Meutch Team
     </body>
     </html>
     """
-    
+
     return send_email(borrower.email, subject, text_content, html_content)
 
 
 def send_loan_due_today_owner_email(loan):
     """Send due date notification email to owner"""
-    from app.models import User  # Import here to avoid circular imports
     from app import db
-    
+    from app.models import User  # Import here to avoid circular imports
+
     borrower = db.session.get(User, loan.borrower_id)
     owner = db.session.get(User, loan.item.owner_id)
-    
+
     if not borrower or not owner:
-        current_app.logger.error(f"User not found for loan due today owner email: borrower={loan.borrower_id}, owner={loan.item.owner_id}")
+        current_app.logger.error(
+            f"User not found for loan due today owner email: borrower={loan.borrower_id}, owner={loan.item.owner_id}"
+        )
         return False
-    
+
     # Generate the item URL
-    item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
+    item_url = url_for("main.item_detail", item_id=loan.item_id, _external=True)
     # Generate the extend loan URL for owners to extend the loan
-    extend_url = url_for('main.extend_loan', loan_id=loan.id, _external=True)
-    
+    extend_url = url_for("main.extend_loan", loan_id=loan.id, _external=True)
+
     subject = f"Meutch - Your item {loan.item.name} is due back today"
-    
+
     text_content = f"""
 Hello {owner.first_name},
 
@@ -950,42 +1008,42 @@ Thank you for sharing with your community!
 Best regards,
 The Meutch Team
     """.strip()
-    
+
     # Create HTML content
     html_content = f"""
     <html>
     <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h2 style="color: #333;">Item Due Back Today</h2>
-        
+
         <div style="background-color: #d1ecf1; padding: 20px; border-radius: 8px; border-left: 4px solid #17a2b8; margin: 20px 0;">
             <p style="margin: 0;"><strong>📅 Your loaned item is due back today</strong></p>
         </div>
-        
+
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Item:</strong> {loan.item.name}</p>
             <p><strong>Borrower:</strong> {borrower.first_name} {borrower.last_name}</p>
             <p><strong>Due Date:</strong> Today, {loan.end_date.strftime('%B %d, %Y')}</p>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             If you need to coordinate the return, please reach out to them. Or you can extend the loan to give them more time.
         </p>
 
         <div style="text-align: center; margin: 20px 0; display:flex; gap:12px; justify-content:center;">
-            <a href="{item_url}" 
+            <a href="{item_url}"
                style="background-color: #007bff; color: white; padding: 12px 20px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details
             </a>
-            <a href="{extend_url}" 
+            <a href="{extend_url}"
                style="background-color: #28a745; color: white; padding: 12px 20px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 Extend Loan
             </a>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             Thank you for sharing with your community!
         </p>
-        
+
         <hr style="margin-top: 30px; border: none; border-top: 1px solid #ddd;">
         <p style="color: #999; font-size: 12px;">
             Best regards,<br>
@@ -994,27 +1052,29 @@ The Meutch Team
     </body>
     </html>
     """
-    
+
     return send_email(owner.email, subject, text_content, html_content)
 
 
 def send_loan_overdue_borrower_email(loan, days_overdue):
     """Send overdue reminder email to borrower"""
-    from app.models import User  # Import here to avoid circular imports
     from app import db
-    
+    from app.models import User  # Import here to avoid circular imports
+
     borrower = db.session.get(User, loan.borrower_id)
     owner = db.session.get(User, loan.item.owner_id)
-    
+
     if not borrower or not owner:
-        current_app.logger.error(f"User not found for loan overdue email: borrower={loan.borrower_id}, owner={loan.item.owner_id}")
+        current_app.logger.error(
+            f"User not found for loan overdue email: borrower={loan.borrower_id}, owner={loan.item.owner_id}"
+        )
         return False
-    
+
     # Generate the item URL
-    item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
-    
+    item_url = url_for("main.item_detail", item_id=loan.item_id, _external=True)
+
     subject = f"Meutch - Reminder: {loan.item.name} is {days_overdue} day{'s' if days_overdue != 1 else ''} overdue"
-    
+
     text_content = f"""
 Hello {borrower.first_name},
 
@@ -1035,39 +1095,39 @@ Thank you for your prompt attention to this matter.
 Best regards,
 The Meutch Team
     """.strip()
-    
+
     # Create HTML content
     html_content = f"""
     <html>
     <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h2 style="color: #333;">Overdue Item Reminder</h2>
-        
+
         <div style="background-color: #f8d7da; padding: 20px; border-radius: 8px; border-left: 4px solid #dc3545; margin: 20px 0;">
             <p style="margin: 0;"><strong>⚠️ Your borrowed item is {days_overdue} day{'s' if days_overdue != 1 else ''} overdue</strong></p>
         </div>
-        
+
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Item:</strong> {loan.item.name}</p>
             <p><strong>Owner:</strong> {owner.first_name} {owner.last_name}</p>
             <p><strong>Due Date:</strong> {loan.end_date.strftime('%B %d, %Y')}</p>
             <p><strong>Days Overdue:</strong> <span style="color: #dc3545; font-weight: bold;">{days_overdue}</span></p>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             Please return the item to the owner as soon as possible. If you need more time, please contact the owner immediately to request an extension or discuss the situation.
         </p>
-        
+
         <div style="text-align: center; margin: 30px 0;">
-            <a href="{item_url}" 
+            <a href="{item_url}"
                style="background-color: #dc3545; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details
             </a>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             Thank you for your prompt attention to this matter.
         </p>
-        
+
         <hr style="margin-top: 30px; border: none; border-top: 1px solid #ddd;">
         <p style="color: #999; font-size: 12px;">
             Best regards,<br>
@@ -1076,29 +1136,31 @@ The Meutch Team
     </body>
     </html>
     """
-    
+
     return send_email(borrower.email, subject, text_content, html_content)
 
 
 def send_loan_overdue_owner_email(loan, days_overdue):
     """Send overdue notification email to owner"""
-    from app.models import User  # Import here to avoid circular imports
     from app import db
-    
+    from app.models import User  # Import here to avoid circular imports
+
     borrower = db.session.get(User, loan.borrower_id)
     owner = db.session.get(User, loan.item.owner_id)
-    
+
     if not borrower or not owner:
-        current_app.logger.error(f"User not found for loan overdue owner email: borrower={loan.borrower_id}, owner={loan.item.owner_id}")
+        current_app.logger.error(
+            f"User not found for loan overdue owner email: borrower={loan.borrower_id}, owner={loan.item.owner_id}"
+        )
         return False
-    
+
     # Generate the item URL
-    item_url = url_for('main.item_detail', item_id=loan.item_id, _external=True)
+    item_url = url_for("main.item_detail", item_id=loan.item_id, _external=True)
     # Generate the extend loan URL for owners to extend the loan
-    extend_url = url_for('main.extend_loan', loan_id=loan.id, _external=True)
-    
+    extend_url = url_for("main.extend_loan", loan_id=loan.id, _external=True)
+
     subject = f"Meutch - Your item {loan.item.name} is {days_overdue} day{'s' if days_overdue != 1 else ''} overdue"
-    
+
     text_content = f"""
 Hello {owner.first_name},
 
@@ -1120,43 +1182,43 @@ Thank you for your patience.
 Best regards,
 The Meutch Team
     """.strip()
-    
+
     # Create HTML content
     html_content = f"""
     <html>
     <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h2 style="color: #333;">Loaned Item Overdue</h2>
-        
+
         <div style="background-color: #f8d7da; padding: 20px; border-radius: 8px; border-left: 4px solid #dc3545; margin: 20px 0;">
             <p style="margin: 0;"><strong>⚠️ Your loaned item is {days_overdue} day{'s' if days_overdue != 1 else ''} overdue</strong></p>
         </div>
-        
+
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Item:</strong> {loan.item.name}</p>
             <p><strong>Borrower:</strong> {borrower.first_name} {borrower.last_name}</p>
             <p><strong>Due Date:</strong> {loan.end_date.strftime('%B %d, %Y')}</p>
             <p><strong>Days Overdue:</strong> <span style="color: #dc3545; font-weight: bold;">{days_overdue}</span></p>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             If you need to coordinate the return, please reach out to them. Or you can extend the loan to give them more time.
         </p>
-        
+
         <div style="text-align: center; margin: 20px 0; display:flex; gap:12px; justify-content:center;">
-            <a href="{item_url}" 
+            <a href="{item_url}"
                style="background-color: #007bff; color: white; padding: 12px 20px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 View Item Details
             </a>
-            <a href="{extend_url}" 
+            <a href="{extend_url}"
                style="background-color: #28a745; color: white; padding: 12px 20px; text-decoration: none; border-radius: 5px; display: inline-block;">
                 Extend Loan
             </a>
         </div>
-        
+
         <p style="color: #666; font-size: 14px;">
             Thank you for your patience.
         </p>
-        
+
         <hr style="margin-top: 30px; border: none; border-top: 1px solid #ddd;">
         <p style="color: #999; font-size: 12px;">
             Best regards,<br>
@@ -1165,5 +1227,5 @@ The Meutch Team
     </body>
     </html>
     """
-    
+
     return send_email(owner.email, subject, text_content, html_content)

--- a/app/utils/home_feed.py
+++ b/app/utils/home_feed.py
@@ -253,6 +253,281 @@ def build_visible_giveaway_events(
     return events
 
 
+def _classify_request_digest_variant(item_request, since=None, until=None):
+    created_in_window = _within_time_window(item_request.created_at, since=since, until=until)
+    fulfilled_in_window = (
+        item_request.status == 'fulfilled'
+        and item_request.fulfilled_at is not None
+        and _within_time_window(item_request.fulfilled_at, since=since, until=until)
+    )
+
+    if created_in_window and fulfilled_in_window:
+        return 'new-resolved-in-window'
+    if created_in_window:
+        return 'new'
+    if fulfilled_in_window:
+        return 'resolved-in-window'
+    return None
+
+
+def _classify_giveaway_digest_variant(item, since=None, until=None):
+    created_in_window = _within_time_window(item.created_at, since=since, until=until)
+    claimed_in_window = (
+        item.claim_status == 'claimed'
+        and item.claimed_at is not None
+        and _within_time_window(item.claimed_at, since=since, until=until)
+    )
+
+    if created_in_window and claimed_in_window:
+        return 'new-resolved-in-window'
+    if created_in_window:
+        return 'new'
+    if claimed_in_window:
+        return 'resolved-in-window'
+    return None
+
+
+def build_digest_request_events(
+    user,
+    scoped_circle_ids=None,
+    scope='all',
+    max_distance=None,
+    distance_explicit=False,
+    since=None,
+    until=None,
+):
+    now = datetime.now(UTC)
+    since_utc = _utc(since)
+    until_utc = _utc(until)
+    shared_circle_user_ids = _shared_circle_user_ids_query(scoped_circle_ids)
+    normalized_scope = _normalize_scope(scope)
+
+    base_query = ItemRequest.query.join(User, ItemRequest.user_id == User.id).filter(
+        ItemRequest.user_id != user.id,
+        User.is_deleted == False,
+        User.vacation_mode == False,
+        or_(
+            and_(
+                ItemRequest.status == 'open',
+                ItemRequest.expires_at > now,
+            ),
+            and_(
+                ItemRequest.status == 'fulfilled',
+                ItemRequest.fulfilled_at.isnot(None),
+            ),
+        ),
+    )
+
+    if since_utc is not None and until_utc is not None:
+        base_query = base_query.filter(
+            or_(
+                and_(
+                    ItemRequest.created_at >= since_utc,
+                    ItemRequest.created_at <= until_utc,
+                ),
+                and_(
+                    ItemRequest.fulfilled_at.isnot(None),
+                    ItemRequest.fulfilled_at >= since_utc,
+                    ItemRequest.fulfilled_at <= until_utc,
+                ),
+            )
+        )
+    elif since_utc is not None:
+        base_query = base_query.filter(
+            or_(
+                ItemRequest.created_at >= since_utc,
+                and_(
+                    ItemRequest.fulfilled_at.isnot(None),
+                    ItemRequest.fulfilled_at >= since_utc,
+                ),
+            )
+        )
+    elif until_utc is not None:
+        base_query = base_query.filter(
+            or_(
+                ItemRequest.created_at <= until_utc,
+                and_(
+                    ItemRequest.fulfilled_at.isnot(None),
+                    ItemRequest.fulfilled_at <= until_utc,
+                ),
+            )
+        )
+
+    if normalized_scope == 'circles':
+        if shared_circle_user_ids is None:
+            return []
+        base_query = base_query.filter(ItemRequest.user_id.in_(shared_circle_user_ids))
+    else:
+        if shared_circle_user_ids is None:
+            base_query = base_query.filter(ItemRequest.visibility == 'public')
+        else:
+            base_query = base_query.filter(
+                or_(
+                    ItemRequest.visibility == 'public',
+                    and_(
+                        ItemRequest.visibility == 'circles',
+                        ItemRequest.user_id.in_(shared_circle_user_ids),
+                    ),
+                )
+            )
+
+    visible_requests = base_query.order_by(ItemRequest.created_at.desc()).all()
+    effective_distance = _effective_giveaway_distance(max_distance, distance_explicit)
+    visible_requests = _distance_filter_requests(visible_requests, user, effective_distance)
+
+    events = []
+    for item_request in visible_requests:
+        digest_variant = _classify_request_digest_variant(item_request, since=since, until=until)
+        if digest_variant is None:
+            continue
+
+        started_at = _utc(item_request.created_at)
+        resolved_at = _utc(item_request.fulfilled_at) if item_request.fulfilled_at else None
+        event_time = resolved_at if digest_variant == 'resolved-in-window' else started_at
+        distance = None
+        if user.is_geocoded and item_request.user and item_request.user.is_geocoded:
+            raw = user.distance_to(item_request.user)
+            distance = format_distance(raw) if raw is not None else None
+        events.append({
+            'event_type': 'request',
+            'created_at': event_time,
+            'started_at': started_at,
+            'resolved_at': resolved_at,
+            'resolution_status': 'fulfilled' if resolved_at is not None else None,
+            'digest_variant': digest_variant,
+            'request_id': item_request.id,
+            'title': item_request.title,
+            'description': item_request.description,
+            'status': item_request.status,
+            'actor_name': item_request.user.full_name if item_request.user else 'Deleted User',
+            'actor_avatar_url': item_request.user.profile_image_url if item_request.user else None,
+            'image_url': None,
+            'action': 'requested',
+            'visibility': item_request.visibility,
+            'distance': distance,
+        })
+    return events
+
+
+def build_digest_giveaway_events(
+    user,
+    scoped_circle_ids=None,
+    scope='all',
+    max_distance=None,
+    distance_explicit=False,
+    since=None,
+    until=None,
+):
+    if not scoped_circle_ids:
+        return []
+
+    since_utc = _utc(since)
+    until_utc = _utc(until)
+    shared_circle_user_ids = _shared_circle_user_ids_query(scoped_circle_ids)
+    all_circle_user_ids = select(circle_members.c.user_id).distinct()
+    normalized_scope = _normalize_scope(scope)
+
+    if normalized_scope == 'circles':
+        visibility_filter = Item.owner_id.in_(shared_circle_user_ids)
+    else:
+        visibility_filter = or_(
+            and_(
+                or_(Item.giveaway_visibility == 'default', Item.giveaway_visibility.is_(None)),
+                Item.owner_id.in_(shared_circle_user_ids),
+            ),
+            and_(
+                Item.giveaway_visibility == 'public',
+                Item.owner_id.in_(all_circle_user_ids),
+            ),
+        )
+
+    base_query = Item.query.join(User, Item.owner_id == User.id).filter(
+        Item.is_giveaway == True,
+        User.vacation_mode == False,
+        visibility_filter,
+        Item.owner_id != user.id,
+        or_(
+            Item.claim_status.is_(None),
+            Item.claim_status == 'unclaimed',
+            and_(
+                Item.claim_status == 'claimed',
+                Item.claimed_at.isnot(None),
+            ),
+        ),
+    )
+
+    if since_utc is not None and until_utc is not None:
+        base_query = base_query.filter(
+            or_(
+                and_(
+                    Item.created_at >= since_utc,
+                    Item.created_at <= until_utc,
+                ),
+                and_(
+                    Item.claimed_at.isnot(None),
+                    Item.claimed_at >= since_utc,
+                    Item.claimed_at <= until_utc,
+                ),
+            )
+        )
+    elif since_utc is not None:
+        base_query = base_query.filter(
+            or_(
+                Item.created_at >= since_utc,
+                and_(
+                    Item.claimed_at.isnot(None),
+                    Item.claimed_at >= since_utc,
+                ),
+            )
+        )
+    elif until_utc is not None:
+        base_query = base_query.filter(
+            or_(
+                Item.created_at <= until_utc,
+                and_(
+                    Item.claimed_at.isnot(None),
+                    Item.claimed_at <= until_utc,
+                ),
+            )
+        )
+
+    giveaway_items = base_query.order_by(Item.created_at.desc()).all()
+    effective_distance = _effective_giveaway_distance(max_distance, distance_explicit)
+    giveaway_items = _distance_filter_items(giveaway_items, user, effective_distance)
+
+    events = []
+    for item in giveaway_items:
+        digest_variant = _classify_giveaway_digest_variant(item, since=since, until=until)
+        if digest_variant is None:
+            continue
+
+        started_at = _utc(item.created_at)
+        resolved_at = _utc(item.claimed_at) if item.claimed_at else None
+        event_time = resolved_at if digest_variant == 'resolved-in-window' else started_at
+        distance = None
+        if user.is_geocoded and item.owner and item.owner.is_geocoded:
+            raw = user.distance_to(item.owner)
+            distance = format_distance(raw) if raw is not None else None
+        events.append({
+            'event_type': 'giveaway',
+            'created_at': event_time,
+            'started_at': started_at,
+            'resolved_at': resolved_at,
+            'resolution_status': 'claimed' if resolved_at is not None else None,
+            'digest_variant': digest_variant,
+            'item_id': item.id,
+            'title': item.name,
+            'description': item.description,
+            'claim_status': item.claim_status,
+            'actor_name': item.owner.full_name if item.owner else 'Deleted User',
+            'actor_avatar_url': item.owner.profile_image_url if item.owner else None,
+            'image_url': item.image,
+            'action': 'posted a giveaway',
+            'distance': distance,
+        })
+    return events
+
+
 def build_recent_lent_events(user, scoped_circle_ids=None, days=30, since=None, until=None):
     if not scoped_circle_ids:
         return []
@@ -490,23 +765,62 @@ def build_digest_payload(user, since=None, until=None, max_events=200):
         window_start = window_end - timedelta(days=7)
 
     included_event_types = _digest_included_event_types(user)
-    events = _assemble_feed_events(
-        user,
-        selected_circle_ids=None,
-        request_scope='all' if user.digest_requests_include_public else 'circles',
-        giveaway_scope='all' if user.digest_giveaways_include_public else 'circles',
-        giveaway_distance=user.digest_radius_miles,
-        giveaway_distance_explicit=True,
-        included_event_types=included_event_types,
-        since=window_start,
-        until=window_end,
-        max_events=max_events,
-    )
+    scoped_circle_ids = _get_scoped_circle_ids(user)
+    events = []
+
+    if 'requests' in included_event_types:
+        events.extend(
+            build_digest_request_events(
+                user,
+                scoped_circle_ids=scoped_circle_ids,
+                scope='all' if user.digest_requests_include_public else 'circles',
+                max_distance=user.digest_radius_miles,
+                distance_explicit=True,
+                since=window_start,
+                until=window_end,
+            )
+        )
+    if 'giveaways' in included_event_types:
+        events.extend(
+            build_digest_giveaway_events(
+                user,
+                scoped_circle_ids=scoped_circle_ids,
+                scope='all' if user.digest_giveaways_include_public else 'circles',
+                max_distance=user.digest_radius_miles,
+                distance_explicit=True,
+                since=window_start,
+                until=window_end,
+            )
+        )
+    if 'loans' in included_event_types:
+        events.extend(
+            build_recent_lent_events(
+                user,
+                scoped_circle_ids=scoped_circle_ids,
+                since=window_start,
+                until=window_end,
+            )
+        )
+    if 'circle_joins' in included_event_types:
+        events.extend(
+            build_circle_join_events(
+                user,
+                scoped_circle_ids=scoped_circle_ids,
+                since=window_start,
+                until=window_end,
+            )
+        )
+
+    events.sort(key=lambda event: event['created_at'], reverse=True)
+    events = events[:max_events]
 
     giveaways = [event for event in events if event.get('event_type') == 'giveaway']
     requests = [event for event in events if event.get('event_type') == 'request']
     circle_joins = [event for event in events if event.get('event_type') == 'circle_join']
     loans = [event for event in events if event.get('event_type') == 'lent']
+
+    giveaways_count = sum(1 for event in giveaways if event.get('digest_variant') != 'resolved-in-window')
+    requests_count = sum(1 for event in requests if event.get('digest_variant') != 'resolved-in-window')
 
     return {
         'window_start': window_start,
@@ -517,8 +831,8 @@ def build_digest_payload(user, since=None, until=None, max_events=200):
         'circle_joins': circle_joins,
         'loans': loans,
         'summary_stats': {
-            'total_new_items': len(giveaways) + len(requests),
-            'giveaways_count': len(giveaways),
-            'borrow_requests_count': len(requests),
+            'total_new_items': giveaways_count + requests_count,
+            'giveaways_count': giveaways_count,
+            'borrow_requests_count': requests_count,
         },
     }

--- a/app/utils/home_feed.py
+++ b/app/utils/home_feed.py
@@ -1,13 +1,22 @@
-from datetime import datetime, UTC, timedelta
-from sqlalchemy import and_, func, or_, select
-from app import db
-from app.models import Circle, CircleJoinRequest, Item, ItemRequest, LoanRequest, User, circle_members
-from app.utils.geocoding import format_distance
+from datetime import UTC, datetime, timedelta
 
+from sqlalchemy import and_, or_, select
+
+from app import db
+from app.models import (
+    Circle,
+    CircleJoinRequest,
+    Item,
+    ItemRequest,
+    LoanRequest,
+    User,
+    circle_members,
+)
+from app.utils.geocoding import format_distance
 
 DEFAULT_GIVEAWAY_DISTANCE_MILES = 20
 RESOLVED_FEED_WINDOW_DAYS = 7
-HOMEPAGE_FEED_EVENT_TYPES = {'requests', 'giveaways', 'loans', 'circle_joins'}
+HOMEPAGE_FEED_EVENT_TYPES = {"requests", "giveaways", "loans", "circle_joins"}
 
 
 def _utc(value):
@@ -29,9 +38,11 @@ def _get_scoped_circle_ids(user, selected_circle_ids=None):
 def _shared_circle_user_ids_query(scoped_circle_ids):
     if not scoped_circle_ids:
         return None
-    return select(circle_members.c.user_id).where(
-        circle_members.c.circle_id.in_(scoped_circle_ids)
-    ).distinct()
+    return (
+        select(circle_members.c.user_id)
+        .where(circle_members.c.circle_id.in_(scoped_circle_ids))
+        .distinct()
+    )
 
 
 def _effective_giveaway_distance(max_distance, distance_explicit):
@@ -43,7 +54,7 @@ def _effective_giveaway_distance(max_distance, distance_explicit):
 
 
 def _normalize_scope(scope):
-    return 'circles' if scope == 'circles' else 'all'
+    return "circles" if scope == "circles" else "all"
 
 
 def _normalize_event_types(included_event_types):
@@ -104,7 +115,7 @@ def _distance_filter_requests(item_requests, user, max_distance):
 def build_visible_requests_events(
     user,
     scoped_circle_ids=None,
-    scope='all',
+    scope="all",
     max_distance=None,
     distance_explicit=False,
     since=None,
@@ -118,15 +129,15 @@ def build_visible_requests_events(
 
     base_query = ItemRequest.query.join(User, ItemRequest.user_id == User.id).filter(
         ItemRequest.user_id != user.id,
-        User.is_deleted == False,
-        User.vacation_mode == False,
+        User.is_deleted.is_(False),
+        User.vacation_mode.is_(False),
         or_(
             and_(
-                ItemRequest.status == 'open',
+                ItemRequest.status == "open",
                 ItemRequest.expires_at > now,
             ),
             and_(
-                ItemRequest.status == 'fulfilled',
+                ItemRequest.status == "fulfilled",
                 ItemRequest.fulfilled_at > fulfilled_cutoff,
             ),
         ),
@@ -135,19 +146,19 @@ def build_visible_requests_events(
     if until_utc is not None:
         base_query = base_query.filter(ItemRequest.created_at <= until_utc)
 
-    if normalized_scope == 'circles':
+    if normalized_scope == "circles":
         if shared_circle_user_ids is None:
             return []
         base_query = base_query.filter(ItemRequest.user_id.in_(shared_circle_user_ids))
     else:
         if shared_circle_user_ids is None:
-            base_query = base_query.filter(ItemRequest.visibility == 'public')
+            base_query = base_query.filter(ItemRequest.visibility == "public")
         else:
             base_query = base_query.filter(
                 or_(
-                    ItemRequest.visibility == 'public',
+                    ItemRequest.visibility == "public",
                     and_(
-                        ItemRequest.visibility == 'circles',
+                        ItemRequest.visibility == "circles",
                         ItemRequest.user_id.in_(shared_circle_user_ids),
                     ),
                 )
@@ -159,35 +170,43 @@ def build_visible_requests_events(
 
     events = []
     for item_request in visible_requests:
-        event_time = _utc(item_request.fulfilled_at) if item_request.status == 'fulfilled' else _utc(item_request.created_at)
+        event_time = (
+            _utc(item_request.fulfilled_at)
+            if item_request.status == "fulfilled"
+            else _utc(item_request.created_at)
+        )
         if not _within_time_window(event_time, since=since, until=until):
             continue
-        action = 'marked a request fulfilled' if item_request.status == 'fulfilled' else 'requested'
+        action = "marked a request fulfilled" if item_request.status == "fulfilled" else "requested"
         distance = None
         if user.is_geocoded and item_request.user and item_request.user.is_geocoded:
             raw = user.distance_to(item_request.user)
             distance = format_distance(raw) if raw is not None else None
-        events.append({
-            'event_type': 'request',
-            'created_at': event_time,
-            'request_id': item_request.id,
-            'title': item_request.title,
-            'description': item_request.description,
-            'status': item_request.status,
-            'actor_name': item_request.user.full_name if item_request.user else 'Deleted User',
-            'actor_avatar_url': item_request.user.profile_image_url if item_request.user else None,
-            'image_url': None,
-            'action': action,
-            'visibility': item_request.visibility,
-            'distance': distance,
-        })
+        events.append(
+            {
+                "event_type": "request",
+                "created_at": event_time,
+                "request_id": item_request.id,
+                "title": item_request.title,
+                "description": item_request.description,
+                "status": item_request.status,
+                "actor_name": item_request.user.full_name if item_request.user else "Deleted User",
+                "actor_avatar_url": item_request.user.profile_image_url
+                if item_request.user
+                else None,
+                "image_url": None,
+                "action": action,
+                "visibility": item_request.visibility,
+                "distance": distance,
+            }
+        )
     return events
 
 
 def build_visible_giveaway_events(
     user,
     scoped_circle_ids=None,
-    scope='all',
+    scope="all",
     max_distance=None,
     distance_explicit=False,
     since=None,
@@ -202,29 +221,29 @@ def build_visible_giveaway_events(
     all_circle_user_ids = select(circle_members.c.user_id).distinct()
     normalized_scope = _normalize_scope(scope)
 
-    if normalized_scope == 'circles':
+    if normalized_scope == "circles":
         visibility_filter = Item.owner_id.in_(shared_circle_user_ids)
     else:
         visibility_filter = or_(
             and_(
-                or_(Item.giveaway_visibility == 'default', Item.giveaway_visibility.is_(None)),
+                or_(Item.giveaway_visibility == "default", Item.giveaway_visibility.is_(None)),
                 Item.owner_id.in_(shared_circle_user_ids),
             ),
             and_(
-                Item.giveaway_visibility == 'public',
+                Item.giveaway_visibility == "public",
                 Item.owner_id.in_(all_circle_user_ids),
             ),
         )
 
     base_query = Item.query.join(User, Item.owner_id == User.id).filter(
-        Item.is_giveaway == True,
-        User.vacation_mode == False,
+        Item.is_giveaway.is_(True),
+        User.vacation_mode.is_(False),
         and_(
             or_(
-                Item.claim_status == 'unclaimed',
+                Item.claim_status == "unclaimed",
                 Item.claim_status.is_(None),
                 and_(
-                    Item.claim_status == 'claimed',
+                    Item.claim_status == "claimed",
                     Item.claimed_at.isnot(None),
                     Item.claimed_at > claimed_cutoff,
                 ),
@@ -240,7 +259,7 @@ def build_visible_giveaway_events(
             or_(
                 Item.created_at <= until_utc,
                 and_(
-                    Item.claim_status == 'claimed',
+                    Item.claim_status == "claimed",
                     Item.claimed_at.isnot(None),
                     Item.claimed_at <= until_utc,
                 ),
@@ -253,68 +272,72 @@ def build_visible_giveaway_events(
 
     events = []
     for item in giveaway_items:
-        event_time = _utc(item.claimed_at) if item.claim_status == 'claimed' else _utc(item.created_at)
+        event_time = (
+            _utc(item.claimed_at) if item.claim_status == "claimed" else _utc(item.created_at)
+        )
         if not _within_time_window(event_time, since=since, until=until):
             continue
-        action = 'gave away' if item.claim_status == 'claimed' else 'posted a giveaway'
+        action = "gave away" if item.claim_status == "claimed" else "posted a giveaway"
         distance = None
         if user.is_geocoded and item.owner and item.owner.is_geocoded:
             raw = user.distance_to(item.owner)
             distance = format_distance(raw) if raw is not None else None
-        events.append({
-            'event_type': 'giveaway',
-            'created_at': event_time,
-            'item_id': item.id,
-            'title': item.name,
-            'description': item.description,
-            'claim_status': item.claim_status,
-            'actor_name': item.owner.full_name if item.owner else 'Deleted User',
-            'actor_avatar_url': item.owner.profile_image_url if item.owner else None,
-            'image_url': item.image,
-            'action': action,
-            'distance': distance,
-        })
+        events.append(
+            {
+                "event_type": "giveaway",
+                "created_at": event_time,
+                "item_id": item.id,
+                "title": item.name,
+                "description": item.description,
+                "claim_status": item.claim_status,
+                "actor_name": item.owner.full_name if item.owner else "Deleted User",
+                "actor_avatar_url": item.owner.profile_image_url if item.owner else None,
+                "image_url": item.image,
+                "action": action,
+                "distance": distance,
+            }
+        )
     return events
 
 
 def _classify_request_digest_variant(item_request, since=None, until=None):
     created_in_window = _within_time_window(item_request.created_at, since=since, until=until)
     fulfilled_in_window = (
-        item_request.status == 'fulfilled'
+        item_request.status == "fulfilled"
         and item_request.fulfilled_at is not None
         and _within_time_window(item_request.fulfilled_at, since=since, until=until)
     )
 
     if created_in_window and fulfilled_in_window:
-        return 'new-resolved-in-window'
+        return "new-resolved-in-window"
     if created_in_window:
-        return 'new'
+        return "new"
     if fulfilled_in_window:
-        return 'resolved-in-window'
+        return "resolved-in-window"
     return None
 
 
 def _classify_giveaway_digest_variant(item, since=None, until=None):
     created_in_window = _within_time_window(item.created_at, since=since, until=until)
     claimed_in_window = (
-        item.claim_status == 'claimed'
+        item.claim_status == "claimed"
         and item.claimed_at is not None
         and _within_time_window(item.claimed_at, since=since, until=until)
     )
 
     if created_in_window and claimed_in_window:
-        return 'new-resolved-in-window'
+        return "new-resolved-in-window"
     if created_in_window:
-        return 'new'
+        return "new"
     if claimed_in_window:
-        return 'resolved-in-window'
+        return "resolved-in-window"
     return None
 
 
 def build_digest_request_events(
     user,
     scoped_circle_ids=None,
-    scope='all',
+    scope="all",
     max_distance=None,
     distance_explicit=False,
     since=None,
@@ -328,15 +351,15 @@ def build_digest_request_events(
 
     base_query = ItemRequest.query.join(User, ItemRequest.user_id == User.id).filter(
         ItemRequest.user_id != user.id,
-        User.is_deleted == False,
-        User.vacation_mode == False,
+        User.is_deleted.is_(False),
+        User.vacation_mode.is_(False),
         or_(
             and_(
-                ItemRequest.status == 'open',
+                ItemRequest.status == "open",
                 ItemRequest.expires_at > now,
             ),
             and_(
-                ItemRequest.status == 'fulfilled',
+                ItemRequest.status == "fulfilled",
                 ItemRequest.fulfilled_at.isnot(None),
             ),
         ),
@@ -377,19 +400,19 @@ def build_digest_request_events(
             )
         )
 
-    if normalized_scope == 'circles':
+    if normalized_scope == "circles":
         if shared_circle_user_ids is None:
             return []
         base_query = base_query.filter(ItemRequest.user_id.in_(shared_circle_user_ids))
     else:
         if shared_circle_user_ids is None:
-            base_query = base_query.filter(ItemRequest.visibility == 'public')
+            base_query = base_query.filter(ItemRequest.visibility == "public")
         else:
             base_query = base_query.filter(
                 or_(
-                    ItemRequest.visibility == 'public',
+                    ItemRequest.visibility == "public",
                     and_(
-                        ItemRequest.visibility == 'circles',
+                        ItemRequest.visibility == "circles",
                         ItemRequest.user_id.in_(shared_circle_user_ids),
                     ),
                 )
@@ -407,36 +430,40 @@ def build_digest_request_events(
 
         started_at = _utc(item_request.created_at)
         resolved_at = _utc(item_request.fulfilled_at) if item_request.fulfilled_at else None
-        event_time = resolved_at if digest_variant == 'resolved-in-window' else started_at
+        event_time = resolved_at if digest_variant == "resolved-in-window" else started_at
         distance = None
         if user.is_geocoded and item_request.user and item_request.user.is_geocoded:
             raw = user.distance_to(item_request.user)
             distance = format_distance(raw) if raw is not None else None
-        events.append({
-            'event_type': 'request',
-            'created_at': event_time,
-            'started_at': started_at,
-            'resolved_at': resolved_at,
-            'resolution_status': 'fulfilled' if resolved_at is not None else None,
-            'digest_variant': digest_variant,
-            'request_id': item_request.id,
-            'title': item_request.title,
-            'description': item_request.description,
-            'status': item_request.status,
-            'actor_name': item_request.user.full_name if item_request.user else 'Deleted User',
-            'actor_avatar_url': item_request.user.profile_image_url if item_request.user else None,
-            'image_url': None,
-            'action': 'requested',
-            'visibility': item_request.visibility,
-            'distance': distance,
-        })
+        events.append(
+            {
+                "event_type": "request",
+                "created_at": event_time,
+                "started_at": started_at,
+                "resolved_at": resolved_at,
+                "resolution_status": "fulfilled" if resolved_at is not None else None,
+                "digest_variant": digest_variant,
+                "request_id": item_request.id,
+                "title": item_request.title,
+                "description": item_request.description,
+                "status": item_request.status,
+                "actor_name": item_request.user.full_name if item_request.user else "Deleted User",
+                "actor_avatar_url": item_request.user.profile_image_url
+                if item_request.user
+                else None,
+                "image_url": None,
+                "action": "requested",
+                "visibility": item_request.visibility,
+                "distance": distance,
+            }
+        )
     return events
 
 
 def build_digest_giveaway_events(
     user,
     scoped_circle_ids=None,
-    scope='all',
+    scope="all",
     max_distance=None,
     distance_explicit=False,
     since=None,
@@ -451,30 +478,30 @@ def build_digest_giveaway_events(
     all_circle_user_ids = select(circle_members.c.user_id).distinct()
     normalized_scope = _normalize_scope(scope)
 
-    if normalized_scope == 'circles':
+    if normalized_scope == "circles":
         visibility_filter = Item.owner_id.in_(shared_circle_user_ids)
     else:
         visibility_filter = or_(
             and_(
-                or_(Item.giveaway_visibility == 'default', Item.giveaway_visibility.is_(None)),
+                or_(Item.giveaway_visibility == "default", Item.giveaway_visibility.is_(None)),
                 Item.owner_id.in_(shared_circle_user_ids),
             ),
             and_(
-                Item.giveaway_visibility == 'public',
+                Item.giveaway_visibility == "public",
                 Item.owner_id.in_(all_circle_user_ids),
             ),
         )
 
     base_query = Item.query.join(User, Item.owner_id == User.id).filter(
-        Item.is_giveaway == True,
-        User.vacation_mode == False,
+        Item.is_giveaway.is_(True),
+        User.vacation_mode.is_(False),
         visibility_filter,
         Item.owner_id != user.id,
         or_(
             Item.claim_status.is_(None),
-            Item.claim_status == 'unclaimed',
+            Item.claim_status == "unclaimed",
             and_(
-                Item.claim_status == 'claimed',
+                Item.claim_status == "claimed",
                 Item.claimed_at.isnot(None),
             ),
         ),
@@ -527,28 +554,30 @@ def build_digest_giveaway_events(
 
         started_at = _utc(item.created_at)
         resolved_at = _utc(item.claimed_at) if item.claimed_at else None
-        event_time = resolved_at if digest_variant == 'resolved-in-window' else started_at
+        event_time = resolved_at if digest_variant == "resolved-in-window" else started_at
         distance = None
         if user.is_geocoded and item.owner and item.owner.is_geocoded:
             raw = user.distance_to(item.owner)
             distance = format_distance(raw) if raw is not None else None
-        events.append({
-            'event_type': 'giveaway',
-            'created_at': event_time,
-            'started_at': started_at,
-            'resolved_at': resolved_at,
-            'resolution_status': 'claimed' if resolved_at is not None else None,
-            'digest_variant': digest_variant,
-            'item_id': item.id,
-            'title': item.name,
-            'description': item.description,
-            'claim_status': item.claim_status,
-            'actor_name': item.owner.full_name if item.owner else 'Deleted User',
-            'actor_avatar_url': item.owner.profile_image_url if item.owner else None,
-            'image_url': item.image,
-            'action': 'posted a giveaway',
-            'distance': distance,
-        })
+        events.append(
+            {
+                "event_type": "giveaway",
+                "created_at": event_time,
+                "started_at": started_at,
+                "resolved_at": resolved_at,
+                "resolution_status": "claimed" if resolved_at is not None else None,
+                "digest_variant": digest_variant,
+                "item_id": item.id,
+                "title": item.name,
+                "description": item.description,
+                "claim_status": item.claim_status,
+                "actor_name": item.owner.full_name if item.owner else "Deleted User",
+                "actor_avatar_url": item.owner.profile_image_url if item.owner else None,
+                "image_url": item.image,
+                "action": "posted a giveaway",
+                "distance": distance,
+            }
+        )
     return events
 
 
@@ -560,13 +589,17 @@ def build_recent_lent_events(user, scoped_circle_ids=None, days=30, since=None, 
     until_utc = _utc(until)
     shared_circle_user_ids = _shared_circle_user_ids_query(scoped_circle_ids)
 
-    base_query = LoanRequest.query.join(Item, LoanRequest.item_id == Item.id).join(User, Item.owner_id == User.id).filter(
-        LoanRequest.status == 'approved',
-        LoanRequest.borrower_id.isnot(None),
-        LoanRequest.created_at >= recent_cutoff,
-        Item.owner_id != user.id,
-        User.vacation_mode == False,
-        Item.owner_id.in_(shared_circle_user_ids),
+    base_query = (
+        LoanRequest.query.join(Item, LoanRequest.item_id == Item.id)
+        .join(User, Item.owner_id == User.id)
+        .filter(
+            LoanRequest.status == "approved",
+            LoanRequest.borrower_id.isnot(None),
+            LoanRequest.created_at >= recent_cutoff,
+            Item.owner_id != user.id,
+            User.vacation_mode.is_(False),
+            Item.owner_id.in_(shared_circle_user_ids),
+        )
     )
 
     if until_utc is not None:
@@ -581,33 +614,37 @@ def build_recent_lent_events(user, scoped_circle_ids=None, days=30, since=None, 
             continue
         if not _within_time_window(loan.created_at, since=since, until=until):
             continue
-        owner_name = item.owner.full_name if item.owner else 'Deleted User'
-        events.append({
-            'event_type': 'lent',
-            'created_at': _utc(loan.created_at),
-            'loan_request_id': loan.id,
-            'item_id': item.id,
-            'title': item.name,
-            'description': item.description,
-            'actor_name': owner_name,
-            'actor_avatar_url': item.owner.profile_image_url if item.owner else None,
-            'image_url': item.image,
-            'action': 'lent out',
-        })
+        owner_name = item.owner.full_name if item.owner else "Deleted User"
+        events.append(
+            {
+                "event_type": "lent",
+                "created_at": _utc(loan.created_at),
+                "loan_request_id": loan.id,
+                "item_id": item.id,
+                "title": item.name,
+                "description": item.description,
+                "actor_name": owner_name,
+                "actor_avatar_url": item.owner.profile_image_url if item.owner else None,
+                "image_url": item.image,
+                "action": "lent out",
+            }
+        )
     return events
 
 
 def consolidate_circle_join_activity(join_rows, circle_sizes):
     grouped = {}
     for row in join_rows:
-        grouped.setdefault(row['user_id'], []).append(row)
+        grouped.setdefault(row["user_id"], []).append(row)
 
     events = []
     for user_rows in grouped.values():
-        user_rows.sort(key=lambda entry: (
-            circle_sizes.get(entry['circle_id'], float('inf')),
-            (entry['circle_name'] or '').lower(),
-        ))
+        user_rows.sort(
+            key=lambda entry: (
+                circle_sizes.get(entry["circle_id"], float("inf")),
+                (entry["circle_name"] or "").lower(),
+            )
+        )
         primary_circle = user_rows[0]
         extra_count = len(user_rows) - 1
 
@@ -616,21 +653,23 @@ def consolidate_circle_join_activity(join_rows, circle_sizes):
             title = f"{primary_circle['circle_name']} + {extra_count} more of your circles"
         else:
             action = "joined"
-            title = primary_circle['circle_name']
+            title = primary_circle["circle_name"]
 
-        events.append({
-            'event_type': 'circle_join',
-            'created_at': primary_circle['created_at'],
-            'user_id': primary_circle['user_id'],
-            'actor_name': primary_circle['user_name'],
-            'actor_avatar_url': primary_circle.get('user_avatar_url'),
-            'image_url': primary_circle.get('circle_image_url'),
-            'circle_id': primary_circle['circle_id'],
-            'title': title,
-            'description': None,
-            'extra_circle_count': extra_count,
-            'action': action,
-        })
+        events.append(
+            {
+                "event_type": "circle_join",
+                "created_at": primary_circle["created_at"],
+                "user_id": primary_circle["user_id"],
+                "actor_name": primary_circle["user_name"],
+                "actor_avatar_url": primary_circle.get("user_avatar_url"),
+                "image_url": primary_circle.get("circle_image_url"),
+                "circle_id": primary_circle["circle_id"],
+                "title": title,
+                "description": None,
+                "extra_circle_count": extra_count,
+                "action": action,
+            }
+        )
 
     return events
 
@@ -641,14 +680,17 @@ def build_circle_join_events(user, scoped_circle_ids=None, days=30, since=None, 
 
     recent_cutoff = _utc(since) or (datetime.now(UTC) - timedelta(days=days))
     until_utc = _utc(until)
-    base_query = db.session.query(CircleJoinRequest).join(User, CircleJoinRequest.user_id == User.id).join(
-        Circle, CircleJoinRequest.circle_id == Circle.id
-    ).filter(
-        CircleJoinRequest.status == 'approved',
-        CircleJoinRequest.created_at >= recent_cutoff,
-        CircleJoinRequest.user_id != user.id,
-        CircleJoinRequest.circle_id.in_(scoped_circle_ids),
-        User.is_deleted == False,
+    base_query = (
+        db.session.query(CircleJoinRequest)
+        .join(User, CircleJoinRequest.user_id == User.id)
+        .join(Circle, CircleJoinRequest.circle_id == Circle.id)
+        .filter(
+            CircleJoinRequest.status == "approved",
+            CircleJoinRequest.created_at >= recent_cutoff,
+            CircleJoinRequest.user_id != user.id,
+            CircleJoinRequest.circle_id.in_(scoped_circle_ids),
+            User.is_deleted.is_(False),
+        )
     )
 
     if until_utc is not None:
@@ -659,27 +701,38 @@ def build_circle_join_events(user, scoped_circle_ids=None, days=30, since=None, 
     if not join_requests:
         return []
 
-    circle_sizes_query = db.session.query(
-        circle_members.c.circle_id,
-        func.count(circle_members.c.user_id),
-    ).filter(
-        circle_members.c.circle_id.in_(scoped_circle_ids),
-    ).group_by(circle_members.c.circle_id).all()
+    circle_sizes_query = (
+        db.session.query(
+            circle_members.c.circle_id,
+            db.func.count(circle_members.c.user_id),
+        )
+        .filter(
+            circle_members.c.circle_id.in_(scoped_circle_ids),
+        )
+        .group_by(circle_members.c.circle_id)
+        .all()
+    )
     circle_sizes = {circle_id: size for circle_id, size in circle_sizes_query}
 
     join_rows = []
     for join_request in join_requests:
         if not _within_time_window(join_request.created_at, since=since, until=until):
             continue
-        join_rows.append({
-            'user_id': join_request.user_id,
-            'user_name': join_request.user.full_name if join_request.user else 'Deleted User',
-            'user_avatar_url': join_request.user.profile_image_url if join_request.user else None,
-            'circle_id': join_request.circle_id,
-            'circle_name': join_request.circle.name if join_request.circle else 'Unknown Circle',
-            'circle_image_url': join_request.circle.image_url if join_request.circle else None,
-            'created_at': _utc(join_request.created_at),
-        })
+        join_rows.append(
+            {
+                "user_id": join_request.user_id,
+                "user_name": join_request.user.full_name if join_request.user else "Deleted User",
+                "user_avatar_url": join_request.user.profile_image_url
+                if join_request.user
+                else None,
+                "circle_id": join_request.circle_id,
+                "circle_name": join_request.circle.name
+                if join_request.circle
+                else "Unknown Circle",
+                "circle_image_url": join_request.circle.image_url if join_request.circle else None,
+                "created_at": _utc(join_request.created_at),
+            }
+        )
 
     return consolidate_circle_join_activity(join_rows, circle_sizes)
 
@@ -687,8 +740,8 @@ def build_circle_join_events(user, scoped_circle_ids=None, days=30, since=None, 
 def _assemble_feed_events(
     user,
     selected_circle_ids=None,
-    request_scope='all',
-    giveaway_scope='all',
+    request_scope="all",
+    giveaway_scope="all",
     giveaway_distance=None,
     giveaway_distance_explicit=False,
     included_event_types=None,
@@ -700,7 +753,7 @@ def _assemble_feed_events(
     normalized_event_types = _normalize_event_types(included_event_types)
 
     events = []
-    if 'requests' in normalized_event_types:
+    if "requests" in normalized_event_types:
         events.extend(
             build_visible_requests_events(
                 user,
@@ -712,7 +765,7 @@ def _assemble_feed_events(
                 until=until,
             )
         )
-    if 'giveaways' in normalized_event_types:
+    if "giveaways" in normalized_event_types:
         events.extend(
             build_visible_giveaway_events(
                 user,
@@ -724,7 +777,7 @@ def _assemble_feed_events(
                 until=until,
             )
         )
-    if 'loans' in normalized_event_types:
+    if "loans" in normalized_event_types:
         events.extend(
             build_recent_lent_events(
                 user,
@@ -733,7 +786,7 @@ def _assemble_feed_events(
                 until=until,
             )
         )
-    if 'circle_joins' in normalized_event_types:
+    if "circle_joins" in normalized_event_types:
         events.extend(
             build_circle_join_events(
                 user,
@@ -743,14 +796,16 @@ def _assemble_feed_events(
             )
         )
 
-    events.sort(key=lambda event: event.get('created_at') or datetime.min.replace(tzinfo=UTC), reverse=True)
+    events.sort(
+        key=lambda event: event.get("created_at") or datetime.min.replace(tzinfo=UTC), reverse=True
+    )
     return events[:max_events]
 
 
 def build_homepage_feed_events(
     user,
     selected_circle_ids=None,
-    scope='all',
+    scope="all",
     giveaway_distance=None,
     giveaway_distance_explicit=False,
     included_event_types=None,
@@ -771,13 +826,13 @@ def build_homepage_feed_events(
 def _digest_included_event_types(user):
     included = []
     if user.digest_include_requests:
-        included.append('requests')
+        included.append("requests")
     if user.digest_include_giveaways:
-        included.append('giveaways')
+        included.append("giveaways")
     if user.digest_include_circle_joins:
-        included.append('circle_joins')
+        included.append("circle_joins")
     if user.digest_include_loans:
-        included.append('loans')
+        included.append("loans")
     return included
 
 
@@ -792,31 +847,31 @@ def build_digest_payload(user, since=None, until=None, max_events=200):
     scoped_circle_ids = _get_scoped_circle_ids(user)
     events = []
 
-    if 'requests' in included_event_types:
+    if "requests" in included_event_types:
         events.extend(
             build_digest_request_events(
                 user,
                 scoped_circle_ids=scoped_circle_ids,
-                scope='all' if user.digest_requests_include_public else 'circles',
+                scope="all" if user.digest_requests_include_public else "circles",
                 max_distance=user.digest_radius_miles,
                 distance_explicit=True,
                 since=window_start,
                 until=window_end,
             )
         )
-    if 'giveaways' in included_event_types:
+    if "giveaways" in included_event_types:
         events.extend(
             build_digest_giveaway_events(
                 user,
                 scoped_circle_ids=scoped_circle_ids,
-                scope='all' if user.digest_giveaways_include_public else 'circles',
+                scope="all" if user.digest_giveaways_include_public else "circles",
                 max_distance=user.digest_radius_miles,
                 distance_explicit=True,
                 since=window_start,
                 until=window_end,
             )
         )
-    if 'loans' in included_event_types:
+    if "loans" in included_event_types:
         events.extend(
             build_recent_lent_events(
                 user,
@@ -825,7 +880,7 @@ def build_digest_payload(user, since=None, until=None, max_events=200):
                 until=window_end,
             )
         )
-    if 'circle_joins' in included_event_types:
+    if "circle_joins" in included_event_types:
         events.extend(
             build_circle_join_events(
                 user,
@@ -835,28 +890,32 @@ def build_digest_payload(user, since=None, until=None, max_events=200):
             )
         )
 
-    events.sort(key=lambda event: event['created_at'], reverse=True)
+    events.sort(key=lambda event: event["created_at"], reverse=True)
     events = events[:max_events]
 
-    giveaways = [event for event in events if event.get('event_type') == 'giveaway']
-    requests = [event for event in events if event.get('event_type') == 'request']
-    circle_joins = [event for event in events if event.get('event_type') == 'circle_join']
-    loans = [event for event in events if event.get('event_type') == 'lent']
+    giveaways = [event for event in events if event.get("event_type") == "giveaway"]
+    requests = [event for event in events if event.get("event_type") == "request"]
+    circle_joins = [event for event in events if event.get("event_type") == "circle_join"]
+    loans = [event for event in events if event.get("event_type") == "lent"]
 
-    giveaways_count = sum(1 for event in giveaways if event.get('digest_variant') != 'resolved-in-window')
-    requests_count = sum(1 for event in requests if event.get('digest_variant') != 'resolved-in-window')
+    giveaways_count = sum(
+        1 for event in giveaways if event.get("digest_variant") != "resolved-in-window"
+    )
+    requests_count = sum(
+        1 for event in requests if event.get("digest_variant") != "resolved-in-window"
+    )
 
     return {
-        'window_start': window_start,
-        'window_end': window_end,
-        'events': events,
-        'giveaways': giveaways,
-        'requests': requests,
-        'circle_joins': circle_joins,
-        'loans': loans,
-        'summary_stats': {
-            'total_new_items': giveaways_count + requests_count,
-            'giveaways_count': giveaways_count,
-            'borrow_requests_count': requests_count,
+        "window_start": window_start,
+        "window_end": window_end,
+        "events": events,
+        "giveaways": giveaways,
+        "requests": requests,
+        "circle_joins": circle_joins,
+        "loans": loans,
+        "summary_stats": {
+            "total_new_items": giveaways_count + requests_count,
+            "giveaways_count": giveaways_count,
+            "borrow_requests_count": requests_count,
         },
     }

--- a/app/utils/home_feed.py
+++ b/app/utils/home_feed.py
@@ -6,6 +6,7 @@ from app.utils.geocoding import format_distance
 
 
 DEFAULT_GIVEAWAY_DISTANCE_MILES = 20
+RESOLVED_FEED_WINDOW_DAYS = 7
 HOMEPAGE_FEED_EVENT_TYPES = {'requests', 'giveaways', 'loans', 'circle_joins'}
 
 
@@ -161,6 +162,7 @@ def build_visible_requests_events(
         event_time = _utc(item_request.fulfilled_at) if item_request.status == 'fulfilled' else _utc(item_request.created_at)
         if not _within_time_window(event_time, since=since, until=until):
             continue
+        action = 'marked a request fulfilled' if item_request.status == 'fulfilled' else 'requested'
         distance = None
         if user.is_geocoded and item_request.user and item_request.user.is_geocoded:
             raw = user.distance_to(item_request.user)
@@ -175,7 +177,7 @@ def build_visible_requests_events(
             'actor_name': item_request.user.full_name if item_request.user else 'Deleted User',
             'actor_avatar_url': item_request.user.profile_image_url if item_request.user else None,
             'image_url': None,
-            'action': 'requested',
+            'action': action,
             'visibility': item_request.visibility,
             'distance': distance,
         })
@@ -194,6 +196,8 @@ def build_visible_giveaway_events(
     if not scoped_circle_ids:
         return []
 
+    now = datetime.now(UTC)
+    claimed_cutoff = _utc(since) or (now - timedelta(days=RESOLVED_FEED_WINDOW_DAYS))
     shared_circle_user_ids = _shared_circle_user_ids_query(scoped_circle_ids)
     all_circle_user_ids = select(circle_members.c.user_id).distinct()
     normalized_scope = _normalize_scope(scope)
@@ -216,14 +220,32 @@ def build_visible_giveaway_events(
         Item.is_giveaway == True,
         User.vacation_mode == False,
         and_(
-            or_(Item.claim_status == 'unclaimed', Item.claim_status.is_(None)),
+            or_(
+                Item.claim_status == 'unclaimed',
+                Item.claim_status.is_(None),
+                and_(
+                    Item.claim_status == 'claimed',
+                    Item.claimed_at.isnot(None),
+                    Item.claimed_at > claimed_cutoff,
+                ),
+            ),
             visibility_filter,
             Item.owner_id != user.id,
         ),
     )
 
-    if _utc(until) is not None:
-        base_query = base_query.filter(Item.created_at <= _utc(until))
+    until_utc = _utc(until)
+    if until_utc is not None:
+        base_query = base_query.filter(
+            or_(
+                Item.created_at <= until_utc,
+                and_(
+                    Item.claim_status == 'claimed',
+                    Item.claimed_at.isnot(None),
+                    Item.claimed_at <= until_utc,
+                ),
+            )
+        )
 
     giveaway_items = base_query.order_by(Item.created_at.desc()).all()
     effective_distance = _effective_giveaway_distance(max_distance, distance_explicit)
@@ -231,9 +253,10 @@ def build_visible_giveaway_events(
 
     events = []
     for item in giveaway_items:
-        event_time = _utc(item.created_at)
+        event_time = _utc(item.claimed_at) if item.claim_status == 'claimed' else _utc(item.created_at)
         if not _within_time_window(event_time, since=since, until=until):
             continue
+        action = 'gave away' if item.claim_status == 'claimed' else 'posted a giveaway'
         distance = None
         if user.is_geocoded and item.owner and item.owner.is_geocoded:
             raw = user.distance_to(item.owner)
@@ -244,10 +267,11 @@ def build_visible_giveaway_events(
             'item_id': item.id,
             'title': item.name,
             'description': item.description,
+            'claim_status': item.claim_status,
             'actor_name': item.owner.full_name if item.owner else 'Deleted User',
             'actor_avatar_url': item.owner.profile_image_url if item.owner else None,
             'image_url': item.image,
-            'action': 'posted a giveaway',
+            'action': action,
             'distance': distance,
         })
     return events

--- a/install-pre-commit-hook.sh
+++ b/install-pre-commit-hook.sh
@@ -49,7 +49,7 @@ fi
 
 print_color $GREEN "✅ Pre-commit hooks installed successfully!"
 print_color $BLUE "📝 Any previous custom pre-commit hook has been replaced."
-print_color $BLUE "📝 Commits now run fast file-scoped linting; pushes run the Alembic check and unit tests."
-print_color $BLUE "💡 To run hooks manually: pre-commit run --all-files"
+print_color $BLUE "📝 Commits now run fast staged-file linting; pushes run the CI-style branch-diff lint, Alembic check, and unit tests."
+print_color $BLUE "💡 To run the CI-style diff-scoped lint locally: ./scripts/run_precommit_diff.sh"
 print_color $BLUE "💡 To bypass a hook for a specific commit, use: git commit --no-verify"
 print_color $GREEN "🎉 Installation complete!"

--- a/scripts/run_precommit_diff.sh
+++ b/scripts/run_precommit_diff.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ -d "$repo_root/venv/bin" ]]; then
+    export PATH="$repo_root/venv/bin:$PATH"
+fi
+
+select_base_ref() {
+    local ref
+    local merge_base
+    local merge_base_timestamp
+    local best_ref=""
+    local best_merge_base=""
+    local best_timestamp=0
+
+    for ref in origin/main origin/staging; do
+        if ! git rev-parse --verify "$ref" >/dev/null 2>&1; then
+            continue
+        fi
+
+        merge_base="$(git merge-base HEAD "$ref")"
+        merge_base_timestamp="$(git show -s --format=%ct "$merge_base")"
+
+        if [[ -z "$best_ref" || "$merge_base_timestamp" -gt "$best_timestamp" ]]; then
+            best_ref="$ref"
+            best_merge_base="$merge_base"
+            best_timestamp="$merge_base_timestamp"
+        fi
+    done
+
+    if [[ -z "$best_ref" ]]; then
+        echo "Unable to determine a base ref. Pass one explicitly, for example: scripts/run_precommit_diff.sh origin/main" >&2
+        exit 1
+    fi
+
+    printf '%s\n%s\n' "$best_ref" "$best_merge_base"
+}
+
+base_ref="${1:-${PRE_COMMIT_BASE_REF:-}}"
+merge_base=""
+
+if [[ -n "$base_ref" ]]; then
+    if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+        echo "Base ref '$base_ref' was not found locally." >&2
+        exit 1
+    fi
+    merge_base="$(git merge-base HEAD "$base_ref")"
+else
+    mapfile -t selection < <(select_base_ref)
+    base_ref="${selection[0]}"
+    merge_base="${selection[1]}"
+fi
+
+echo "Running pre-commit for changes since $base_ref ($merge_base)"
+pre-commit run -v --show-diff-on-failure --color=always --hook-stage pre-commit --from-ref "$merge_base" --to-ref HEAD

--- a/tests/integration/test_completed_giveaway_visibility.py
+++ b/tests/integration/test_completed_giveaway_visibility.py
@@ -1,9 +1,4 @@
-"""
-Tests for completed giveaway visibility in various views.
-
-Completed (claimed) giveaways should not appear in public feeds
-but should remain visible to owner and recipient for 90 days.
-"""
+"""Tests for completed giveaway visibility in various views."""
 from datetime import datetime, UTC, timedelta
 import pytest
 from app import db
@@ -13,10 +8,10 @@ from conftest import login_user
 
 
 class TestCompletedGiveawayVisibility:
-    """Test that completed giveaways don't show in public views."""
+    """Test that completed giveaways stay hidden in browse surfaces but can appear in the home feed."""
     
-    def test_claimed_giveaway_not_in_home_page(self, client, app, auth_user):
-        """Test that claimed giveaways don't appear on home page."""
+    def test_claimed_giveaway_shows_as_claimed_on_home_page(self, client, app, auth_user):
+        """Test that recently claimed giveaways appear on home page with a resolved label."""
         user_email = None
         with app.app_context():
             # Create a circle and users
@@ -73,14 +68,16 @@ class TestCompletedGiveawayVisibility:
         # Unclaimed should appear
         assert unclaimed_name in html
         
-        # Claimed should NOT appear
-        assert claimed_name not in html
+        # Recently claimed should appear with a visible resolved state
+        assert claimed_name in html
+        assert 'Claimed' in html
+        assert 'gave away' in html
 
         # Pending pickup should NOT appear to other users
         assert pending_name not in html
     
-    def test_claimed_giveaway_not_in_authenticated_home_feed(self, client, app, auth_user):
-        """Test that claimed giveaways don't appear in the authenticated homepage feed."""
+    def test_claimed_giveaway_not_in_authenticated_home_feed_after_visibility_window(self, client, app, auth_user):
+        """Test that old claimed giveaways age out of the authenticated homepage feed."""
         with app.app_context():
             circle = CircleFactory()
             owner = UserFactory()
@@ -112,7 +109,7 @@ class TestCompletedGiveawayVisibility:
                 giveaway_visibility='default',
                 claim_status='claimed',
                 claimed_by=claimer,
-                claimed_at=datetime.now(UTC) - timedelta(days=5)
+                claimed_at=datetime.now(UTC) - timedelta(days=8)
             )
             
             db.session.commit()
@@ -128,7 +125,7 @@ class TestCompletedGiveawayVisibility:
             # Pending pickup should NOT appear to other users
             assert pending.name not in html
             
-            # Claimed should NOT appear
+            # Claimed should age out of the feed after the recent-activity window
             assert claimed.name not in html
     
     def test_claimed_giveaway_not_in_search_results(self, client, app, auth_user):

--- a/tests/integration/test_completed_giveaway_visibility.py
+++ b/tests/integration/test_completed_giveaway_visibility.py
@@ -1,15 +1,15 @@
 """Tests for completed giveaway visibility in various views."""
-from datetime import datetime, UTC, timedelta
-import pytest
+
+from datetime import UTC, datetime, timedelta
+
 from app import db
-from app.models import Item, User, circle_members
-from tests.factories import UserFactory, ItemFactory, CircleFactory
 from conftest import login_user
+from tests.factories import CircleFactory, ItemFactory, UserFactory
 
 
 class TestCompletedGiveawayVisibility:
     """Test that completed giveaways stay hidden in browse surfaces but can appear in the home feed."""
-    
+
     def test_claimed_giveaway_shows_as_claimed_on_home_page(self, client, app, auth_user):
         """Test that recently claimed giveaways appear on home page with a resolved label."""
         user_email = None
@@ -20,114 +20,117 @@ class TestCompletedGiveawayVisibility:
             claimer = UserFactory()
             current_user = auth_user()
             user_email = current_user.email
-            
+
             # Add users to circle
             circle.members.append(owner)
             circle.members.append(claimer)
             circle.members.append(current_user)
-            
+
             # Create unclaimed and claimed giveaways
             unclaimed_giveaway = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='unclaimed'
+                giveaway_visibility="default",
+                claim_status="unclaimed",
             )
             unclaimed_name = unclaimed_giveaway.name
-            
+
             claimed_giveaway = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=claimer,
-                claimed_at=datetime.now(UTC) - timedelta(days=5)
+                claimed_at=datetime.now(UTC) - timedelta(days=5),
             )
             claimed_name = claimed_giveaway.name
 
             pending_giveaway = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='pending_pickup',
-                claimed_by=claimer
+                giveaway_visibility="default",
+                claim_status="pending_pickup",
+                claimed_by=claimer,
             )
             pending_name = pending_giveaway.name
-            
+
             db.session.commit()
-            
+
         # Log in the user
         from conftest import login_user
+
         login_user(client, email=user_email)
-            
+
         # Test as authenticated user
-        response = client.get('/?distance=')
+        response = client.get("/?distance=")
         assert response.status_code == 200
         html = response.data.decode()
-        
+
         # Unclaimed should appear
         assert unclaimed_name in html
-        
+
         # Recently claimed should appear with a visible resolved state
         assert claimed_name in html
-        assert 'Claimed' in html
-        assert 'gave away' in html
+        assert "Claimed" in html
+        assert "gave away" in html
 
         # Pending pickup should NOT appear to other users
         assert pending_name not in html
-    
-    def test_claimed_giveaway_not_in_authenticated_home_feed_after_visibility_window(self, client, app, auth_user):
+
+    def test_claimed_giveaway_not_in_authenticated_home_feed_after_visibility_window(
+        self, client, app, auth_user
+    ):
         """Test that old claimed giveaways age out of the authenticated homepage feed."""
         with app.app_context():
             circle = CircleFactory()
             owner = UserFactory()
             claimer = UserFactory()
             current_user = auth_user()
-            
+
             circle.members.append(owner)
             circle.members.append(claimer)
             circle.members.append(current_user)
-            
+
             unclaimed = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='unclaimed'
+                giveaway_visibility="default",
+                claim_status="unclaimed",
             )
-            
+
             pending = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='pending_pickup',
-                claimed_by=claimer
+                giveaway_visibility="default",
+                claim_status="pending_pickup",
+                claimed_by=claimer,
             )
-            
+
             claimed = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=claimer,
-                claimed_at=datetime.now(UTC) - timedelta(days=8)
+                claimed_at=datetime.now(UTC) - timedelta(days=8),
             )
-            
+
             db.session.commit()
-            
+
             login_user(client, email=current_user.email)
-            response = client.get('/?distance=')
+            response = client.get("/?distance=")
             assert response.status_code == 200
             html = response.data.decode()
-            
+
             # Unclaimed should appear
             assert unclaimed.name in html
-            
+
             # Pending pickup should NOT appear to other users
             assert pending.name not in html
-            
+
             # Claimed should age out of the feed after the recent-activity window
             assert claimed.name not in html
-    
+
     def test_claimed_giveaway_not_in_search_results(self, client, app, auth_user):
         """Test that claimed giveaways don't appear in search results."""
         with app.app_context():
@@ -135,55 +138,55 @@ class TestCompletedGiveawayVisibility:
             owner = UserFactory()
             claimer = UserFactory()
             current_user = auth_user()
-            
+
             circle.members.append(owner)
             circle.members.append(claimer)
             circle.members.append(current_user)
-            
-            unclaimed = ItemFactory(
+
+            ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='unclaimed',
-                name='Searchable Item Unclaimed'
+                giveaway_visibility="default",
+                claim_status="unclaimed",
+                name="Searchable Item Unclaimed",
             )
-            
-            claimed = ItemFactory(
+
+            ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=claimer,
                 claimed_at=datetime.now(UTC) - timedelta(days=5),
-                name='Searchable Item Claimed'
+                name="Searchable Item Claimed",
             )
 
             pending = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='pending_pickup',
+                giveaway_visibility="default",
+                claim_status="pending_pickup",
                 claimed_by=claimer,
-                name='Searchable Item Pending'
+                name="Searchable Item Pending",
             )
-            
+
             db.session.commit()
-            
+
             login_user(client, email=current_user.email)
             # Search for both items
-            response = client.get('/find?q=Searchable&item_type=both')
+            response = client.get("/find?q=Searchable&item_type=both")
             assert response.status_code == 200
             html = response.data.decode()
-            
+
             # Unclaimed should appear
-            assert 'Searchable Item Unclaimed' in html
-            
+            assert "Searchable Item Unclaimed" in html
+
             # Claimed should NOT appear
-            assert 'Searchable Item Claimed' not in html
+            assert "Searchable Item Claimed" not in html
 
             # Pending pickup should NOT appear to other users
             assert pending.name not in html
-    
+
     def test_claimed_giveaway_not_in_category_view(self, client, app, auth_user):
         """Test that claimed giveaways don't appear in category pages."""
         with app.app_context():
@@ -191,58 +194,59 @@ class TestCompletedGiveawayVisibility:
             owner = UserFactory()
             claimer = UserFactory()
             current_user = auth_user()
-            
+
             circle.members.append(owner)
             circle.members.append(claimer)
             circle.members.append(current_user)
-            
+
             # Both items in same category
             from tests.factories import CategoryFactory
+
             category = CategoryFactory()
-            
+
             unclaimed = ItemFactory(
                 owner=owner,
                 category=category,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='unclaimed'
+                giveaway_visibility="default",
+                claim_status="unclaimed",
             )
-            
+
             claimed = ItemFactory(
                 owner=owner,
                 category=category,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=claimer,
-                claimed_at=datetime.now(UTC) - timedelta(days=5)
+                claimed_at=datetime.now(UTC) - timedelta(days=5),
             )
 
             pending = ItemFactory(
                 owner=owner,
                 category=category,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='pending_pickup',
-                claimed_by=claimer
+                giveaway_visibility="default",
+                claim_status="pending_pickup",
+                claimed_by=claimer,
             )
-            
+
             db.session.commit()
-            
+
             login_user(client, email=current_user.email)
-            response = client.get(f'/category/{category.id}?item_type=giveaways')
+            response = client.get(f"/category/{category.id}?item_type=giveaways")
             assert response.status_code == 200
             html = response.data.decode()
-            
+
             # Unclaimed should appear
             assert unclaimed.name in html
-            
+
             # Claimed should NOT appear
             assert claimed.name not in html
 
             # Pending pickup should NOT appear to other users
             assert pending.name not in html
-    
+
     def test_claimed_giveaway_not_in_tag_view(self, client, app, auth_user):
         """Test that claimed giveaways don't appear in tag pages."""
         with app.app_context():
@@ -250,115 +254,116 @@ class TestCompletedGiveawayVisibility:
             owner = UserFactory()
             claimer = UserFactory()
             current_user = auth_user()
-            
+
             circle.members.append(owner)
             circle.members.append(claimer)
             circle.members.append(current_user)
-            
+
             from tests.factories import TagFactory
+
             tag = TagFactory()
-            
+
             unclaimed = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='unclaimed'
+                giveaway_visibility="default",
+                claim_status="unclaimed",
             )
             unclaimed.tags.append(tag)
-            
+
             claimed = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=claimer,
-                claimed_at=datetime.now(UTC) - timedelta(days=5)
+                claimed_at=datetime.now(UTC) - timedelta(days=5),
             )
             claimed.tags.append(tag)
 
             pending = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='pending_pickup',
-                claimed_by=claimer
+                giveaway_visibility="default",
+                claim_status="pending_pickup",
+                claimed_by=claimer,
             )
             pending.tags.append(tag)
-            
+
             db.session.commit()
-            
+
             login_user(client, email=current_user.email)
-            response = client.get(f'/tag/{tag.id}?item_type=giveaways')
+            response = client.get(f"/tag/{tag.id}?item_type=giveaways")
             assert response.status_code == 200
             html = response.data.decode()
-            
+
             # Unclaimed should appear
             assert unclaimed.name in html
-            
+
             # Claimed should NOT appear
             assert claimed.name not in html
 
             # Pending pickup should NOT appear to other users
             assert pending.name not in html
-    
+
     def test_claimed_giveaway_visible_to_owner_in_profile(self, client, app, auth_user):
         """Test that claimed giveaways appear in owner's profile for 90 days."""
         with app.app_context():
             current_user = auth_user()
             circle = CircleFactory()
             circle.members.append(current_user)
-            
+
             claimer = UserFactory()
-            
+
             claimed = ItemFactory(
                 owner=current_user,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=claimer,
-                claimed_at=datetime.now(UTC) - timedelta(days=5)
+                claimed_at=datetime.now(UTC) - timedelta(days=5),
             )
-            
+
             db.session.commit()
-            
+
             login_user(client, email=current_user.email)
-            response = client.get('/profile')
+            response = client.get("/profile")
             assert response.status_code == 200
             html = response.data.decode()
-            
+
             # Should appear in past giveaways section
             assert claimed.name in html
-            assert 'Past Giveaways' in html
-    
+            assert "Past Giveaways" in html
+
     def test_claimed_giveaway_hidden_after_90_days_in_profile(self, client, app, auth_user):
         """Test that claimed giveaways disappear from profile after 90 days."""
         with app.app_context():
             current_user = auth_user()
             circle = CircleFactory()
             circle.members.append(current_user)
-            
+
             claimer = UserFactory()
-            
+
             # Create a giveaway claimed 91 days ago
             old_claimed = ItemFactory(
                 owner=current_user,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=claimer,
-                claimed_at=datetime.now(UTC) - timedelta(days=91)
+                claimed_at=datetime.now(UTC) - timedelta(days=91),
             )
-            
+
             db.session.commit()
-            
+
             login_user(client, email=current_user.email)
-            response = client.get('/profile')
+            response = client.get("/profile")
             assert response.status_code == 200
             html = response.data.decode()
-            
+
             # Should NOT appear (too old)
             assert old_claimed.name not in html
-    
+
     def test_pending_pickup_giveaway_visible_to_owner_only(self, client, app, auth_user):
         """Test pending_pickup giveaways are visible to owner but hidden from others."""
         owner_email = None
@@ -372,114 +377,116 @@ class TestCompletedGiveawayVisibility:
             other_user = UserFactory()
             owner_email = owner.email
             other_user_email = other_user.email
-            
+
             circle.members.append(owner)
             circle.members.append(claimer)
             circle.members.append(other_user)
-            
+
             pending = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='pending_pickup',
-                claimed_by=claimer
+                giveaway_visibility="default",
+                claim_status="pending_pickup",
+                claimed_by=claimer,
             )
             pending_name = pending.name
             pending_id = pending.id
-            
+
             db.session.commit()
-        
+
         # Owner should see pending pickup in profile
         login_user(client, email=owner_email)
-        response = client.get('/profile')
+        response = client.get("/profile")
         assert response.status_code == 200
         assert pending_name in response.data.decode()
 
         # Other users should not see pending pickup in discovery views
-        client.get('/logout', follow_redirects=True)
+        client.get("/logout", follow_redirects=True)
         login_user(client, email=other_user_email)
 
-        response = client.get('/')
+        response = client.get("/")
         assert response.status_code == 200
         assert pending_name not in response.data.decode()
-        
-        response = client.get(f'/find?q={pending_name}&item_type=both')
+
+        response = client.get(f"/find?q={pending_name}&item_type=both")
         assert response.status_code == 200
-        assert f'/item/{pending_id}'.encode() not in response.data
+        assert f"/item/{pending_id}".encode() not in response.data
 
 
 class TestGiveawayBadgeText:
     """Test that the badge displays 'Rehomed' for claimed giveaways."""
-    
+
     def test_rehomed_badge_on_claimed_giveaway_in_profile(self, client, app, auth_user):
         """Test that claimed giveaways show 'Rehomed' badge in profile."""
         with app.app_context():
             current_user = auth_user()
             circle = CircleFactory()
             circle.members.append(current_user)
-            
+
             claimer = UserFactory()
-            
-            claimed = ItemFactory(
+
+            ItemFactory(
                 owner=current_user,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=claimer,
                 claimed_at=datetime.now(UTC) - timedelta(days=5),
-                available=False
+                available=False,
             )
-            
+
             db.session.commit()
-            
+
             login_user(client, email=current_user.email)
-            response = client.get('/profile')
+            response = client.get("/profile")
             assert response.status_code == 200
             html = response.data.decode()
-            
+
             # Should show Rehomed badge
-            assert 'Rehomed' in html
-            assert 'bg-success' in html
-            
+            assert "Rehomed" in html
+            assert "bg-success" in html
+
             # Should NOT show old "Claimed" text in this context
             # Note: "Claimed" appears in other contexts so we check specifically
             # that the badge is present with the Rehomed text
-            assert 'fa-heart' in html
-    
+            assert "fa-heart" in html
+
     def test_pending_pickup_badge_shows_correctly(self, client, app, auth_user):
         """Test that pending_pickup giveaways show correct badge."""
         with app.app_context():
             current_user = auth_user()
             circle = CircleFactory()
             circle.members.append(current_user)
-            
+
             claimer = UserFactory()
-            
-            pending = ItemFactory(
+
+            ItemFactory(
                 owner=current_user,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='pending_pickup',
+                giveaway_visibility="default",
+                claim_status="pending_pickup",
                 claimed_by=claimer,
-                available=False
+                available=False,
             )
-            
+
             db.session.commit()
-            
+
             login_user(client, email=current_user.email)
-            response = client.get('/profile')
+            response = client.get("/profile")
             assert response.status_code == 200
             html = response.data.decode()
-            
+
             # Should show Pending Pickup badge
-            assert 'Pending Pickup' in html
-            assert 'bg-warning' in html
+            assert "Pending Pickup" in html
+            assert "bg-warning" in html
 
 
 class TestClaimedGiveawayDirectUrlVisibility:
     """Test direct URL visibility rules for claimed giveaways."""
 
-    def test_claimed_giveaway_direct_url_unavailable_to_unrelated_user(self, client, app, auth_user):
+    def test_claimed_giveaway_direct_url_unavailable_to_unrelated_user(
+        self, client, app, auth_user
+    ):
         """Unrelated users should see unavailable page for claimed giveaway details."""
         with app.app_context():
             owner = UserFactory()
@@ -489,20 +496,22 @@ class TestClaimedGiveawayDirectUrlVisibility:
             claimed = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=recipient,
-                claimed_at=datetime.now(UTC) - timedelta(days=10)
+                claimed_at=datetime.now(UTC) - timedelta(days=10),
             )
             db.session.commit()
 
             login_user(client, email=unrelated_user.email)
-            response = client.get(f'/item/{claimed.id}')
+            response = client.get(f"/item/{claimed.id}")
             assert response.status_code == 200
-            assert b'This item has found its new home.' in response.data
+            assert b"This item has found its new home." in response.data
             assert claimed.name.encode() not in response.data
 
-    def test_claimed_giveaway_direct_url_visible_to_owner_and_recipient_within_90_days(self, client, app):
+    def test_claimed_giveaway_direct_url_visible_to_owner_and_recipient_within_90_days(
+        self, client, app
+    ):
         """Owner and recipient can view claimed giveaway details within 90 days."""
         with app.app_context():
             owner = UserFactory()
@@ -511,25 +520,25 @@ class TestClaimedGiveawayDirectUrlVisibility:
             claimed = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=recipient,
-                claimed_at=datetime.now(UTC) - timedelta(days=20)
+                claimed_at=datetime.now(UTC) - timedelta(days=20),
             )
             db.session.commit()
 
             login_user(client, email=owner.email)
-            owner_response = client.get(f'/item/{claimed.id}')
+            owner_response = client.get(f"/item/{claimed.id}")
             assert owner_response.status_code == 200
             assert claimed.name.encode() in owner_response.data
-            assert b'This item has found its new home.' not in owner_response.data
+            assert b"This item has found its new home." not in owner_response.data
 
-            client.get('/logout', follow_redirects=True)
+            client.get("/logout", follow_redirects=True)
             login_user(client, email=recipient.email)
-            recipient_response = client.get(f'/item/{claimed.id}')
+            recipient_response = client.get(f"/item/{claimed.id}")
             assert recipient_response.status_code == 200
             assert claimed.name.encode() in recipient_response.data
-            assert b'This item has found its new home.' not in recipient_response.data
+            assert b"This item has found its new home." not in recipient_response.data
 
     def test_claimed_giveaway_direct_url_unavailable_after_90_days_for_everyone(self, client, app):
         """No user, including owner/recipient, can view claimed giveaway after 90 days."""
@@ -540,22 +549,22 @@ class TestClaimedGiveawayDirectUrlVisibility:
             claimed = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                giveaway_visibility='default',
-                claim_status='claimed',
+                giveaway_visibility="default",
+                claim_status="claimed",
                 claimed_by=recipient,
-                claimed_at=datetime.now(UTC) - timedelta(days=91)
+                claimed_at=datetime.now(UTC) - timedelta(days=91),
             )
             db.session.commit()
 
             login_user(client, email=owner.email)
-            owner_response = client.get(f'/item/{claimed.id}')
+            owner_response = client.get(f"/item/{claimed.id}")
             assert owner_response.status_code == 200
-            assert b'This item has found its new home.' in owner_response.data
+            assert b"This item has found its new home." in owner_response.data
             assert claimed.name.encode() not in owner_response.data
 
-            client.get('/logout', follow_redirects=True)
+            client.get("/logout", follow_redirects=True)
             login_user(client, email=recipient.email)
-            recipient_response = client.get(f'/item/{claimed.id}')
+            recipient_response = client.get(f"/item/{claimed.id}")
             assert recipient_response.status_code == 200
-            assert b'This item has found its new home.' in recipient_response.data
+            assert b"This item has found its new home." in recipient_response.data
             assert claimed.name.encode() not in recipient_response.data

--- a/tests/integration/test_request_routes.py
+++ b/tests/integration/test_request_routes.py
@@ -1,11 +1,18 @@
 """Integration tests for requests routes."""
-import pytest
-from datetime import datetime, UTC, timedelta
+
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
+
 from app import db
-from app.models import ItemRequest, Circle, Message, GiveawayInterest
-from tests.factories import UserFactory, ItemFactory, ItemRequestFactory, CircleFactory, MessageFactory
+from app.models import GiveawayInterest, ItemRequest, Message
 from conftest import login_user
+from tests.factories import (
+    CircleFactory,
+    ItemFactory,
+    ItemRequestFactory,
+    MessageFactory,
+    UserFactory,
+)
 
 
 class TestRequestsFeedAccess:
@@ -13,18 +20,18 @@ class TestRequestsFeedAccess:
 
     def test_feed_requires_login(self, client, app):
         """Test that the feed requires authentication."""
-        response = client.get('/requests/')
+        response = client.get("/requests/")
         assert response.status_code == 302
-        assert '/login' in response.headers['Location']
+        assert "/login" in response.headers["Location"]
 
     def test_feed_shows_no_circles_message(self, client, app, auth_user):
         """Test homepage feed shows no-circles message for users with no circles."""
         with app.app_context():
             user = auth_user()
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Join a circle to get started' in response.data
+            assert b"Join a circle to get started" in response.data
 
 
 class TestRequestsFeedFiltering:
@@ -43,21 +50,21 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=shared_circle_user,
-                title='Shared circles request',
-                visibility='circles',
+                title="Shared circles request",
+                visibility="circles",
             )
             ItemRequestFactory(
                 user=public_user,
-                title='Public all-scope request',
-                visibility='public',
+                title="Public all-scope request",
+                visibility="public",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Shared circles request' in response.data
-            assert b'Public all-scope request' in response.data
+            assert b"Shared circles request" in response.data
+            assert b"Public all-scope request" in response.data
 
     def test_all_scope_includes_public_and_shared_circles_only(self, client, app, auth_user):
         """Test all scope includes public requests plus shared-circle circles requests."""
@@ -75,27 +82,27 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=shared_circle_user,
-                title='Visible circles request',
-                visibility='circles',
+                title="Visible circles request",
+                visibility="circles",
             )
             ItemRequestFactory(
                 user=public_user,
-                title='Visible public request',
-                visibility='public',
+                title="Visible public request",
+                visibility="public",
             )
             ItemRequestFactory(
                 user=isolated_circle_user,
-                title='Hidden isolated circles request',
-                visibility='circles',
+                title="Hidden isolated circles request",
+                visibility="circles",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Visible circles request' in response.data
-            assert b'Visible public request' in response.data
-            assert b'Hidden isolated circles request' not in response.data
+            assert b"Visible circles request" in response.data
+            assert b"Visible public request" in response.data
+            assert b"Hidden isolated circles request" not in response.data
 
     def test_feed_shows_circle_members_requests(self, client, app, auth_user):
         """Test that requests from circle members are visible."""
@@ -107,17 +114,17 @@ class TestRequestsFeedFiltering:
             circle.members.append(other_user)
             db.session.commit()
 
-            req = ItemRequestFactory(
+            ItemRequestFactory(
                 user=other_user,
-                title='Need a screwdriver',
-                visibility='circles',
+                title="Need a screwdriver",
+                visibility="circles",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Need a screwdriver' in response.data
+            assert b"Need a screwdriver" in response.data
 
     def test_feed_hides_non_circle_members_requests(self, client, app, auth_user):
         """Test that requests from non-circle members are hidden."""
@@ -133,15 +140,15 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=other_user,
-                title='Hidden request',
-                visibility='circles',
+                title="Hidden request",
+                visibility="circles",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Hidden request' not in response.data
+            assert b"Hidden request" not in response.data
 
     def test_feed_shows_public_requests(self, client, app, auth_user):
         """Test that public requests are visible in all scope."""
@@ -151,15 +158,15 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=other_user,
-                title='Public screwdriver request',
-                visibility='public',
+                title="Public screwdriver request",
+                visibility="public",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Public screwdriver request' in response.data
+            assert b"Public screwdriver request" in response.data
 
     def test_feed_hides_expired_requests(self, client, app, auth_user):
         """Test that expired requests are not shown in the feed."""
@@ -172,16 +179,16 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=other_user,
-                title='Expired request',
-                visibility='circles',
+                title="Expired request",
+                visibility="circles",
                 expires_at=datetime.now(UTC) - timedelta(days=1),
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Expired request' not in response.data
+            assert b"Expired request" not in response.data
 
     def test_feed_shows_recently_fulfilled_requests(self, client, app, auth_user):
         """Test that fulfilled requests from others within 7 days are shown."""
@@ -194,19 +201,19 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=other_user,
-                title='Got my screwdriver',
-                visibility='circles',
-                status='fulfilled',
+                title="Got my screwdriver",
+                visibility="circles",
+                status="fulfilled",
                 fulfilled_at=datetime.now(UTC) - timedelta(days=3),
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Got my screwdriver' in response.data
-            assert b'Fulfilled' in response.data
-            assert b'marked a request fulfilled' in response.data
+            assert b"Got my screwdriver" in response.data
+            assert b"Fulfilled" in response.data
+            assert b"marked a request fulfilled" in response.data
 
     def test_feed_hides_old_fulfilled_requests(self, client, app, auth_user):
         """Test that fulfilled requests from others older than 7 days are hidden."""
@@ -219,17 +226,17 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=other_user,
-                title='Old fulfilled request',
-                visibility='circles',
-                status='fulfilled',
+                title="Old fulfilled request",
+                visibility="circles",
+                status="fulfilled",
                 fulfilled_at=datetime.now(UTC) - timedelta(days=8),
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Old fulfilled request' not in response.data
+            assert b"Old fulfilled request" not in response.data
 
     def test_feed_excludes_own_fulfilled_requests(self, client, app, auth_user):
         """Test that the homepage feed never shows a user's own fulfilled requests."""
@@ -239,17 +246,17 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=user,
-                title='My request from 30 days ago',
-                visibility='circles',
-                status='fulfilled',
+                title="My request from 30 days ago",
+                visibility="circles",
+                status="fulfilled",
                 fulfilled_at=datetime.now(UTC) - timedelta(days=30),
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'My request from 30 days ago' not in response.data
+            assert b"My request from 30 days ago" not in response.data
 
     def test_feed_excludes_own_expired_requests(self, client, app, auth_user):
         """Test that the homepage feed never shows a user's own expired requests."""
@@ -259,17 +266,17 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=user,
-                title='My request that expired 30 days ago',
-                visibility='circles',
-                status='open',
+                title="My request that expired 30 days ago",
+                visibility="circles",
+                status="open",
                 expires_at=datetime.now(UTC) - timedelta(days=30),
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'My request that expired 30 days ago' not in response.data
+            assert b"My request that expired 30 days ago" not in response.data
 
     def test_feed_hides_deleted_requests(self, client, app, auth_user):
         """Test that deleted requests are never shown."""
@@ -282,16 +289,16 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=other_user,
-                title='Deleted request',
-                visibility='circles',
-                status='deleted',
+                title="Deleted request",
+                visibility="circles",
+                status="deleted",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Deleted request' not in response.data
+            assert b"Deleted request" not in response.data
 
     def test_feed_hides_vacation_mode_users(self, client, app, auth_user):
         """Test that requests from vacation mode users are hidden."""
@@ -304,15 +311,15 @@ class TestRequestsFeedFiltering:
 
             ItemRequestFactory(
                 user=other_user,
-                title='Vacation request',
-                visibility='circles',
+                title="Vacation request",
+                visibility="circles",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Vacation request' not in response.data
+            assert b"Vacation request" not in response.data
 
     def test_feed_never_shows_own_requests(self, client, app, auth_user):
         """Test that the homepage feed never shows a user's own open requests."""
@@ -322,14 +329,14 @@ class TestRequestsFeedFiltering:
             circle.members.append(user)
             db.session.commit()
 
-            ItemRequestFactory(user=user, title='My own request')
+            ItemRequestFactory(user=user, title="My own request")
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'My own request' not in response.data
-            assert b'My Requests' not in response.data
+            assert b"My own request" not in response.data
+            assert b"My Requests" not in response.data
 
     def test_feed_public_distance_filter(self, client, app, auth_user):
         """Test homepage distance controls can narrow and expand visible public requests."""
@@ -337,27 +344,27 @@ class TestRequestsFeedFiltering:
             user = auth_user()
             # auth_user has coordinates (40.7128, -74.0060) - NYC
             nearby_user = UserFactory(latitude=40.7300, longitude=-74.0000)  # Very close to NYC
-            far_user = UserFactory(latitude=34.0522, longitude=-118.2437)    # Los Angeles
+            far_user = UserFactory(latitude=34.0522, longitude=-118.2437)  # Los Angeles
 
             # User needs to be in a circle to access the feed
             circle = CircleFactory()
             circle.members.append(user)
             db.session.commit()
 
-            ItemRequestFactory(user=nearby_user, title='Nearby request', visibility='public')
-            ItemRequestFactory(user=far_user, title='Far away request', visibility='public')
+            ItemRequestFactory(user=nearby_user, title="Nearby request", visibility="public")
+            ItemRequestFactory(user=far_user, title="Far away request", visibility="public")
             db.session.commit()
 
             login_user(client, user.email)
-            default_response = client.get('/')
+            default_response = client.get("/")
             assert default_response.status_code == 200
-            assert b'Nearby request' in default_response.data
-            assert b'Far away request' not in default_response.data
+            assert b"Nearby request" in default_response.data
+            assert b"Far away request" not in default_response.data
 
-            no_limit_response = client.get('/?distance=none')
+            no_limit_response = client.get("/?distance=none")
             assert no_limit_response.status_code == 200
-            assert b'Nearby request' in no_limit_response.data
-            assert b'Far away request' in no_limit_response.data
+            assert b"Nearby request" in no_limit_response.data
+            assert b"Far away request" in no_limit_response.data
 
 
 class TestRequestCreation:
@@ -368,34 +375,39 @@ class TestRequestCreation:
         with app.app_context():
             user = auth_user()
             login_user(client, user.email)
-            response = client.get('/requests/new')
+            response = client.get("/requests/new")
             assert response.status_code == 200
-            assert b'Post a Request' in response.data
+            assert b"Post a Request" in response.data
 
     def test_create_request_success(self, client, app, auth_user):
         """Test creating a request successfully."""
         with app.app_context():
             from datetime import date, timedelta
+
             user = auth_user()
             login_user(client, user.email)
 
-            response = client.post('/requests/new', data={
-                'title': 'Plastic googly eyes',
-                'description': 'I need eight for a craft project',
-                'expires_at': (date.today() + timedelta(days=30)).isoformat(),
-                'seeking': 'either',
-                'visibility': 'circles',
-            }, follow_redirects=True)
+            response = client.post(
+                "/requests/new",
+                data={
+                    "title": "Plastic googly eyes",
+                    "description": "I need eight for a craft project",
+                    "expires_at": (date.today() + timedelta(days=30)).isoformat(),
+                    "seeking": "either",
+                    "visibility": "circles",
+                },
+                follow_redirects=True,
+            )
 
             assert response.status_code == 200
-            assert b'Your request has been posted!' in response.data
+            assert b"Your request has been posted!" in response.data
 
-            req = ItemRequest.query.filter_by(title='Plastic googly eyes').first()
+            req = ItemRequest.query.filter_by(title="Plastic googly eyes").first()
             assert req is not None
             assert req.user_id == user.id
-            assert req.seeking == 'either'
-            assert req.visibility == 'circles'
-            assert req.status == 'open'
+            assert req.seeking == "either"
+            assert req.visibility == "circles"
+            assert req.status == "open"
 
     def test_new_request_form_defaults_visibility_to_public(self, client, app, auth_user):
         """Test new request form renders public as the default visibility."""
@@ -403,7 +415,7 @@ class TestRequestCreation:
             user = auth_user()
             login_user(client, user.email)
 
-            response = client.get('/requests/new')
+            response = client.get("/requests/new")
 
             assert response.status_code == 200
             assert b'<option selected value="public">Public</option>' in response.data
@@ -414,61 +426,73 @@ class TestRequestCreation:
             user = auth_user()
             login_user(client, user.email)
 
-            response = client.post('/requests/new', data={
-                'title': '',
-                'expires_at': '',
-                'seeking': 'either',
-                'visibility': 'circles',
-            })
+            response = client.post(
+                "/requests/new",
+                data={
+                    "title": "",
+                    "expires_at": "",
+                    "seeking": "either",
+                    "visibility": "circles",
+                },
+            )
 
             assert response.status_code == 200
-            assert b'Post a Request' in response.data
+            assert b"Post a Request" in response.data
             # No request should have been created
             assert ItemRequest.query.count() == 0
 
     def test_create_request_requires_login(self, client, app):
         """Test that creating a request requires authentication."""
-        response = client.get('/requests/new')
+        response = client.get("/requests/new")
         assert response.status_code == 302
-        assert '/login' in response.headers['Location']
+        assert "/login" in response.headers["Location"]
 
     def test_create_public_request_without_location_blocked(self, client, app):
         """Test that a user without location cannot create a public request."""
         with app.app_context():
             from datetime import date
+
             user = UserFactory(latitude=None, longitude=None)
             login_user(client, user.email)
 
-            response = client.post('/requests/new', data={
-                'title': 'Need a ladder',
-                'description': 'For painting',
-                'expires_at': (date.today() + timedelta(days=30)).isoformat(),
-                'seeking': 'either',
-                'visibility': 'public',
-            })
+            response = client.post(
+                "/requests/new",
+                data={
+                    "title": "Need a ladder",
+                    "description": "For painting",
+                    "expires_at": (date.today() + timedelta(days=30)).isoformat(),
+                    "seeking": "either",
+                    "visibility": "public",
+                },
+            )
 
             assert response.status_code == 200
-            assert b'You must set your location' in response.data
-            assert ItemRequest.query.filter_by(title='Need a ladder').first() is None
+            assert b"You must set your location" in response.data
+            assert ItemRequest.query.filter_by(title="Need a ladder").first() is None
 
     def test_create_circles_request_without_location_allowed(self, client, app):
         """Test that a user without location can create a circles-only request."""
         with app.app_context():
             from datetime import date
+
             user = UserFactory(latitude=None, longitude=None)
             login_user(client, user.email)
 
-            response = client.post('/requests/new', data={
-                'title': 'Need a ladder',
-                'description': 'For painting',
-                'expires_at': (date.today() + timedelta(days=30)).isoformat(),
-                'seeking': 'either',
-                'visibility': 'circles',
-            }, follow_redirects=True)
+            response = client.post(
+                "/requests/new",
+                data={
+                    "title": "Need a ladder",
+                    "description": "For painting",
+                    "expires_at": (date.today() + timedelta(days=30)).isoformat(),
+                    "seeking": "either",
+                    "visibility": "circles",
+                },
+                follow_redirects=True,
+            )
 
             assert response.status_code == 200
-            assert b'Your request has been posted!' in response.data
-            assert ItemRequest.query.filter_by(title='Need a ladder').first() is not None
+            assert b"Your request has been posted!" in response.data
+            assert ItemRequest.query.filter_by(title="Need a ladder").first() is not None
 
 
 class TestRequestEditing:
@@ -482,35 +506,40 @@ class TestRequestEditing:
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get(f'/requests/{req.id}/edit')
+            response = client.get(f"/requests/{req.id}/edit")
             assert response.status_code == 200
-            assert b'Edit Request' in response.data
+            assert b"Edit Request" in response.data
 
     def test_edit_request_success(self, client, app, auth_user):
         """Test successfully editing a request."""
         with app.app_context():
             from datetime import date, timedelta
+
             user = auth_user()
-            req = ItemRequestFactory(user=user, title='Old title')
+            req = ItemRequestFactory(user=user, title="Old title")
             db.session.commit()
             req_id = req.id
 
             login_user(client, user.email)
-            response = client.post(f'/requests/{req_id}/edit', data={
-                'title': 'New title',
-                'description': 'Updated description',
-                'expires_at': (date.today() + timedelta(days=60)).isoformat(),
-                'seeking': 'loan',
-                'visibility': 'public',
-            }, follow_redirects=True)
+            response = client.post(
+                f"/requests/{req_id}/edit",
+                data={
+                    "title": "New title",
+                    "description": "Updated description",
+                    "expires_at": (date.today() + timedelta(days=60)).isoformat(),
+                    "seeking": "loan",
+                    "visibility": "public",
+                },
+                follow_redirects=True,
+            )
 
             assert response.status_code == 200
-            assert b'Your request has been updated.' in response.data
+            assert b"Your request has been updated." in response.data
 
             updated_req = db.session.get(ItemRequest, req_id)
-            assert updated_req.title == 'New title'
-            assert updated_req.seeking == 'loan'
-            assert updated_req.visibility == 'public'
+            assert updated_req.title == "New title"
+            assert updated_req.seeking == "loan"
+            assert updated_req.visibility == "public"
 
     def test_edit_other_users_request_forbidden(self, client, app, auth_user):
         """Test that editing another user's request returns 403."""
@@ -521,42 +550,46 @@ class TestRequestEditing:
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get(f'/requests/{req.id}/edit')
+            response = client.get(f"/requests/{req.id}/edit")
             assert response.status_code == 403
 
     def test_edit_deleted_request_returns_404(self, client, app, auth_user):
         """Test that editing a deleted request returns 404."""
         with app.app_context():
             user = auth_user()
-            req = ItemRequestFactory(user=user, status='deleted')
+            req = ItemRequestFactory(user=user, status="deleted")
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get(f'/requests/{req.id}/edit')
+            response = client.get(f"/requests/{req.id}/edit")
             assert response.status_code == 404
 
     def test_edit_request_to_public_without_location_blocked(self, client, app):
         """Test that editing a request to public is blocked without location."""
         with app.app_context():
             from datetime import date
+
             user = UserFactory(latitude=None, longitude=None)
-            req = ItemRequestFactory(user=user, visibility='circles')
+            req = ItemRequestFactory(user=user, visibility="circles")
             db.session.commit()
             req_id = req.id
 
             login_user(client, user.email)
-            response = client.post(f'/requests/{req_id}/edit', data={
-                'title': 'Updated title',
-                'expires_at': (date.today() + timedelta(days=60)).isoformat(),
-                'seeking': 'either',
-                'visibility': 'public',
-            })
+            response = client.post(
+                f"/requests/{req_id}/edit",
+                data={
+                    "title": "Updated title",
+                    "expires_at": (date.today() + timedelta(days=60)).isoformat(),
+                    "seeking": "either",
+                    "visibility": "public",
+                },
+            )
 
             assert response.status_code == 200
-            assert b'You must set your location' in response.data
+            assert b"You must set your location" in response.data
             # Verify request was NOT updated to public
             updated_req = db.session.get(ItemRequest, req_id)
-            assert updated_req.visibility == 'circles'
+            assert updated_req.visibility == "circles"
 
 
 class TestRequestDeletion:
@@ -571,13 +604,13 @@ class TestRequestDeletion:
             req_id = req.id
 
             login_user(client, user.email)
-            response = client.post(f'/requests/{req_id}/delete', follow_redirects=True)
+            response = client.post(f"/requests/{req_id}/delete", follow_redirects=True)
 
             assert response.status_code == 200
-            assert b'Your request has been removed.' in response.data
+            assert b"Your request has been removed." in response.data
 
             deleted_req = db.session.get(ItemRequest, req_id)
-            assert deleted_req.status == 'deleted'
+            assert deleted_req.status == "deleted"
 
     def test_delete_other_users_request_forbidden(self, client, app, auth_user):
         """Test that deleting another user's request returns 403."""
@@ -588,16 +621,17 @@ class TestRequestDeletion:
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.post(f'/requests/{req.id}/delete')
+            response = client.post(f"/requests/{req.id}/delete")
             assert response.status_code == 403
 
     def test_delete_nonexistent_request_returns_404(self, client, app, auth_user):
         """Test deleting a nonexistent request returns 404."""
         import uuid
+
         with app.app_context():
             user = auth_user()
             login_user(client, user.email)
-            response = client.post(f'/requests/{uuid.uuid4()}/delete')
+            response = client.post(f"/requests/{uuid.uuid4()}/delete")
             assert response.status_code == 404
 
 
@@ -613,13 +647,13 @@ class TestRequestFulfillment:
             req_id = req.id
 
             login_user(client, user.email)
-            response = client.post(f'/requests/{req_id}/fulfill', follow_redirects=True)
+            response = client.post(f"/requests/{req_id}/fulfill", follow_redirects=True)
 
             assert response.status_code == 200
-            assert b'fulfilled' in response.data.lower()
+            assert b"fulfilled" in response.data.lower()
 
             fulfilled_req = db.session.get(ItemRequest, req_id)
-            assert fulfilled_req.status == 'fulfilled'
+            assert fulfilled_req.status == "fulfilled"
             assert fulfilled_req.fulfilled_at is not None
 
     def test_fulfill_other_users_request_forbidden(self, client, app, auth_user):
@@ -631,8 +665,9 @@ class TestRequestFulfillment:
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.post(f'/requests/{req.id}/fulfill')
+            response = client.post(f"/requests/{req.id}/fulfill")
             assert response.status_code == 403
+
 
 class TestRequestDetail:
     """Test request detail page."""
@@ -641,32 +676,33 @@ class TestRequestDetail:
         """Test that the detail page loads."""
         with app.app_context():
             user = auth_user()
-            req = ItemRequestFactory(user=user, title='My detailed request')
+            req = ItemRequestFactory(user=user, title="My detailed request")
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get(f'/requests/{req.id}/detail')
+            response = client.get(f"/requests/{req.id}/detail")
             assert response.status_code == 200
-            assert b'My detailed request' in response.data
+            assert b"My detailed request" in response.data
 
     def test_detail_deleted_request_returns_404(self, client, app, auth_user):
         """Test that viewing a deleted request returns 404."""
         with app.app_context():
             user = auth_user()
-            req = ItemRequestFactory(user=user, status='deleted')
+            req = ItemRequestFactory(user=user, status="deleted")
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get(f'/requests/{req.id}/detail')
+            response = client.get(f"/requests/{req.id}/detail")
             assert response.status_code == 404
 
     def test_detail_nonexistent_request_returns_404(self, client, app, auth_user):
         """Test viewing a nonexistent request returns 404."""
         import uuid
+
         with app.app_context():
             user = auth_user()
             login_user(client, user.email)
-            response = client.get(f'/requests/{uuid.uuid4()}/detail')
+            response = client.get(f"/requests/{uuid.uuid4()}/detail")
             assert response.status_code == 404
 
     def test_detail_shows_owner_actions(self, client, app, auth_user):
@@ -677,10 +713,10 @@ class TestRequestDetail:
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get(f'/requests/{req.id}/detail')
+            response = client.get(f"/requests/{req.id}/detail")
             assert response.status_code == 200
-            assert b'Edit' in response.data
-            assert b'Mark Fulfilled' in response.data
+            assert b"Edit" in response.data
+            assert b"Mark Fulfilled" in response.data
 
 
 class TestRequestConversations:
@@ -691,18 +727,18 @@ class TestRequestConversations:
         with app.app_context():
             requester = UserFactory()
             helper = UserFactory()
-            item_request = ItemRequestFactory(user=requester, visibility='public')
+            item_request = ItemRequestFactory(user=requester, visibility="public")
             db.session.commit()
 
             login_user(client, helper.email)
             response = client.post(
-                f'/requests/{item_request.id}/conversation',
-                data={'body': 'I have one you can borrow!'},
+                f"/requests/{item_request.id}/conversation",
+                data={"body": "I have one you can borrow!"},
                 follow_redirects=True,
             )
 
             assert response.status_code == 200
-            assert b'I have one you can borrow!' in response.data
+            assert b"I have one you can borrow!" in response.data
 
             message = Message.query.filter_by(request_id=item_request.id).first()
             assert message is not None
@@ -715,69 +751,70 @@ class TestRequestConversations:
         with app.app_context():
             requester = UserFactory()
             helper = UserFactory()
-            item_request = ItemRequestFactory(user=requester, visibility='public')
+            item_request = ItemRequestFactory(user=requester, visibility="public")
             existing_message = MessageFactory(
                 sender=helper,
                 recipient=requester,
                 item=None,
                 request=item_request,
-                body='Existing request thread',
+                body="Existing request thread",
             )
             db.session.commit()
 
             login_user(client, helper.email)
-            response = client.get(f'/requests/{item_request.id}/conversation')
+            response = client.get(f"/requests/{item_request.id}/conversation")
 
             assert response.status_code == 302
-            assert f'/message/{existing_message.id}' in response.headers['Location']
+            assert f"/message/{existing_message.id}" in response.headers["Location"]
 
     def test_messages_inbox_shows_request_title(self, client, app):
         """Request-linked conversations should show Re: title in inbox."""
         with app.app_context():
             requester = UserFactory()
             helper = UserFactory()
-            item_request = ItemRequestFactory(user=requester, title='Need a melon baller', visibility='public')
+            item_request = ItemRequestFactory(
+                user=requester, title="Need a melon baller", visibility="public"
+            )
             MessageFactory(
                 sender=helper,
                 recipient=requester,
                 item=None,
                 request=item_request,
-                body='I can help with this.',
+                body="I can help with this.",
             )
             db.session.commit()
 
             login_user(client, requester.email)
-            response = client.get('/messages')
+            response = client.get("/messages")
 
             assert response.status_code == 200
-            assert b'Re: Need a melon baller' in response.data
+            assert b"Re: Need a melon baller" in response.data
 
     def test_view_conversation_reply_preserves_request_context(self, client, app):
         """Replies in request threads should keep request_id and null item_id."""
         with app.app_context():
             requester = UserFactory()
             helper = UserFactory()
-            item_request = ItemRequestFactory(user=requester, visibility='public')
+            item_request = ItemRequestFactory(user=requester, visibility="public")
             first_message = MessageFactory(
                 sender=helper,
                 recipient=requester,
                 item=None,
                 request=item_request,
-                body='Initial request message',
+                body="Initial request message",
             )
             db.session.commit()
 
             login_user(client, requester.email)
             response = client.post(
-                f'/message/{first_message.id}',
-                data={'body': 'Thanks, messaging you now!'},
+                f"/message/{first_message.id}",
+                data={"body": "Thanks, messaging you now!"},
                 follow_redirects=True,
             )
 
             assert response.status_code == 200
             reply = Message.query.filter(
-                Message.parent_id == first_message.id,
-                Message.body == 'Thanks, messaging you now!'
+                Message.parent_id == first_message.id, Message.body == "Thanks, messaging you now!"
             ).first()
             assert reply is not None
             assert reply.request_id == item_request.id
@@ -791,7 +828,7 @@ class TestRequestConversations:
             giveaway = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                claim_status='pending_pickup',
+                claim_status="pending_pickup",
                 claimed_by=claimant,
                 available=False,
             )
@@ -799,20 +836,22 @@ class TestRequestConversations:
                 sender=owner,
                 recipient=claimant,
                 item=giveaway,
-                body='Ready for pickup when you are.',
+                body="Ready for pickup when you are.",
             )
             db.session.commit()
 
             login_user(client, claimant.email)
-            response = client.get(f'/message/{first_message.id}')
+            response = client.get(f"/message/{first_message.id}")
 
             assert response.status_code == 200
-            assert b'Pending Pickup' in response.data
-            assert b'Borrowed' not in response.data
-            assert b'You are the selected recipient for this giveaway.' in response.data
-            assert b'Mark Handoff Complete' not in response.data
+            assert b"Pending Pickup" in response.data
+            assert b"Borrowed" not in response.data
+            assert b"You are the selected recipient for this giveaway." in response.data
+            assert b"Mark Handoff Complete" not in response.data
 
-    def test_view_conversation_pending_pickup_giveaway_owner_sees_handoff_actions(self, client, app):
+    def test_view_conversation_pending_pickup_giveaway_owner_sees_handoff_actions(
+        self, client, app
+    ):
         """Owners should get the handoff-complete CTA in the recipient conversation."""
         with app.app_context():
             owner = UserFactory()
@@ -820,7 +859,7 @@ class TestRequestConversations:
             giveaway = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                claim_status='pending_pickup',
+                claim_status="pending_pickup",
                 claimed_by=claimant,
                 available=False,
             )
@@ -828,20 +867,22 @@ class TestRequestConversations:
                 sender=owner,
                 recipient=claimant,
                 item=giveaway,
-                body='Let me know when you are on your way.',
+                body="Let me know when you are on your way.",
             )
             db.session.commit()
 
             login_user(client, owner.email)
-            response = client.get(f'/message/{first_message.id}')
+            response = client.get(f"/message/{first_message.id}")
 
             assert response.status_code == 200
-            assert b'Giveaway Pickup' in response.data
-            assert b'Mark Handoff Complete' in response.data
-            assert b'Change Recipient' in response.data
-            assert b'Release to Everyone' in response.data
+            assert b"Giveaway Pickup" in response.data
+            assert b"Mark Handoff Complete" in response.data
+            assert b"Change Recipient" in response.data
+            assert b"Release to Everyone" in response.data
 
-    def test_view_conversation_unclaimed_giveaway_owner_sees_quick_select_actions(self, client, app):
+    def test_view_conversation_unclaimed_giveaway_owner_sees_quick_select_actions(
+        self, client, app
+    ):
         """Owners should get the direct recipient-selection CTA in an interested user's conversation."""
         with app.app_context():
             owner = UserFactory()
@@ -849,33 +890,35 @@ class TestRequestConversations:
             giveaway = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                claim_status='unclaimed',
+                claim_status="unclaimed",
                 available=True,
             )
             interest = GiveawayInterest(
                 item_id=giveaway.id,
                 user_id=requester.id,
-                status='active',
+                status="active",
             )
             first_message = MessageFactory(
                 sender=requester,
                 recipient=owner,
                 item=giveaway,
-                body='I would love to pick this up.',
+                body="I would love to pick this up.",
             )
             db.session.add(interest)
             db.session.commit()
 
             login_user(client, owner.email)
-            response = client.get(f'/message/{first_message.id}')
+            response = client.get(f"/message/{first_message.id}")
 
             assert response.status_code == 200
-            assert b'Choose Recipient' in response.data
-            assert b'Give Item to This User' in response.data
-            assert b'View Interested Users' in response.data
-            assert b'Mark Handoff Complete' not in response.data
+            assert b"Choose Recipient" in response.data
+            assert b"Give Item to This User" in response.data
+            assert b"View Interested Users" in response.data
+            assert b"Mark Handoff Complete" not in response.data
 
-    def test_view_conversation_unclaimed_giveaway_shows_interested_count_guidance(self, client, app):
+    def test_view_conversation_unclaimed_giveaway_shows_interested_count_guidance(
+        self, client, app
+    ):
         """Owner quick-select panel should call out when multiple users are interested."""
         with app.app_context():
             owner = UserFactory()
@@ -884,29 +927,35 @@ class TestRequestConversations:
             giveaway = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                claim_status='unclaimed',
+                claim_status="unclaimed",
                 available=True,
             )
-            db.session.add_all([
-                GiveawayInterest(item_id=giveaway.id, user_id=requester.id, status='active'),
-                GiveawayInterest(item_id=giveaway.id, user_id=another_requester.id, status='active'),
-            ])
+            db.session.add_all(
+                [
+                    GiveawayInterest(item_id=giveaway.id, user_id=requester.id, status="active"),
+                    GiveawayInterest(
+                        item_id=giveaway.id, user_id=another_requester.id, status="active"
+                    ),
+                ]
+            )
             first_message = MessageFactory(
                 sender=requester,
                 recipient=owner,
                 item=giveaway,
-                body='Happy to collect it this week.',
+                body="Happy to collect it this week.",
             )
             db.session.commit()
 
             login_user(client, owner.email)
-            response = client.get(f'/message/{first_message.id}')
+            response = client.get(f"/message/{first_message.id}")
 
             assert response.status_code == 200
-            assert b'2 people are interested in this giveaway.' in response.data
-            assert b'View Interested Users' in response.data
+            assert b"2 people are interested in this giveaway." in response.data
+            assert b"View Interested Users" in response.data
 
-    def test_view_conversation_unclaimed_giveaway_recipient_does_not_see_quick_select_actions(self, client, app):
+    def test_view_conversation_unclaimed_giveaway_recipient_does_not_see_quick_select_actions(
+        self, client, app
+    ):
         """Recipients should not see owner-only quick-select actions."""
         with app.app_context():
             owner = UserFactory()
@@ -914,31 +963,33 @@ class TestRequestConversations:
             giveaway = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                claim_status='unclaimed',
+                claim_status="unclaimed",
                 available=True,
             )
             interest = GiveawayInterest(
                 item_id=giveaway.id,
                 user_id=requester.id,
-                status='active',
+                status="active",
             )
             first_message = MessageFactory(
                 sender=owner,
                 recipient=requester,
                 item=giveaway,
-                body='Thanks for reaching out.',
+                body="Thanks for reaching out.",
             )
             db.session.add(interest)
             db.session.commit()
 
             login_user(client, requester.email)
-            response = client.get(f'/message/{first_message.id}')
+            response = client.get(f"/message/{first_message.id}")
 
             assert response.status_code == 200
-            assert b'Choose Recipient' not in response.data
-            assert b'Give Item to This User' not in response.data
+            assert b"Choose Recipient" not in response.data
+            assert b"Give Item to This User" not in response.data
 
-    def test_view_conversation_unclaimed_giveaway_hides_quick_select_when_user_not_interested(self, client, app):
+    def test_view_conversation_unclaimed_giveaway_hides_quick_select_when_user_not_interested(
+        self, client, app
+    ):
         """Owner should not get the quick-select CTA if the conversation partner is not in the pool."""
         with app.app_context():
             owner = UserFactory()
@@ -946,23 +997,23 @@ class TestRequestConversations:
             giveaway = ItemFactory(
                 owner=owner,
                 is_giveaway=True,
-                claim_status='unclaimed',
+                claim_status="unclaimed",
                 available=True,
             )
             first_message = MessageFactory(
                 sender=chatter,
                 recipient=owner,
                 item=giveaway,
-                body='Is this still available?',
+                body="Is this still available?",
             )
             db.session.commit()
 
             login_user(client, owner.email)
-            response = client.get(f'/message/{first_message.id}')
+            response = client.get(f"/message/{first_message.id}")
 
             assert response.status_code == 200
-            assert b'Choose Recipient' not in response.data
-            assert b'Give Item to This User' not in response.data
+            assert b"Choose Recipient" not in response.data
+            assert b"Give Item to This User" not in response.data
 
 
 class TestRequestNavigation:
@@ -973,18 +1024,18 @@ class TestRequestNavigation:
         with app.app_context():
             user = auth_user()
             login_user(client, user.email)
-            response = client.get('/')
+            response = client.get("/")
             assert response.status_code == 200
-            assert b'Home' in response.data
-            assert b'Find' in response.data
-            assert b'/find' in response.data
+            assert b"Home" in response.data
+            assert b"Find" in response.data
+            assert b"/find" in response.data
             assert b'href="/giveaways"' not in response.data
             assert b'href="/requests/"' not in response.data
             assert b'class="nav-link" href="/list-item"' not in response.data
 
     def test_nav_link_not_for_anonymous(self, client, app):
         """Test that Requests nav link is not shown to anonymous users."""
-        response = client.get('/')
+        response = client.get("/")
         assert response.status_code == 200
         # The navbar should not contain a Requests nav link for anonymous users
         # (the landing page mock feed uses the icon but NOT as a nav link)
@@ -997,65 +1048,67 @@ class TestRequestEmailNotifications:
     def test_start_conversation_sends_email_notification(self, client, app):
         """Test that starting a conversation on a request sends an email notification to the requester."""
         with app.app_context():
-            requester = UserFactory(email='requester@test.com')
-            helper = UserFactory(email='helper@test.com')
+            requester = UserFactory(email="requester@test.com")
+            helper = UserFactory(email="helper@test.com")
             item_request = ItemRequestFactory(
                 user=requester,
-                title='Need a melon baller',
-                visibility='public',
+                title="Need a melon baller",
+                visibility="public",
             )
             db.session.commit()
 
             login_user(client, helper.email)
 
             # Patch the email sending function
-            with patch('app.utils.email.send_email') as mock_send_email:
+            with patch("app.utils.email.send_email") as mock_send_email:
                 mock_send_email.return_value = True
 
                 response = client.post(
-                    f'/requests/{item_request.id}/conversation',
-                    data={'body': 'I have one you can borrow!'},
+                    f"/requests/{item_request.id}/conversation",
+                    data={"body": "I have one you can borrow!"},
                     follow_redirects=True,
                 )
 
                 assert response.status_code == 200
-                assert b'Your message has been sent.' in response.data
+                assert b"Your message has been sent." in response.data
 
                 # Verify email was sent
                 mock_send_email.assert_called_once()
                 call_args = mock_send_email.call_args
                 assert call_args[0][0] == requester.email  # to_email
-                assert 'Meutch - New Message about request: Need a melon baller' in call_args[0][1]  # subject
-                assert 'I have one you can borrow!' in call_args[0][2]  # message body
+                assert (
+                    "Meutch - New Message about request: Need a melon baller" in call_args[0][1]
+                )  # subject
+                assert "I have one you can borrow!" in call_args[0][2]  # message body
 
     def test_reply_to_request_conversation_sends_email(self, client, app):
         """Test that replying in a request conversation thread sends email notification."""
         with app.app_context():
-            requester = UserFactory(email='requester@test.com')
-            helper = UserFactory(email='helper@test.com')
+            requester = UserFactory(email="requester@test.com")
+            helper = UserFactory(email="helper@test.com")
             item_request = ItemRequestFactory(
                 user=requester,
-                title='Need a hammer drill',
-                visibility='public',
+                title="Need a hammer drill",
+                visibility="public",
             )
             initial_message = MessageFactory(
                 sender=helper,
                 recipient=requester,
                 item=None,
                 request=item_request,
-                body='I have one you can borrow!',
+                body="I have one you can borrow!",
             )
             db.session.commit()
 
             login_user(client, requester.email)
 
             # Patch the email sending function
-            with patch('app.utils.email.send_email') as mock_send_email:
+            with patch("app.utils.email.send_email") as mock_send_email:
                 mock_send_email.return_value = True
 
                 response = client.post(
-                    f'/message/{initial_message.id}',
-                    data={'body': 'Great! When can I pick it up?'},
+                    f"/message/{initial_message.id}",
+                    data={"body": "Great! When can I pick it up?"},
                     follow_redirects=True,
                 )
 
@@ -1065,29 +1118,31 @@ class TestRequestEmailNotifications:
                 mock_send_email.assert_called_once()
                 call_args = mock_send_email.call_args
                 assert call_args[0][0] == helper.email  # to_email (the other participant)
-                assert 'Meutch - New Message about request: Need a hammer drill' in call_args[0][1]  # subject
-                assert 'Great! When can I pick it up?' in call_args[0][2]  # message body
+                assert (
+                    "Meutch - New Message about request: Need a hammer drill" in call_args[0][1]
+                )  # subject
+                assert "Great! When can I pick it up?" in call_args[0][2]  # message body
 
     def test_request_message_email_includes_context(self, client, app):
         """Test that request message emails properly identify the request context."""
         with app.app_context():
-            requester = UserFactory(email='requester@test.com', first_name='Alice')
-            helper = UserFactory(email='helper@test.com', first_name='Bob')
+            requester = UserFactory(email="requester@test.com", first_name="Alice")
+            helper = UserFactory(email="helper@test.com", first_name="Bob")
             item_request = ItemRequestFactory(
                 user=requester,
-                title='Looking for a soldering iron',
-                visibility='public',
+                title="Looking for a soldering iron",
+                visibility="public",
             )
             db.session.commit()
 
             login_user(client, helper.email)
 
-            with patch('app.utils.email.send_email') as mock_send_email:
+            with patch("app.utils.email.send_email") as mock_send_email:
                 mock_send_email.return_value = True
 
                 response = client.post(
-                    f'/requests/{item_request.id}/conversation',
-                    data={'body': 'I have a soldering iron!'},
+                    f"/requests/{item_request.id}/conversation",
+                    data={"body": "I have a soldering iron!"},
                     follow_redirects=True,
                 )
 
@@ -1098,7 +1153,9 @@ class TestRequestEmailNotifications:
                 text_content = call_args[0][2]  # text_content argument
 
                 # Verify the email includes request-specific context
-                assert 'Looking for a soldering iron' in text_content  # request title
-                assert 'Bob' in text_content  # helper's first name
-                assert 'I have a soldering iron!' in text_content  # message body
-                assert 'view_conversation' in call_args[0][3] or 'conversation' in text_content  # has link
+                assert "Looking for a soldering iron" in text_content  # request title
+                assert "Bob" in text_content  # helper's first name
+                assert "I have a soldering iron!" in text_content  # message body
+                assert (
+                    "view_conversation" in call_args[0][3] or "conversation" in text_content
+                )  # has link

--- a/tests/integration/test_request_routes.py
+++ b/tests/integration/test_request_routes.py
@@ -205,6 +205,8 @@ class TestRequestsFeedFiltering:
             response = client.get('/')
             assert response.status_code == 200
             assert b'Got my screwdriver' in response.data
+            assert b'Fulfilled' in response.data
+            assert b'marked a request fulfilled' in response.data
 
     def test_feed_hides_old_fulfilled_requests(self, client, app, auth_user):
         """Test that fulfilled requests from others older than 7 days are hidden."""

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -379,11 +379,11 @@ class TestEmailUtils:
                 unsubscribe_url="https://example.com/digest/unsubscribe/token123",
             )
 
-            assert "Alex: Free Chair was claimed" in content["text"]
-            assert "Taylor: Need a ladder was marked fulfilled" in content["text"]
+            assert "Free Chair offered by Alex was claimed" in content["text"]
+            assert "Need a ladder was marked fulfilled" in content["text"]
             assert "This should not be repeated" not in content["text"]
-            assert "Image: https://example.com/chair.jpg" not in content["text"]
-            assert "Free Chair was claimed" in content["html"]
+            assert "Image: https://example.com/chair.jpg" in content["text"]
+            assert "Free Chair offered by Alex was claimed" in content["html"]
             assert "Need a ladder was marked fulfilled" in content["html"]
 
     def test_send_digest_email_sends_when_payload_has_only_resolution_events(self, app):

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -191,3 +191,201 @@ class TestEmailUtils:
                 assert result is False
                 # send_email should never be called
                 mock_send_email.assert_not_called()
+
+    def test_build_digest_email_content_adds_same_window_resolution_labels(self, app):
+        with app.app_context():
+            user = UserFactory(first_name='Digest', digest_frequency='daily')
+            payload = {
+                'summary_stats': {
+                    'total_new_items': 2,
+                    'giveaways_count': 1,
+                    'borrow_requests_count': 1,
+                },
+                'events': [
+                    {
+                        'event_type': 'giveaway',
+                        'item_id': uuid.uuid4(),
+                        'actor_name': 'Alex',
+                        'title': 'Free Chair',
+                        'description': 'Great chair in good condition',
+                        'image_url': 'https://example.com/chair.jpg',
+                        'action': 'posted a giveaway',
+                        'digest_variant': 'new-resolved-in-window',
+                        'resolution_status': 'claimed',
+                    },
+                    {
+                        'event_type': 'request',
+                        'request_id': uuid.uuid4(),
+                        'actor_name': 'Taylor',
+                        'title': 'Need a ladder',
+                        'description': 'Need for one weekend project',
+                        'image_url': None,
+                        'action': 'requested',
+                        'digest_variant': 'new-resolved-in-window',
+                        'resolution_status': 'fulfilled',
+                    },
+                ],
+                'giveaways': [
+                    {
+                        'event_type': 'giveaway',
+                        'item_id': uuid.uuid4(),
+                        'actor_name': 'Alex',
+                        'title': 'Free Chair',
+                        'description': 'Great chair in good condition',
+                        'image_url': 'https://example.com/chair.jpg',
+                        'action': 'posted a giveaway',
+                        'digest_variant': 'new-resolved-in-window',
+                        'resolution_status': 'claimed',
+                    }
+                ],
+                'requests': [
+                    {
+                        'event_type': 'request',
+                        'request_id': uuid.uuid4(),
+                        'actor_name': 'Taylor',
+                        'title': 'Need a ladder',
+                        'description': 'Need for one weekend project',
+                        'image_url': None,
+                        'action': 'requested',
+                        'digest_variant': 'new-resolved-in-window',
+                        'resolution_status': 'fulfilled',
+                    }
+                ],
+                'circle_joins': [],
+                'loans': [],
+            }
+
+            content = build_digest_email_content(
+                user,
+                payload,
+                manage_url='https://example.com/digest/manage/token123',
+                unsubscribe_url='https://example.com/digest/unsubscribe/token123',
+            )
+
+            assert 'Alex posted a giveaway: Free Chair [Claimed]' in content['text']
+            assert 'Taylor requested: Need a ladder [Fulfilled]' in content['text']
+            assert '>Claimed</span>' in content['html']
+            assert '>Fulfilled</span>' in content['html']
+
+    def test_build_digest_email_content_renders_resolution_only_copy(self, app):
+        with app.app_context():
+            user = UserFactory(first_name='Digest', digest_frequency='weekly')
+            giveaway_id = uuid.uuid4()
+            request_id = uuid.uuid4()
+            payload = {
+                'summary_stats': {
+                    'total_new_items': 0,
+                    'giveaways_count': 0,
+                    'borrow_requests_count': 0,
+                },
+                'events': [
+                    {
+                        'event_type': 'giveaway',
+                        'item_id': giveaway_id,
+                        'actor_name': 'Alex',
+                        'title': 'Free Chair',
+                        'description': 'This should not be repeated',
+                        'image_url': 'https://example.com/chair.jpg',
+                        'action': 'posted a giveaway',
+                        'digest_variant': 'resolved-in-window',
+                        'resolution_status': 'claimed',
+                    },
+                    {
+                        'event_type': 'request',
+                        'request_id': request_id,
+                        'actor_name': 'Taylor',
+                        'title': 'Need a ladder',
+                        'description': 'This should not be repeated',
+                        'image_url': None,
+                        'action': 'requested',
+                        'digest_variant': 'resolved-in-window',
+                        'resolution_status': 'fulfilled',
+                    },
+                ],
+                'giveaways': [
+                    {
+                        'event_type': 'giveaway',
+                        'item_id': giveaway_id,
+                        'actor_name': 'Alex',
+                        'title': 'Free Chair',
+                        'description': 'This should not be repeated',
+                        'image_url': 'https://example.com/chair.jpg',
+                        'action': 'posted a giveaway',
+                        'digest_variant': 'resolved-in-window',
+                        'resolution_status': 'claimed',
+                    }
+                ],
+                'requests': [
+                    {
+                        'event_type': 'request',
+                        'request_id': request_id,
+                        'actor_name': 'Taylor',
+                        'title': 'Need a ladder',
+                        'description': 'This should not be repeated',
+                        'image_url': None,
+                        'action': 'requested',
+                        'digest_variant': 'resolved-in-window',
+                        'resolution_status': 'fulfilled',
+                    }
+                ],
+                'circle_joins': [],
+                'loans': [],
+            }
+
+            content = build_digest_email_content(
+                user,
+                payload,
+                manage_url='https://example.com/digest/manage/token123',
+                unsubscribe_url='https://example.com/digest/unsubscribe/token123',
+            )
+
+            assert 'Alex: Free Chair was claimed' in content['text']
+            assert 'Taylor: Need a ladder was marked fulfilled' in content['text']
+            assert 'This should not be repeated' not in content['text']
+            assert 'Image: https://example.com/chair.jpg' not in content['text']
+            assert 'Free Chair was claimed' in content['html']
+            assert 'Need a ladder was marked fulfilled' in content['html']
+
+    def test_send_digest_email_sends_when_payload_has_only_resolution_events(self, app):
+        with app.app_context():
+            user = UserFactory(first_name='Digest', digest_frequency='weekly')
+            payload = {
+                'summary_stats': {
+                    'total_new_items': 0,
+                    'giveaways_count': 0,
+                    'borrow_requests_count': 0,
+                },
+                'events': [
+                    {
+                        'event_type': 'giveaway',
+                        'item_id': uuid.uuid4(),
+                        'actor_name': 'Alex',
+                        'title': 'Free Chair',
+                        'action': 'posted a giveaway',
+                        'digest_variant': 'resolved-in-window',
+                        'resolution_status': 'claimed',
+                    }
+                ],
+                'giveaways': [
+                    {
+                        'event_type': 'giveaway',
+                        'item_id': uuid.uuid4(),
+                        'actor_name': 'Alex',
+                        'title': 'Free Chair',
+                        'action': 'posted a giveaway',
+                        'digest_variant': 'resolved-in-window',
+                        'resolution_status': 'claimed',
+                    }
+                ],
+                'requests': [],
+                'circle_joins': [],
+                'loans': [],
+            }
+
+            with patch('app.utils.email.send_email') as mock_send_email:
+                mock_send_email.return_value = True
+
+                result = send_digest_email(user, payload)
+
+                assert result is True
+                mock_send_email.assert_called_once()

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -1,31 +1,38 @@
 """Unit tests for email utilities."""
-import pytest
+
 import uuid
-from unittest.mock import patch, Mock
-from app.utils.email import send_account_deletion_email, build_digest_email_content, send_digest_email
+from unittest.mock import patch
+
+import pytest
+
+from app.utils.email import (
+    build_digest_email_content,
+    send_account_deletion_email,
+    send_digest_email,
+)
 from tests.factories import UserFactory
 
 
 class TestEmailUtils:
     """Test email utility functions."""
-    
+
     def test_send_account_deletion_email_content(self):
         """Test that account deletion email contains correct content."""
-        with patch('app.utils.email.send_email') as mock_send_email:
+        with patch("app.utils.email.send_email") as mock_send_email:
             mock_send_email.return_value = True
-            
+
             # Call the function
             result = send_account_deletion_email("test@example.com", "John")
-            
+
             # Verify send_email was called
             assert mock_send_email.called
             call_args = mock_send_email.call_args[0]
-            
+
             # Check email parameters
             email_address = call_args[0]
             subject = call_args[1]
             content = call_args[2]
-            
+
             assert email_address == "test@example.com"
             assert "Account Successfully Deleted" in subject
             assert "Hello John" in content
@@ -33,67 +40,67 @@ class TestEmailUtils:
             assert "Your name will continue to appear in message history" in content
             assert "Thank you for being part of the Meutch community" in content
             assert result is True
-    
+
     def test_send_account_deletion_email_failure(self):
         """Test that account deletion email handles send failure gracefully."""
-        with patch('app.utils.email.send_email') as mock_send_email:
+        with patch("app.utils.email.send_email") as mock_send_email:
             mock_send_email.return_value = False
-            
+
             # Call the function
             result = send_account_deletion_email("test@example.com", "John")
-            
+
             # Should return False when send_email fails
             assert result is False
-    
+
     def test_send_account_deletion_email_exception(self):
         """Test that account deletion email handles exceptions."""
-        with patch('app.utils.email.send_email') as mock_send_email:
+        with patch("app.utils.email.send_email") as mock_send_email:
             mock_send_email.side_effect = Exception("Network error")
-            
+
             # Should raise the exception (not caught in this function)
             with pytest.raises(Exception, match="Network error"):
                 send_account_deletion_email("test@example.com", "John")
 
     def test_build_digest_email_content_includes_sections_and_manage_links(self, app):
         with app.app_context():
-            user = UserFactory(first_name='Digest', digest_frequency='daily')
+            user = UserFactory(first_name="Digest", digest_frequency="daily")
             payload = {
-                'summary_stats': {
-                    'total_new_items': 2,
-                    'giveaways_count': 1,
-                    'borrow_requests_count': 1,
+                "summary_stats": {
+                    "total_new_items": 2,
+                    "giveaways_count": 1,
+                    "borrow_requests_count": 1,
                 },
-                'giveaways': [
+                "giveaways": [
                     {
-                        'event_type': 'giveaway',
-                        'item_id': uuid.uuid4(),
-                        'actor_name': 'Alex',
-                        'title': 'Free Chair',
-                        'description': 'Great chair in good condition',
-                        'image_url': 'https://example.com/chair.jpg',
-                        'action': 'posted a giveaway',
+                        "event_type": "giveaway",
+                        "item_id": uuid.uuid4(),
+                        "actor_name": "Alex",
+                        "title": "Free Chair",
+                        "description": "Great chair in good condition",
+                        "image_url": "https://example.com/chair.jpg",
+                        "action": "posted a giveaway",
                     }
                 ],
-                'requests': [
+                "requests": [
                     {
-                        'event_type': 'request',
-                        'request_id': uuid.uuid4(),
-                        'actor_name': 'Taylor',
-                        'title': 'Need a ladder',
-                        'description': 'Need for one weekend project',
-                        'image_url': 'https://example.com/ladder.jpg',
-                        'action': 'requested',
+                        "event_type": "request",
+                        "request_id": uuid.uuid4(),
+                        "actor_name": "Taylor",
+                        "title": "Need a ladder",
+                        "description": "Need for one weekend project",
+                        "image_url": "https://example.com/ladder.jpg",
+                        "action": "requested",
                     }
                 ],
-                'circle_joins': [],
-                'loans': [
+                "circle_joins": [],
+                "loans": [
                     {
-                        'event_type': 'lent',
-                        'item_id': uuid.uuid4(),
-                        'actor_name': 'Morgan',
-                        'title': 'Power Drill',
-                        'image_url': 'https://example.com/drill.jpg',
-                        'action': 'lent out',
+                        "event_type": "lent",
+                        "item_id": uuid.uuid4(),
+                        "actor_name": "Morgan",
+                        "title": "Power Drill",
+                        "image_url": "https://example.com/drill.jpg",
+                        "action": "lent out",
                     }
                 ],
             }
@@ -101,24 +108,24 @@ class TestEmailUtils:
             content = build_digest_email_content(
                 user,
                 payload,
-                manage_url='https://example.com/digest/manage/token123',
-                unsubscribe_url='https://example.com/digest/unsubscribe/token123',
+                manage_url="https://example.com/digest/manage/token123",
+                unsubscribe_url="https://example.com/digest/unsubscribe/token123",
             )
 
-            assert content['subject'] == 'Meutch Digest - 3 new activities'
-            assert 'This is your daily Meutch digest.' in content['text']
-            assert 'Great chair in good condition' in content['text']
-            assert 'Need for one weekend project' in content['text']
-            assert 'https://example.com/chair.jpg' in content['text']
-            assert 'https://example.com/ladder.jpg' in content['text']
-            assert 'https://example.com/drill.jpg' in content['text']
-            assert 'Giveaways' in content['text']
-            assert 'Requests' in content['text']
-            assert 'https://example.com/digest/manage/token123' in content['text']
-            assert 'https://example.com/digest/unsubscribe/token123' in content['text']
-            assert 'One-click unsubscribe' in content['html']
-            assert '0 circle joins' not in content['text']
-            assert '3 new activities' not in content['text']
+            assert content["subject"] == "Meutch Digest - 3 new activities"
+            assert "This is your daily Meutch digest." in content["text"]
+            assert "Great chair in good condition" in content["text"]
+            assert "Need for one weekend project" in content["text"]
+            assert "https://example.com/chair.jpg" in content["text"]
+            assert "https://example.com/ladder.jpg" in content["text"]
+            assert "https://example.com/drill.jpg" in content["text"]
+            assert "Giveaways" in content["text"]
+            assert "Requests" in content["text"]
+            assert "https://example.com/digest/manage/token123" in content["text"]
+            assert "https://example.com/digest/unsubscribe/token123" in content["text"]
+            assert "One-click unsubscribe" in content["html"]
+            assert "0 circle joins" not in content["text"]
+            assert "3 new activities" not in content["text"]
 
     def test_digest_circle_joins_consolidated_per_circle(self, app):
         """Multiple people joining the same circle appear as one item per circle, not per person.
@@ -126,65 +133,98 @@ class TestEmailUtils:
         Also verifies the link reads 'View circle' (not 'View activity') and appears once per circle.
         """
         with app.app_context():
-            user = UserFactory(first_name='Subscriber', digest_frequency='weekly')
+            user = UserFactory(first_name="Subscriber", digest_frequency="weekly")
             circle_x_id = uuid.uuid4()
             circle_y_id = uuid.uuid4()
             payload = {
-                'summary_stats': {'total_new_items': 0, 'giveaways_count': 0, 'borrow_requests_count': 0},
-                'giveaways': [],
-                'requests': [],
-                'loans': [],
-                'circle_joins': [
-                    {'event_type': 'circle_join', 'circle_id': circle_x_id, 'title': 'Circle X', 'actor_name': 'Alice',   'action': 'joined', 'image_url': None},
-                    {'event_type': 'circle_join', 'circle_id': circle_x_id, 'title': 'Circle X', 'actor_name': 'Bob',     'action': 'joined', 'image_url': None},
-                    {'event_type': 'circle_join', 'circle_id': circle_x_id, 'title': 'Circle X', 'actor_name': 'Celeste', 'action': 'joined', 'image_url': None},
-                    {'event_type': 'circle_join', 'circle_id': circle_y_id, 'title': 'Circle Y', 'actor_name': 'Alice',   'action': 'joined', 'image_url': None},
+                "summary_stats": {
+                    "total_new_items": 0,
+                    "giveaways_count": 0,
+                    "borrow_requests_count": 0,
+                },
+                "giveaways": [],
+                "requests": [],
+                "loans": [],
+                "circle_joins": [
+                    {
+                        "event_type": "circle_join",
+                        "circle_id": circle_x_id,
+                        "title": "Circle X",
+                        "actor_name": "Alice",
+                        "action": "joined",
+                        "image_url": None,
+                    },
+                    {
+                        "event_type": "circle_join",
+                        "circle_id": circle_x_id,
+                        "title": "Circle X",
+                        "actor_name": "Bob",
+                        "action": "joined",
+                        "image_url": None,
+                    },
+                    {
+                        "event_type": "circle_join",
+                        "circle_id": circle_x_id,
+                        "title": "Circle X",
+                        "actor_name": "Celeste",
+                        "action": "joined",
+                        "image_url": None,
+                    },
+                    {
+                        "event_type": "circle_join",
+                        "circle_id": circle_y_id,
+                        "title": "Circle Y",
+                        "actor_name": "Alice",
+                        "action": "joined",
+                        "image_url": None,
+                    },
                 ],
             }
             content = build_digest_email_content(
-                user, payload,
-                manage_url='https://example.com/digest/manage/token',
-                unsubscribe_url='https://example.com/digest/unsubscribe/token',
+                user,
+                payload,
+                manage_url="https://example.com/digest/manage/token",
+                unsubscribe_url="https://example.com/digest/unsubscribe/token",
             )
 
-            text = content['text']
-            html = content['html']
+            text = content["text"]
+            html = content["html"]
 
             # Circle names should appear once each, not once per joiner
-            assert text.count('Circle X') == 1, "Circle X should not be repeated per joiner"
-            assert text.count('Circle Y') == 1, "Circle Y should not be repeated per joiner"
+            assert text.count("Circle X") == 1, "Circle X should not be repeated per joiner"
+            assert text.count("Circle Y") == 1, "Circle Y should not be repeated per joiner"
 
             # Should show correct plural/singular phrasing
-            assert '3 people' in text
-            assert '1 person' in text
+            assert "3 people" in text
+            assert "1 person" in text
 
             # All joiner names should be listed
-            assert 'Alice' in text
-            assert 'Bob' in text
-            assert 'Celeste' in text
+            assert "Alice" in text
+            assert "Bob" in text
+            assert "Celeste" in text
 
             # HTML should say "View circle", not "View activity", for circle joins
-            assert 'View circle' in html
-            assert 'View activity' not in html
+            assert "View circle" in html
+            assert "View activity" not in html
 
     def test_send_digest_email_returns_false_when_no_events(self, app):
         """Test that send_digest_email returns False and skips sending when payload has no events."""
         with app.app_context():
-            user = UserFactory(first_name='Digest', digest_frequency='weekly')
+            user = UserFactory(first_name="Digest", digest_frequency="weekly")
             payload = {
-                'summary_stats': {
-                    'total_new_items': 0,
-                    'giveaways_count': 0,
-                    'borrow_requests_count': 0,
+                "summary_stats": {
+                    "total_new_items": 0,
+                    "giveaways_count": 0,
+                    "borrow_requests_count": 0,
                 },
-                'events': [],
-                'giveaways': [],
-                'requests': [],
-                'circle_joins': [],
-                'loans': [],
+                "events": [],
+                "giveaways": [],
+                "requests": [],
+                "circle_joins": [],
+                "loans": [],
             }
 
-            with patch('app.utils.email.send_email') as mock_send_email:
+            with patch("app.utils.email.send_email") as mock_send_email:
                 result = send_digest_email(user, payload)
 
                 # Should return False when no events exist
@@ -194,195 +234,195 @@ class TestEmailUtils:
 
     def test_build_digest_email_content_adds_same_window_resolution_labels(self, app):
         with app.app_context():
-            user = UserFactory(first_name='Digest', digest_frequency='daily')
+            user = UserFactory(first_name="Digest", digest_frequency="daily")
             payload = {
-                'summary_stats': {
-                    'total_new_items': 2,
-                    'giveaways_count': 1,
-                    'borrow_requests_count': 1,
+                "summary_stats": {
+                    "total_new_items": 2,
+                    "giveaways_count": 1,
+                    "borrow_requests_count": 1,
                 },
-                'events': [
+                "events": [
                     {
-                        'event_type': 'giveaway',
-                        'item_id': uuid.uuid4(),
-                        'actor_name': 'Alex',
-                        'title': 'Free Chair',
-                        'description': 'Great chair in good condition',
-                        'image_url': 'https://example.com/chair.jpg',
-                        'action': 'posted a giveaway',
-                        'digest_variant': 'new-resolved-in-window',
-                        'resolution_status': 'claimed',
+                        "event_type": "giveaway",
+                        "item_id": uuid.uuid4(),
+                        "actor_name": "Alex",
+                        "title": "Free Chair",
+                        "description": "Great chair in good condition",
+                        "image_url": "https://example.com/chair.jpg",
+                        "action": "posted a giveaway",
+                        "digest_variant": "new-resolved-in-window",
+                        "resolution_status": "claimed",
                     },
                     {
-                        'event_type': 'request',
-                        'request_id': uuid.uuid4(),
-                        'actor_name': 'Taylor',
-                        'title': 'Need a ladder',
-                        'description': 'Need for one weekend project',
-                        'image_url': None,
-                        'action': 'requested',
-                        'digest_variant': 'new-resolved-in-window',
-                        'resolution_status': 'fulfilled',
+                        "event_type": "request",
+                        "request_id": uuid.uuid4(),
+                        "actor_name": "Taylor",
+                        "title": "Need a ladder",
+                        "description": "Need for one weekend project",
+                        "image_url": None,
+                        "action": "requested",
+                        "digest_variant": "new-resolved-in-window",
+                        "resolution_status": "fulfilled",
                     },
                 ],
-                'giveaways': [
+                "giveaways": [
                     {
-                        'event_type': 'giveaway',
-                        'item_id': uuid.uuid4(),
-                        'actor_name': 'Alex',
-                        'title': 'Free Chair',
-                        'description': 'Great chair in good condition',
-                        'image_url': 'https://example.com/chair.jpg',
-                        'action': 'posted a giveaway',
-                        'digest_variant': 'new-resolved-in-window',
-                        'resolution_status': 'claimed',
+                        "event_type": "giveaway",
+                        "item_id": uuid.uuid4(),
+                        "actor_name": "Alex",
+                        "title": "Free Chair",
+                        "description": "Great chair in good condition",
+                        "image_url": "https://example.com/chair.jpg",
+                        "action": "posted a giveaway",
+                        "digest_variant": "new-resolved-in-window",
+                        "resolution_status": "claimed",
                     }
                 ],
-                'requests': [
+                "requests": [
                     {
-                        'event_type': 'request',
-                        'request_id': uuid.uuid4(),
-                        'actor_name': 'Taylor',
-                        'title': 'Need a ladder',
-                        'description': 'Need for one weekend project',
-                        'image_url': None,
-                        'action': 'requested',
-                        'digest_variant': 'new-resolved-in-window',
-                        'resolution_status': 'fulfilled',
+                        "event_type": "request",
+                        "request_id": uuid.uuid4(),
+                        "actor_name": "Taylor",
+                        "title": "Need a ladder",
+                        "description": "Need for one weekend project",
+                        "image_url": None,
+                        "action": "requested",
+                        "digest_variant": "new-resolved-in-window",
+                        "resolution_status": "fulfilled",
                     }
                 ],
-                'circle_joins': [],
-                'loans': [],
+                "circle_joins": [],
+                "loans": [],
             }
 
             content = build_digest_email_content(
                 user,
                 payload,
-                manage_url='https://example.com/digest/manage/token123',
-                unsubscribe_url='https://example.com/digest/unsubscribe/token123',
+                manage_url="https://example.com/digest/manage/token123",
+                unsubscribe_url="https://example.com/digest/unsubscribe/token123",
             )
 
-            assert 'Alex posted a giveaway: Free Chair [Claimed]' in content['text']
-            assert 'Taylor requested: Need a ladder [Fulfilled]' in content['text']
-            assert '>Claimed</span>' in content['html']
-            assert '>Fulfilled</span>' in content['html']
+            assert "Alex posted a giveaway: Free Chair [Claimed]" in content["text"]
+            assert "Taylor requested: Need a ladder [Fulfilled]" in content["text"]
+            assert ">Claimed</span>" in content["html"]
+            assert ">Fulfilled</span>" in content["html"]
 
     def test_build_digest_email_content_renders_resolution_only_copy(self, app):
         with app.app_context():
-            user = UserFactory(first_name='Digest', digest_frequency='weekly')
+            user = UserFactory(first_name="Digest", digest_frequency="weekly")
             giveaway_id = uuid.uuid4()
             request_id = uuid.uuid4()
             payload = {
-                'summary_stats': {
-                    'total_new_items': 0,
-                    'giveaways_count': 0,
-                    'borrow_requests_count': 0,
+                "summary_stats": {
+                    "total_new_items": 0,
+                    "giveaways_count": 0,
+                    "borrow_requests_count": 0,
                 },
-                'events': [
+                "events": [
                     {
-                        'event_type': 'giveaway',
-                        'item_id': giveaway_id,
-                        'actor_name': 'Alex',
-                        'title': 'Free Chair',
-                        'description': 'This should not be repeated',
-                        'image_url': 'https://example.com/chair.jpg',
-                        'action': 'posted a giveaway',
-                        'digest_variant': 'resolved-in-window',
-                        'resolution_status': 'claimed',
+                        "event_type": "giveaway",
+                        "item_id": giveaway_id,
+                        "actor_name": "Alex",
+                        "title": "Free Chair",
+                        "description": "This should not be repeated",
+                        "image_url": "https://example.com/chair.jpg",
+                        "action": "posted a giveaway",
+                        "digest_variant": "resolved-in-window",
+                        "resolution_status": "claimed",
                     },
                     {
-                        'event_type': 'request',
-                        'request_id': request_id,
-                        'actor_name': 'Taylor',
-                        'title': 'Need a ladder',
-                        'description': 'This should not be repeated',
-                        'image_url': None,
-                        'action': 'requested',
-                        'digest_variant': 'resolved-in-window',
-                        'resolution_status': 'fulfilled',
+                        "event_type": "request",
+                        "request_id": request_id,
+                        "actor_name": "Taylor",
+                        "title": "Need a ladder",
+                        "description": "This should not be repeated",
+                        "image_url": None,
+                        "action": "requested",
+                        "digest_variant": "resolved-in-window",
+                        "resolution_status": "fulfilled",
                     },
                 ],
-                'giveaways': [
+                "giveaways": [
                     {
-                        'event_type': 'giveaway',
-                        'item_id': giveaway_id,
-                        'actor_name': 'Alex',
-                        'title': 'Free Chair',
-                        'description': 'This should not be repeated',
-                        'image_url': 'https://example.com/chair.jpg',
-                        'action': 'posted a giveaway',
-                        'digest_variant': 'resolved-in-window',
-                        'resolution_status': 'claimed',
+                        "event_type": "giveaway",
+                        "item_id": giveaway_id,
+                        "actor_name": "Alex",
+                        "title": "Free Chair",
+                        "description": "This should not be repeated",
+                        "image_url": "https://example.com/chair.jpg",
+                        "action": "posted a giveaway",
+                        "digest_variant": "resolved-in-window",
+                        "resolution_status": "claimed",
                     }
                 ],
-                'requests': [
+                "requests": [
                     {
-                        'event_type': 'request',
-                        'request_id': request_id,
-                        'actor_name': 'Taylor',
-                        'title': 'Need a ladder',
-                        'description': 'This should not be repeated',
-                        'image_url': None,
-                        'action': 'requested',
-                        'digest_variant': 'resolved-in-window',
-                        'resolution_status': 'fulfilled',
+                        "event_type": "request",
+                        "request_id": request_id,
+                        "actor_name": "Taylor",
+                        "title": "Need a ladder",
+                        "description": "This should not be repeated",
+                        "image_url": None,
+                        "action": "requested",
+                        "digest_variant": "resolved-in-window",
+                        "resolution_status": "fulfilled",
                     }
                 ],
-                'circle_joins': [],
-                'loans': [],
+                "circle_joins": [],
+                "loans": [],
             }
 
             content = build_digest_email_content(
                 user,
                 payload,
-                manage_url='https://example.com/digest/manage/token123',
-                unsubscribe_url='https://example.com/digest/unsubscribe/token123',
+                manage_url="https://example.com/digest/manage/token123",
+                unsubscribe_url="https://example.com/digest/unsubscribe/token123",
             )
 
-            assert 'Alex: Free Chair was claimed' in content['text']
-            assert 'Taylor: Need a ladder was marked fulfilled' in content['text']
-            assert 'This should not be repeated' not in content['text']
-            assert 'Image: https://example.com/chair.jpg' not in content['text']
-            assert 'Free Chair was claimed' in content['html']
-            assert 'Need a ladder was marked fulfilled' in content['html']
+            assert "Alex: Free Chair was claimed" in content["text"]
+            assert "Taylor: Need a ladder was marked fulfilled" in content["text"]
+            assert "This should not be repeated" not in content["text"]
+            assert "Image: https://example.com/chair.jpg" not in content["text"]
+            assert "Free Chair was claimed" in content["html"]
+            assert "Need a ladder was marked fulfilled" in content["html"]
 
     def test_send_digest_email_sends_when_payload_has_only_resolution_events(self, app):
         with app.app_context():
-            user = UserFactory(first_name='Digest', digest_frequency='weekly')
+            user = UserFactory(first_name="Digest", digest_frequency="weekly")
             payload = {
-                'summary_stats': {
-                    'total_new_items': 0,
-                    'giveaways_count': 0,
-                    'borrow_requests_count': 0,
+                "summary_stats": {
+                    "total_new_items": 0,
+                    "giveaways_count": 0,
+                    "borrow_requests_count": 0,
                 },
-                'events': [
+                "events": [
                     {
-                        'event_type': 'giveaway',
-                        'item_id': uuid.uuid4(),
-                        'actor_name': 'Alex',
-                        'title': 'Free Chair',
-                        'action': 'posted a giveaway',
-                        'digest_variant': 'resolved-in-window',
-                        'resolution_status': 'claimed',
+                        "event_type": "giveaway",
+                        "item_id": uuid.uuid4(),
+                        "actor_name": "Alex",
+                        "title": "Free Chair",
+                        "action": "posted a giveaway",
+                        "digest_variant": "resolved-in-window",
+                        "resolution_status": "claimed",
                     }
                 ],
-                'giveaways': [
+                "giveaways": [
                     {
-                        'event_type': 'giveaway',
-                        'item_id': uuid.uuid4(),
-                        'actor_name': 'Alex',
-                        'title': 'Free Chair',
-                        'action': 'posted a giveaway',
-                        'digest_variant': 'resolved-in-window',
-                        'resolution_status': 'claimed',
+                        "event_type": "giveaway",
+                        "item_id": uuid.uuid4(),
+                        "actor_name": "Alex",
+                        "title": "Free Chair",
+                        "action": "posted a giveaway",
+                        "digest_variant": "resolved-in-window",
+                        "resolution_status": "claimed",
                     }
                 ],
-                'requests': [],
-                'circle_joins': [],
-                'loans': [],
+                "requests": [],
+                "circle_joins": [],
+                "loans": [],
             }
 
-            with patch('app.utils.email.send_email') as mock_send_email:
+            with patch("app.utils.email.send_email") as mock_send_email:
                 mock_send_email.return_value = True
 
                 result = send_digest_email(user, payload)

--- a/tests/unit/test_home_feed.py
+++ b/tests/unit/test_home_feed.py
@@ -1,45 +1,51 @@
-from datetime import date, datetime, UTC, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from app import db
 from app.models import LoanRequest
 from app.utils.home_feed import (
-    build_recent_lent_events,
     build_digest_payload,
-    build_visible_requests_events,
+    build_recent_lent_events,
     build_visible_giveaway_events,
+    build_visible_requests_events,
     consolidate_circle_join_activity,
 )
-from tests.factories import CategoryFactory, CircleFactory, ItemFactory, UserFactory, ItemRequestFactory
+from tests.factories import (
+    CategoryFactory,
+    CircleFactory,
+    ItemFactory,
+    ItemRequestFactory,
+    UserFactory,
+)
 
 
 def test_consolidate_circle_join_activity_merges_by_user():
     join_rows = [
         {
-            'user_id': 'user-1',
-            'user_name': 'Alex Doe',
-            'circle_id': 'circle-large',
-            'circle_name': 'Large Circle',
-            'created_at': None,
+            "user_id": "user-1",
+            "user_name": "Alex Doe",
+            "circle_id": "circle-large",
+            "circle_name": "Large Circle",
+            "created_at": None,
         },
         {
-            'user_id': 'user-1',
-            'user_name': 'Alex Doe',
-            'circle_id': 'circle-small',
-            'circle_name': 'Small Circle',
-            'created_at': None,
+            "user_id": "user-1",
+            "user_name": "Alex Doe",
+            "circle_id": "circle-small",
+            "circle_name": "Small Circle",
+            "created_at": None,
         },
     ]
     circle_sizes = {
-        'circle-large': 9,
-        'circle-small': 3,
+        "circle-large": 9,
+        "circle-small": 3,
     }
 
     events = consolidate_circle_join_activity(join_rows, circle_sizes)
 
     assert len(events) == 1
-    assert events[0]['circle_id'] == 'circle-small'
-    assert events[0]['extra_circle_count'] == 1
-    assert ' + 1 more of your circles' in events[0]['title']
+    assert events[0]["circle_id"] == "circle-small"
+    assert events[0]["extra_circle_count"] == 1
+    assert " + 1 more of your circles" in events[0]["title"]
 
 
 def test_build_visible_giveaway_events_defaults_to_20_miles(app):
@@ -55,17 +61,17 @@ def test_build_visible_giveaway_events_defaults_to_20_miles(app):
             owner=near_owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='unclaimed',
-            name='Nearby Giveaway',
+            giveaway_visibility="default",
+            claim_status="unclaimed",
+            name="Nearby Giveaway",
         )
         far_item = ItemFactory(
             owner=far_owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='unclaimed',
-            name='Far Giveaway',
+            giveaway_visibility="default",
+            claim_status="unclaimed",
+            name="Far Giveaway",
         )
         db.session.commit()
 
@@ -77,7 +83,7 @@ def test_build_visible_giveaway_events_defaults_to_20_miles(app):
             max_distance=None,
             distance_explicit=False,
         )
-        default_item_ids = {event['item_id'] for event in default_events}
+        default_item_ids = {event["item_id"] for event in default_events}
 
         explicit_no_distance_events = build_visible_giveaway_events(
             viewer,
@@ -85,7 +91,7 @@ def test_build_visible_giveaway_events_defaults_to_20_miles(app):
             max_distance=None,
             distance_explicit=True,
         )
-        explicit_item_ids = {event['item_id'] for event in explicit_no_distance_events}
+        explicit_item_ids = {event["item_id"] for event in explicit_no_distance_events}
 
         assert near_item.id in default_item_ids
         assert far_item.id not in default_item_ids
@@ -107,21 +113,21 @@ def test_build_visible_giveaway_events_include_recently_claimed_items(app):
             owner=owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='claimed',
+            giveaway_visibility="default",
+            claim_status="claimed",
             claimed_by=claimer,
             claimed_at=now - timedelta(days=2),
-            name='Recently Claimed Giveaway',
+            name="Recently Claimed Giveaway",
         )
         old_claimed_item = ItemFactory(
             owner=owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='claimed',
+            giveaway_visibility="default",
+            claim_status="claimed",
             claimed_by=claimer,
             claimed_at=now - timedelta(days=8),
-            name='Old Claimed Giveaway',
+            name="Old Claimed Giveaway",
         )
         db.session.commit()
 
@@ -130,32 +136,32 @@ def test_build_visible_giveaway_events_include_recently_claimed_items(app):
             scoped_circle_ids={circle.id},
         )
 
-        item_ids = {event['item_id'] for event in events}
+        item_ids = {event["item_id"] for event in events}
         assert claimed_item.id in item_ids
         assert old_claimed_item.id not in item_ids
 
-        claimed_event = next(event for event in events if event['item_id'] == claimed_item.id)
-        assert claimed_event['claim_status'] == 'claimed'
-        assert claimed_event['action'] == 'gave away'
-        assert claimed_event['created_at'] == claimed_item.claimed_at.replace(tzinfo=UTC)
+        claimed_event = next(event for event in events if event["item_id"] == claimed_item.id)
+        assert claimed_event["claim_status"] == "claimed"
+        assert claimed_event["action"] == "gave away"
+        assert claimed_event["created_at"] == claimed_item.claimed_at.replace(tzinfo=UTC)
 
 
 def test_build_recent_lent_events_hides_borrower_identity(app):
     with app.app_context():
         viewer = UserFactory()
         owner = UserFactory()
-        borrower = UserFactory(first_name='VeryUniqueBorrower', last_name='Name')
+        borrower = UserFactory(first_name="VeryUniqueBorrower", last_name="Name")
         category = CategoryFactory()
         circle = CircleFactory()
         circle.members.extend([viewer, owner, borrower])
 
-        item = ItemFactory(owner=owner, category=category, name='Shared Drill')
+        item = ItemFactory(owner=owner, category=category, name="Shared Drill")
         loan = LoanRequest(
             item_id=item.id,
             borrower_id=borrower.id,
             start_date=date.today(),
             end_date=date.today(),
-            status='approved',
+            status="approved",
         )
         db.session.add(loan)
         db.session.commit()
@@ -164,9 +170,9 @@ def test_build_recent_lent_events_hides_borrower_identity(app):
 
         assert len(events) == 1
         event = events[0]
-        assert event['event_type'] == 'lent'
-        assert 'borrower_name' not in event
-        assert 'VeryUniqueBorrower' not in event['actor_name']
+        assert event["event_type"] == "lent"
+        assert "borrower_name" not in event
+        assert "VeryUniqueBorrower" not in event["actor_name"]
 
 
 def test_build_visible_requests_events_defaults_to_20_miles_for_geocoded_user(app):
@@ -177,8 +183,12 @@ def test_build_visible_requests_events_defaults_to_20_miles_for_geocoded_user(ap
         circle = CircleFactory()
         circle.members.extend([viewer, near_requester, far_requester])
 
-        near_request = ItemRequestFactory(user=near_requester, title='Nearby Request', visibility='public')
-        far_request = ItemRequestFactory(user=far_requester, title='Far Request', visibility='public')
+        near_request = ItemRequestFactory(
+            user=near_requester, title="Nearby Request", visibility="public"
+        )
+        far_request = ItemRequestFactory(
+            user=far_requester, title="Far Request", visibility="public"
+        )
         db.session.commit()
 
         scoped_circle_ids = {circle.id}
@@ -186,20 +196,20 @@ def test_build_visible_requests_events_defaults_to_20_miles_for_geocoded_user(ap
         default_events = build_visible_requests_events(
             viewer,
             scoped_circle_ids=scoped_circle_ids,
-            scope='all',
+            scope="all",
             max_distance=None,
             distance_explicit=False,
         )
-        default_request_ids = {event['request_id'] for event in default_events}
+        default_request_ids = {event["request_id"] for event in default_events}
 
         explicit_no_distance_events = build_visible_requests_events(
             viewer,
             scoped_circle_ids=scoped_circle_ids,
-            scope='all',
+            scope="all",
             max_distance=None,
             distance_explicit=True,
         )
-        explicit_request_ids = {event['request_id'] for event in explicit_no_distance_events}
+        explicit_request_ids = {event["request_id"] for event in explicit_no_distance_events}
 
         assert near_request.id in default_request_ids
         assert far_request.id not in default_request_ids
@@ -227,24 +237,24 @@ def test_build_digest_payload_respects_window_and_include_toggles(app):
             owner=owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='unclaimed',
-            name='In Window Giveaway',
+            giveaway_visibility="default",
+            claim_status="unclaimed",
+            name="In Window Giveaway",
             created_at=now - timedelta(hours=2),
         )
         ItemFactory(
             owner=owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='unclaimed',
-            name='Old Giveaway',
+            giveaway_visibility="default",
+            claim_status="unclaimed",
+            name="Old Giveaway",
             created_at=now - timedelta(days=5),
         )
         ItemRequestFactory(
             user=owner,
-            title='Borrow Saw',
-            visibility='circles',
+            title="Borrow Saw",
+            visibility="circles",
             created_at=now - timedelta(hours=1),
         )
         db.session.commit()
@@ -255,11 +265,11 @@ def test_build_digest_payload_respects_window_and_include_toggles(app):
             until=now,
         )
 
-        assert len(payload['giveaways']) == 1
-        assert payload['giveaways'][0]['item_id'] == in_window_item.id
-        assert payload['requests'] == []
-        assert payload['circle_joins'] == []
-        assert payload['loans'] == []
+        assert len(payload["giveaways"]) == 1
+        assert payload["giveaways"][0]["item_id"] == in_window_item.id
+        assert payload["requests"] == []
+        assert payload["circle_joins"] == []
+        assert payload["loans"] == []
 
 
 def test_build_digest_payload_summary_stats_counts_requests_and_giveaways(app):
@@ -282,22 +292,22 @@ def test_build_digest_payload_summary_stats_counts_requests_and_giveaways(app):
             owner=owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='unclaimed',
+            giveaway_visibility="default",
+            claim_status="unclaimed",
             created_at=now - timedelta(hours=2),
         )
         ItemRequestFactory(
             user=owner,
-            visibility='circles',
+            visibility="circles",
             created_at=now - timedelta(hours=1),
         )
         db.session.commit()
 
         payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
 
-        assert payload['summary_stats']['giveaways_count'] == 1
-        assert payload['summary_stats']['borrow_requests_count'] == 1
-        assert payload['summary_stats']['total_new_items'] == 2
+        assert payload["summary_stats"]["giveaways_count"] == 1
+        assert payload["summary_stats"]["borrow_requests_count"] == 1
+        assert payload["summary_stats"]["total_new_items"] == 2
 
 
 def test_build_digest_payload_keeps_same_window_fulfilled_request_in_requests_section(app):
@@ -316,8 +326,8 @@ def test_build_digest_payload_keeps_same_window_fulfilled_request_in_requests_se
         now = datetime.now(UTC)
         item_request = ItemRequestFactory(
             user=requester,
-            visibility='circles',
-            status='fulfilled',
+            visibility="circles",
+            status="fulfilled",
             created_at=now - timedelta(hours=6),
             fulfilled_at=now - timedelta(hours=1),
         )
@@ -325,16 +335,16 @@ def test_build_digest_payload_keeps_same_window_fulfilled_request_in_requests_se
 
         payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
 
-        assert len(payload['requests']) == 1
-        event = payload['requests'][0]
-        assert event['request_id'] == item_request.id
-        assert event['digest_variant'] == 'new-resolved-in-window'
-        assert event['created_at'] == item_request.created_at.replace(tzinfo=UTC)
-        assert event['started_at'] == item_request.created_at.replace(tzinfo=UTC)
-        assert event['resolved_at'] == item_request.fulfilled_at.replace(tzinfo=UTC)
-        assert event['resolution_status'] == 'fulfilled'
-        assert payload['summary_stats']['borrow_requests_count'] == 1
-        assert payload['summary_stats']['total_new_items'] == 1
+        assert len(payload["requests"]) == 1
+        event = payload["requests"][0]
+        assert event["request_id"] == item_request.id
+        assert event["digest_variant"] == "new-resolved-in-window"
+        assert event["created_at"] == item_request.created_at.replace(tzinfo=UTC)
+        assert event["started_at"] == item_request.created_at.replace(tzinfo=UTC)
+        assert event["resolved_at"] == item_request.fulfilled_at.replace(tzinfo=UTC)
+        assert event["resolution_status"] == "fulfilled"
+        assert payload["summary_stats"]["borrow_requests_count"] == 1
+        assert payload["summary_stats"]["total_new_items"] == 1
 
 
 def test_build_digest_payload_emits_resolution_only_request_event(app):
@@ -353,8 +363,8 @@ def test_build_digest_payload_emits_resolution_only_request_event(app):
         now = datetime.now(UTC)
         item_request = ItemRequestFactory(
             user=requester,
-            visibility='circles',
-            status='fulfilled',
+            visibility="circles",
+            status="fulfilled",
             created_at=now - timedelta(days=4),
             fulfilled_at=now - timedelta(hours=2),
         )
@@ -362,15 +372,15 @@ def test_build_digest_payload_emits_resolution_only_request_event(app):
 
         payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
 
-        assert len(payload['requests']) == 1
-        event = payload['requests'][0]
-        assert event['request_id'] == item_request.id
-        assert event['digest_variant'] == 'resolved-in-window'
-        assert event['created_at'] == item_request.fulfilled_at.replace(tzinfo=UTC)
-        assert event['started_at'] == item_request.created_at.replace(tzinfo=UTC)
-        assert event['resolved_at'] == item_request.fulfilled_at.replace(tzinfo=UTC)
-        assert payload['summary_stats']['borrow_requests_count'] == 0
-        assert payload['summary_stats']['total_new_items'] == 0
+        assert len(payload["requests"]) == 1
+        event = payload["requests"][0]
+        assert event["request_id"] == item_request.id
+        assert event["digest_variant"] == "resolved-in-window"
+        assert event["created_at"] == item_request.fulfilled_at.replace(tzinfo=UTC)
+        assert event["started_at"] == item_request.created_at.replace(tzinfo=UTC)
+        assert event["resolved_at"] == item_request.fulfilled_at.replace(tzinfo=UTC)
+        assert payload["summary_stats"]["borrow_requests_count"] == 0
+        assert payload["summary_stats"]["total_new_items"] == 0
 
 
 def test_build_digest_payload_keeps_same_window_claimed_giveaway_in_giveaways_section(app):
@@ -392,10 +402,10 @@ def test_build_digest_payload_keeps_same_window_claimed_giveaway_in_giveaways_se
             owner=owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='claimed',
+            giveaway_visibility="default",
+            claim_status="claimed",
             available=False,
-            name='Claimed in Window',
+            name="Claimed in Window",
             created_at=now - timedelta(hours=5),
             claimed_at=now - timedelta(hours=1),
         )
@@ -403,16 +413,16 @@ def test_build_digest_payload_keeps_same_window_claimed_giveaway_in_giveaways_se
 
         payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
 
-        assert len(payload['giveaways']) == 1
-        event = payload['giveaways'][0]
-        assert event['item_id'] == item.id
-        assert event['digest_variant'] == 'new-resolved-in-window'
-        assert event['created_at'] == item.created_at.replace(tzinfo=UTC)
-        assert event['started_at'] == item.created_at.replace(tzinfo=UTC)
-        assert event['resolved_at'] == item.claimed_at.replace(tzinfo=UTC)
-        assert event['resolution_status'] == 'claimed'
-        assert payload['summary_stats']['giveaways_count'] == 1
-        assert payload['summary_stats']['total_new_items'] == 1
+        assert len(payload["giveaways"]) == 1
+        event = payload["giveaways"][0]
+        assert event["item_id"] == item.id
+        assert event["digest_variant"] == "new-resolved-in-window"
+        assert event["created_at"] == item.created_at.replace(tzinfo=UTC)
+        assert event["started_at"] == item.created_at.replace(tzinfo=UTC)
+        assert event["resolved_at"] == item.claimed_at.replace(tzinfo=UTC)
+        assert event["resolution_status"] == "claimed"
+        assert payload["summary_stats"]["giveaways_count"] == 1
+        assert payload["summary_stats"]["total_new_items"] == 1
 
 
 def test_build_digest_payload_emits_resolution_only_claimed_giveaway_event(app):
@@ -434,10 +444,10 @@ def test_build_digest_payload_emits_resolution_only_claimed_giveaway_event(app):
             owner=owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='claimed',
+            giveaway_visibility="default",
+            claim_status="claimed",
             available=False,
-            name='Claimed Later',
+            name="Claimed Later",
             created_at=now - timedelta(days=3),
             claimed_at=now - timedelta(hours=3),
         )
@@ -445,15 +455,15 @@ def test_build_digest_payload_emits_resolution_only_claimed_giveaway_event(app):
 
         payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
 
-        assert len(payload['giveaways']) == 1
-        event = payload['giveaways'][0]
-        assert event['item_id'] == item.id
-        assert event['digest_variant'] == 'resolved-in-window'
-        assert event['created_at'] == item.claimed_at.replace(tzinfo=UTC)
-        assert event['started_at'] == item.created_at.replace(tzinfo=UTC)
-        assert event['resolved_at'] == item.claimed_at.replace(tzinfo=UTC)
-        assert payload['summary_stats']['giveaways_count'] == 0
-        assert payload['summary_stats']['total_new_items'] == 0
+        assert len(payload["giveaways"]) == 1
+        event = payload["giveaways"][0]
+        assert event["item_id"] == item.id
+        assert event["digest_variant"] == "resolved-in-window"
+        assert event["created_at"] == item.claimed_at.replace(tzinfo=UTC)
+        assert event["started_at"] == item.created_at.replace(tzinfo=UTC)
+        assert event["resolved_at"] == item.claimed_at.replace(tzinfo=UTC)
+        assert payload["summary_stats"]["giveaways_count"] == 0
+        assert payload["summary_stats"]["total_new_items"] == 0
 
 
 def test_build_digest_payload_toggles_suppress_request_and_giveaway_resolution_events(app):
@@ -476,16 +486,16 @@ def test_build_digest_payload_toggles_suppress_request_and_giveaway_resolution_e
             owner=owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='claimed',
+            giveaway_visibility="default",
+            claim_status="claimed",
             available=False,
             created_at=now - timedelta(days=2),
             claimed_at=now - timedelta(hours=2),
         )
         ItemRequestFactory(
             user=owner,
-            visibility='circles',
-            status='fulfilled',
+            visibility="circles",
+            status="fulfilled",
             created_at=now - timedelta(days=2),
             fulfilled_at=now - timedelta(hours=1),
         )
@@ -493,9 +503,9 @@ def test_build_digest_payload_toggles_suppress_request_and_giveaway_resolution_e
 
         payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
 
-        assert payload['events'] == []
-        assert payload['giveaways'] == []
-        assert payload['requests'] == []
+        assert payload["events"] == []
+        assert payload["giveaways"] == []
+        assert payload["requests"] == []
 
 
 def test_build_digest_payload_summary_stats_exclude_resolution_only_events(app):
@@ -518,16 +528,16 @@ def test_build_digest_payload_summary_stats_exclude_resolution_only_events(app):
             owner=owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='claimed',
+            giveaway_visibility="default",
+            claim_status="claimed",
             available=False,
             created_at=now - timedelta(days=3),
             claimed_at=now - timedelta(hours=2),
         )
         ItemRequestFactory(
             user=owner,
-            visibility='circles',
-            status='fulfilled',
+            visibility="circles",
+            status="fulfilled",
             created_at=now - timedelta(hours=6),
             fulfilled_at=now - timedelta(hours=1),
         )
@@ -535,10 +545,10 @@ def test_build_digest_payload_summary_stats_exclude_resolution_only_events(app):
 
         payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
 
-        assert len(payload['events']) == 2
-        assert payload['summary_stats']['giveaways_count'] == 0
-        assert payload['summary_stats']['borrow_requests_count'] == 1
-        assert payload['summary_stats']['total_new_items'] == 1
+        assert len(payload["events"]) == 2
+        assert payload["summary_stats"]["giveaways_count"] == 0
+        assert payload["summary_stats"]["borrow_requests_count"] == 1
+        assert payload["summary_stats"]["total_new_items"] == 1
 
 
 def test_build_digest_payload_skips_pending_pickup_giveaway_without_claimed_at(app):
@@ -560,8 +570,8 @@ def test_build_digest_payload_skips_pending_pickup_giveaway_without_claimed_at(a
             owner=owner,
             category=category,
             is_giveaway=True,
-            giveaway_visibility='default',
-            claim_status='pending_pickup',
+            giveaway_visibility="default",
+            claim_status="pending_pickup",
             available=False,
             created_at=now - timedelta(days=2),
         )
@@ -569,5 +579,5 @@ def test_build_digest_payload_skips_pending_pickup_giveaway_without_claimed_at(a
 
         payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
 
-        assert payload['giveaways'] == []
-        assert payload['events'] == []
+        assert payload["giveaways"] == []
+        assert payload["events"] == []

--- a/tests/unit/test_home_feed.py
+++ b/tests/unit/test_home_feed.py
@@ -251,3 +251,276 @@ def test_build_digest_payload_summary_stats_counts_requests_and_giveaways(app):
         assert payload['summary_stats']['giveaways_count'] == 1
         assert payload['summary_stats']['borrow_requests_count'] == 1
         assert payload['summary_stats']['total_new_items'] == 2
+
+
+def test_build_digest_payload_keeps_same_window_fulfilled_request_in_requests_section(app):
+    with app.app_context():
+        viewer = UserFactory(
+            digest_include_giveaways=False,
+            digest_include_requests=True,
+            digest_include_circle_joins=False,
+            digest_include_loans=False,
+            digest_requests_include_public=False,
+        )
+        requester = UserFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, requester])
+
+        now = datetime.now(UTC)
+        item_request = ItemRequestFactory(
+            user=requester,
+            visibility='circles',
+            status='fulfilled',
+            created_at=now - timedelta(hours=6),
+            fulfilled_at=now - timedelta(hours=1),
+        )
+        db.session.commit()
+
+        payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
+
+        assert len(payload['requests']) == 1
+        event = payload['requests'][0]
+        assert event['request_id'] == item_request.id
+        assert event['digest_variant'] == 'new-resolved-in-window'
+        assert event['created_at'] == item_request.created_at.replace(tzinfo=UTC)
+        assert event['started_at'] == item_request.created_at.replace(tzinfo=UTC)
+        assert event['resolved_at'] == item_request.fulfilled_at.replace(tzinfo=UTC)
+        assert event['resolution_status'] == 'fulfilled'
+        assert payload['summary_stats']['borrow_requests_count'] == 1
+        assert payload['summary_stats']['total_new_items'] == 1
+
+
+def test_build_digest_payload_emits_resolution_only_request_event(app):
+    with app.app_context():
+        viewer = UserFactory(
+            digest_include_giveaways=False,
+            digest_include_requests=True,
+            digest_include_circle_joins=False,
+            digest_include_loans=False,
+            digest_requests_include_public=False,
+        )
+        requester = UserFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, requester])
+
+        now = datetime.now(UTC)
+        item_request = ItemRequestFactory(
+            user=requester,
+            visibility='circles',
+            status='fulfilled',
+            created_at=now - timedelta(days=4),
+            fulfilled_at=now - timedelta(hours=2),
+        )
+        db.session.commit()
+
+        payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
+
+        assert len(payload['requests']) == 1
+        event = payload['requests'][0]
+        assert event['request_id'] == item_request.id
+        assert event['digest_variant'] == 'resolved-in-window'
+        assert event['created_at'] == item_request.fulfilled_at.replace(tzinfo=UTC)
+        assert event['started_at'] == item_request.created_at.replace(tzinfo=UTC)
+        assert event['resolved_at'] == item_request.fulfilled_at.replace(tzinfo=UTC)
+        assert payload['summary_stats']['borrow_requests_count'] == 0
+        assert payload['summary_stats']['total_new_items'] == 0
+
+
+def test_build_digest_payload_keeps_same_window_claimed_giveaway_in_giveaways_section(app):
+    with app.app_context():
+        viewer = UserFactory(
+            digest_include_giveaways=True,
+            digest_include_requests=False,
+            digest_include_circle_joins=False,
+            digest_include_loans=False,
+            digest_giveaways_include_public=False,
+        )
+        owner = UserFactory()
+        category = CategoryFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, owner])
+
+        now = datetime.now(UTC)
+        item = ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility='default',
+            claim_status='claimed',
+            available=False,
+            name='Claimed in Window',
+            created_at=now - timedelta(hours=5),
+            claimed_at=now - timedelta(hours=1),
+        )
+        db.session.commit()
+
+        payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
+
+        assert len(payload['giveaways']) == 1
+        event = payload['giveaways'][0]
+        assert event['item_id'] == item.id
+        assert event['digest_variant'] == 'new-resolved-in-window'
+        assert event['created_at'] == item.created_at.replace(tzinfo=UTC)
+        assert event['started_at'] == item.created_at.replace(tzinfo=UTC)
+        assert event['resolved_at'] == item.claimed_at.replace(tzinfo=UTC)
+        assert event['resolution_status'] == 'claimed'
+        assert payload['summary_stats']['giveaways_count'] == 1
+        assert payload['summary_stats']['total_new_items'] == 1
+
+
+def test_build_digest_payload_emits_resolution_only_claimed_giveaway_event(app):
+    with app.app_context():
+        viewer = UserFactory(
+            digest_include_giveaways=True,
+            digest_include_requests=False,
+            digest_include_circle_joins=False,
+            digest_include_loans=False,
+            digest_giveaways_include_public=False,
+        )
+        owner = UserFactory()
+        category = CategoryFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, owner])
+
+        now = datetime.now(UTC)
+        item = ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility='default',
+            claim_status='claimed',
+            available=False,
+            name='Claimed Later',
+            created_at=now - timedelta(days=3),
+            claimed_at=now - timedelta(hours=3),
+        )
+        db.session.commit()
+
+        payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
+
+        assert len(payload['giveaways']) == 1
+        event = payload['giveaways'][0]
+        assert event['item_id'] == item.id
+        assert event['digest_variant'] == 'resolved-in-window'
+        assert event['created_at'] == item.claimed_at.replace(tzinfo=UTC)
+        assert event['started_at'] == item.created_at.replace(tzinfo=UTC)
+        assert event['resolved_at'] == item.claimed_at.replace(tzinfo=UTC)
+        assert payload['summary_stats']['giveaways_count'] == 0
+        assert payload['summary_stats']['total_new_items'] == 0
+
+
+def test_build_digest_payload_toggles_suppress_request_and_giveaway_resolution_events(app):
+    with app.app_context():
+        viewer = UserFactory(
+            digest_include_giveaways=False,
+            digest_include_requests=False,
+            digest_include_circle_joins=False,
+            digest_include_loans=False,
+            digest_giveaways_include_public=False,
+            digest_requests_include_public=False,
+        )
+        owner = UserFactory()
+        category = CategoryFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, owner])
+
+        now = datetime.now(UTC)
+        ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility='default',
+            claim_status='claimed',
+            available=False,
+            created_at=now - timedelta(days=2),
+            claimed_at=now - timedelta(hours=2),
+        )
+        ItemRequestFactory(
+            user=owner,
+            visibility='circles',
+            status='fulfilled',
+            created_at=now - timedelta(days=2),
+            fulfilled_at=now - timedelta(hours=1),
+        )
+        db.session.commit()
+
+        payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
+
+        assert payload['events'] == []
+        assert payload['giveaways'] == []
+        assert payload['requests'] == []
+
+
+def test_build_digest_payload_summary_stats_exclude_resolution_only_events(app):
+    with app.app_context():
+        viewer = UserFactory(
+            digest_include_giveaways=True,
+            digest_include_requests=True,
+            digest_include_circle_joins=False,
+            digest_include_loans=False,
+            digest_giveaways_include_public=False,
+            digest_requests_include_public=False,
+        )
+        owner = UserFactory()
+        category = CategoryFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, owner])
+
+        now = datetime.now(UTC)
+        ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility='default',
+            claim_status='claimed',
+            available=False,
+            created_at=now - timedelta(days=3),
+            claimed_at=now - timedelta(hours=2),
+        )
+        ItemRequestFactory(
+            user=owner,
+            visibility='circles',
+            status='fulfilled',
+            created_at=now - timedelta(hours=6),
+            fulfilled_at=now - timedelta(hours=1),
+        )
+        db.session.commit()
+
+        payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
+
+        assert len(payload['events']) == 2
+        assert payload['summary_stats']['giveaways_count'] == 0
+        assert payload['summary_stats']['borrow_requests_count'] == 1
+        assert payload['summary_stats']['total_new_items'] == 1
+
+
+def test_build_digest_payload_skips_pending_pickup_giveaway_without_claimed_at(app):
+    with app.app_context():
+        viewer = UserFactory(
+            digest_include_giveaways=True,
+            digest_include_requests=False,
+            digest_include_circle_joins=False,
+            digest_include_loans=False,
+            digest_giveaways_include_public=False,
+        )
+        owner = UserFactory()
+        category = CategoryFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, owner])
+
+        now = datetime.now(UTC)
+        ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility='default',
+            claim_status='pending_pickup',
+            available=False,
+            created_at=now - timedelta(days=2),
+        )
+        db.session.commit()
+
+        payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
+
+        assert payload['giveaways'] == []
+        assert payload['events'] == []

--- a/tests/unit/test_home_feed.py
+++ b/tests/unit/test_home_feed.py
@@ -93,6 +93,53 @@ def test_build_visible_giveaway_events_defaults_to_20_miles(app):
         assert far_item.id in explicit_item_ids
 
 
+def test_build_visible_giveaway_events_include_recently_claimed_items(app):
+    with app.app_context():
+        viewer = UserFactory()
+        owner = UserFactory()
+        claimer = UserFactory()
+        category = CategoryFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, owner, claimer])
+
+        now = datetime.now(UTC)
+        claimed_item = ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility='default',
+            claim_status='claimed',
+            claimed_by=claimer,
+            claimed_at=now - timedelta(days=2),
+            name='Recently Claimed Giveaway',
+        )
+        old_claimed_item = ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility='default',
+            claim_status='claimed',
+            claimed_by=claimer,
+            claimed_at=now - timedelta(days=8),
+            name='Old Claimed Giveaway',
+        )
+        db.session.commit()
+
+        events = build_visible_giveaway_events(
+            viewer,
+            scoped_circle_ids={circle.id},
+        )
+
+        item_ids = {event['item_id'] for event in events}
+        assert claimed_item.id in item_ids
+        assert old_claimed_item.id not in item_ids
+
+        claimed_event = next(event for event in events if event['item_id'] == claimed_item.id)
+        assert claimed_event['claim_status'] == 'claimed'
+        assert claimed_event['action'] == 'gave away'
+        assert claimed_event['created_at'] == claimed_item.claimed_at.replace(tzinfo=UTC)
+
+
 def test_build_recent_lent_events_hides_borrower_identity(app):
     with app.app_context():
         viewer = UserFactory()


### PR DESCRIPTION
Fixes #290

Now resolution events, i.e., a giveaway is claimed or a request is fulfilled, appear in email digests. If open and close events happen within the window of a single email, they are bundled together. And then the resolution events now appear in the application home feed as well.

Also since I just added pre-commit checks, there are a ton of unrelated changes due to linting. And I touched some of the pre-commit files here. The gist there is that I need pre-commit check on the PR to match what runs locally and they were checking different things.

Thus two changelog entries for the same PR.