### PR TITLE
feat: support Canadian addresses, send address to Nominatim as components instead of one big string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Profiles, loan-request conversations, and giveaway requester views now show the circles you have in common with the other user, with linked circle badges for quick context and an explicit empty state when a giveaway requester shares no circles with you ([#345](https://github.com/sfirke/meutch/pull/345)).
 - Digest emails now surface fulfilled requests and claimed giveaways, including clear labels when an item is both created and resolved within the same digest window ([#339](https://github.com/sfirke/meutch/pull/339)).
 - Admin panel now separates user management from analytics, with a new Monthly Active Users chart that tracks qualifying activity from January 2026 onward ([#342](https://github.com/sfirke/meutch/pull/342)).
-- Address entry forms now use Canada-friendly "State/Province" and "Postal Code" wording while keeping the existing geocoding flow and US-focused default examples ([#362](https://github.com/sfirke/meutch/pull/362)).
+- Address entry forms now use Canada-friendly "State/Province" and "Postal Code" wording, plus country dropdowns that put the United States of America and Canada first while keeping the existing geocoding flow ([#362](https://github.com/sfirke/meutch/pull/362)).
 
 ### Developer Experience
 - Massive refactor that split `routes.py` into many views and pushed the app logic down into a new service layer ([#352](https://github.com/sfirke/meutch/pull/352)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Address entry forms now use Canada-friendly "State/Province" and "Postal Code" wording, plus country dropdowns that put the United States of America and Canada first while keeping the existing geocoding flow ([#362](https://github.com/sfirke/meutch/pull/362)).
 
 ### Bug fixes
-- Geocoding now sends structured address components to Nominatim and retries without the postal code when that field blocks an otherwise valid street-level match, improving Canadian residential address lookups.
+- Geocoding now sends structured address components to Nominatim and retries without the postal code when that field blocks an otherwise valid street-level match ([#362](https://github.com/sfirke/meutch/pull/362)).
 
 ### Developer Experience
 - Massive refactor that split `routes.py` into many views and pushed the app logic down into a new service layer ([#352](https://github.com/sfirke/meutch/pull/352)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Admin panel now separates user management from analytics, with a new Monthly Active Users chart that tracks qualifying activity from January 2026 onward ([#342](https://github.com/sfirke/meutch/pull/342)).
 - Address entry forms now use Canada-friendly "State/Province" and "Postal Code" wording, plus country dropdowns that put the United States of America and Canada first while keeping the existing geocoding flow ([#362](https://github.com/sfirke/meutch/pull/362)).
 
+### Bug fixes
+- Geocoding now sends structured address components to Nominatim and retries without the postal code when that field blocks an otherwise valid street-level match, improving Canadian residential address lookups.
+
 ### Developer Experience
 - Massive refactor that split `routes.py` into many views and pushed the app logic down into a new service layer ([#352](https://github.com/sfirke/meutch/pull/352)).
 - Align local pre-push linting with CI by sharing the same branch-diff `pre-commit` runner and documenting the diff-scoped command ([#339](https://github.com/sfirke/meutch/pull/339)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Profiles, loan-request conversations, and giveaway requester views now show the circles you have in common with the other user, with linked circle badges for quick context and an explicit empty state when a giveaway requester shares no circles with you ([#345](https://github.com/sfirke/meutch/pull/345)).
 - Digest emails now surface fulfilled requests and claimed giveaways, including clear labels when an item is both created and resolved within the same digest window ([#339](https://github.com/sfirke/meutch/pull/339)).
 - Admin panel now separates user management from analytics, with a new Monthly Active Users chart that tracks qualifying activity from January 2026 onward ([#342](https://github.com/sfirke/meutch/pull/342)).
+- Address entry forms now use Canada-friendly "State/Province" and "Postal Code" wording while keeping the existing geocoding flow and US-focused default examples.
 
 ### Developer Experience
 - Massive refactor that split `routes.py` into many views and pushed the app logic down into a new service layer ([#352](https://github.com/sfirke/meutch/pull/352)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Profiles, loan-request conversations, and giveaway requester views now show the circles you have in common with the other user, with linked circle badges for quick context and an explicit empty state when a giveaway requester shares no circles with you ([#345](https://github.com/sfirke/meutch/pull/345)).
 - Digest emails now surface fulfilled requests and claimed giveaways, including clear labels when an item is both created and resolved within the same digest window ([#339](https://github.com/sfirke/meutch/pull/339)).
 - Admin panel now separates user management from analytics, with a new Monthly Active Users chart that tracks qualifying activity from January 2026 onward ([#342](https://github.com/sfirke/meutch/pull/342)).
-- Address entry forms now use Canada-friendly "State/Province" and "Postal Code" wording while keeping the existing geocoding flow and US-focused default examples.
+- Address entry forms now use Canada-friendly "State/Province" and "Postal Code" wording while keeping the existing geocoding flow and US-focused default examples ([#362](https://github.com/sfirke/meutch/pull/362)).
 
 ### Developer Experience
 - Massive refactor that split `routes.py` into many views and pushed the app logic down into a new service layer ([#352](https://github.com/sfirke/meutch/pull/352)).

--- a/app/forms_auth.py
+++ b/app/forms_auth.py
@@ -18,7 +18,12 @@ from wtforms.validators import (
     ValidationError,
 )
 
-from app.forms_shared import DIGEST_FREQUENCY_CHOICES
+from app.forms_shared import (
+    COUNTRY_CHOICES,
+    COUNTRY_DEFAULT,
+    DIGEST_FREQUENCY_CHOICES,
+    CountryChoice,
+)
 from app.models import User
 
 
@@ -111,13 +116,15 @@ class RegistrationForm(FlaskForm):
             Length(max=20, message="Postal Code must be under 20 characters."),
         ],
     )
-    country = StringField(
+    country = SelectField(
         "Country",
         validators=[
             Optional(),
-            Length(max=100, message="Country must be under 100 characters."),
+            CountryChoice(),
         ],
-        default="USA",
+        choices=COUNTRY_CHOICES,
+        default=COUNTRY_DEFAULT,
+        validate_choice=False,
     )
 
     latitude = FloatField(

--- a/app/forms_auth.py
+++ b/app/forms_auth.py
@@ -98,17 +98,17 @@ class RegistrationForm(FlaskForm):
         ],
     )
     state = StringField(
-        "State",
+        "State/Province",
         validators=[
             Optional(),
-            Length(max=100, message="State must be under 100 characters."),
+            Length(max=100, message="State/Province must be under 100 characters."),
         ],
     )
     zip_code = StringField(
-        "ZIP Code",
+        "Postal Code",
         validators=[
             Optional(),
-            Length(max=20, message="ZIP Code must be under 20 characters."),
+            Length(max=20, message="Postal Code must be under 20 characters."),
         ],
     )
     country = StringField(

--- a/app/forms_circles.py
+++ b/app/forms_circles.py
@@ -11,7 +11,7 @@ from wtforms import (
 )
 from wtforms.validators import DataRequired, Length, NumberRange, Optional
 
-from app.forms_shared import OptionalFileAllowed
+from app.forms_shared import COUNTRY_CHOICES, COUNTRY_DEFAULT, CountryChoice, OptionalFileAllowed
 
 
 class CircleCreateForm(FlaskForm):
@@ -86,13 +86,15 @@ class CircleCreateForm(FlaskForm):
             Length(max=20, message="Postal Code must be under 20 characters."),
         ],
     )
-    country = StringField(
+    country = SelectField(
         "Country",
         validators=[
             Optional(),
-            Length(max=100, message="Country must be under 100 characters."),
+            CountryChoice(),
         ],
-        default="USA",
+        choices=COUNTRY_CHOICES,
+        default=COUNTRY_DEFAULT,
+        validate_choice=False,
     )
 
     latitude = FloatField(

--- a/app/forms_circles.py
+++ b/app/forms_circles.py
@@ -73,17 +73,17 @@ class CircleCreateForm(FlaskForm):
         ],
     )
     state = StringField(
-        "State",
+        "State/Province",
         validators=[
             Optional(),
-            Length(max=100, message="State must be under 100 characters."),
+            Length(max=100, message="State/Province must be under 100 characters."),
         ],
     )
     zip_code = StringField(
-        "ZIP Code",
+        "Postal Code",
         validators=[
             Optional(),
-            Length(max=20, message="ZIP Code must be under 20 characters."),
+            Length(max=20, message="Postal Code must be under 20 characters."),
         ],
     )
     country = StringField(

--- a/app/forms_profile.py
+++ b/app/forms_profile.py
@@ -12,7 +12,14 @@ from wtforms import (
 )
 from wtforms.validators import DataRequired, Length, NumberRange, Optional, ValidationError
 
-from app.forms_shared import DIGEST_FREQUENCY_CHOICES, OptionalFileAllowed, OptionalURL
+from app.forms_shared import (
+    COUNTRY_CHOICES,
+    COUNTRY_DEFAULT,
+    DIGEST_FREQUENCY_CHOICES,
+    CountryChoice,
+    OptionalFileAllowed,
+    OptionalURL,
+)
 
 
 class UpdateLocationForm(FlaskForm):
@@ -55,13 +62,15 @@ class UpdateLocationForm(FlaskForm):
             Length(max=20, message="Postal Code must be under 20 characters."),
         ],
     )
-    country = StringField(
+    country = SelectField(
         "Country",
         validators=[
             Optional(),
-            Length(max=100, message="Country must be under 100 characters."),
+            CountryChoice(),
         ],
-        default="USA",
+        choices=COUNTRY_CHOICES,
+        default=COUNTRY_DEFAULT,
+        validate_choice=False,
     )
 
     latitude = FloatField(

--- a/app/forms_profile.py
+++ b/app/forms_profile.py
@@ -42,17 +42,17 @@ class UpdateLocationForm(FlaskForm):
         ],
     )
     state = StringField(
-        "State",
+        "State/Province",
         validators=[
             Optional(),
-            Length(max=100, message="State must be under 100 characters."),
+            Length(max=100, message="State/Province must be under 100 characters."),
         ],
     )
     zip_code = StringField(
-        "ZIP Code",
+        "Postal Code",
         validators=[
             Optional(),
-            Length(max=20, message="ZIP Code must be under 20 characters."),
+            Length(max=20, message="Postal Code must be under 20 characters."),
         ],
     )
     country = StringField(

--- a/app/forms_shared.py
+++ b/app/forms_shared.py
@@ -1,6 +1,7 @@
+import pycountry
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileAllowed
-from wtforms.validators import URL
+from wtforms.validators import URL, ValidationError
 
 from app.models import User
 
@@ -12,6 +13,64 @@ DIGEST_FREQUENCY_CHOICES = [
     ),
     (User.DIGEST_FREQUENCY_NONE, "Never (must log in to follow activity)"),
 ]
+
+COUNTRY_DEFAULT = "United States of America"
+COUNTRY_PRIORITY_ORDER = (COUNTRY_DEFAULT, "Canada")
+
+
+def _country_display_name(country):
+    if country.alpha_2 == "US":
+        return COUNTRY_DEFAULT
+    return getattr(country, "common_name", country.name)
+
+
+def _build_country_choices():
+    remaining_countries = sorted(
+        {
+            _country_display_name(country)
+            for country in pycountry.countries
+            if _country_display_name(country) not in COUNTRY_PRIORITY_ORDER
+        }
+    )
+    return tuple((country_name, country_name) for country_name in COUNTRY_PRIORITY_ORDER) + tuple(
+        (country_name, country_name) for country_name in remaining_countries
+    )
+
+
+COUNTRY_CHOICES = _build_country_choices()
+_COUNTRY_LOOKUP = {value.casefold(): value for value, _ in COUNTRY_CHOICES}
+_COUNTRY_LOOKUP.update(
+    {
+        "us": COUNTRY_DEFAULT,
+        "usa": COUNTRY_DEFAULT,
+        "u.s.": COUNTRY_DEFAULT,
+        "u.s.a.": COUNTRY_DEFAULT,
+        "united states": COUNTRY_DEFAULT,
+    }
+)
+
+
+def normalize_country_choice(value):
+    """Normalize user-provided country values to the canonical dropdown value."""
+    if not value or not value.strip():
+        return value
+    stripped_value = value.strip()
+    return _COUNTRY_LOOKUP.get(stripped_value.casefold(), stripped_value)
+
+
+def CountryChoice(message=None):
+    """Validator that restricts countries to the supported dropdown values."""
+
+    def _validate(form, field):
+        if not field.data:
+            return
+
+        normalized_country = normalize_country_choice(field.data)
+        if normalized_country not in _COUNTRY_LOOKUP.values():
+            raise ValidationError(message or "Please choose a country from the list.")
+        field.data = normalized_country
+
+    return _validate
 
 
 def OptionalURL(message=None):

--- a/app/services/circle_service.py
+++ b/app/services/circle_service.py
@@ -65,7 +65,13 @@ def _apply_circle_location(
     address = build_address_string(street, city, state, zip_code, country)
 
     try:
-        coordinates = geocode_address(address)
+        coordinates = geocode_address(
+            street=street,
+            city=city,
+            state=state,
+            zip_code=zip_code,
+            country=country,
+        )
         if coordinates:
             circle.latitude, circle.longitude = coordinates
             logger.info("Successfully geocoded address for circle %s", circle.name)

--- a/app/services/location_service.py
+++ b/app/services/location_service.py
@@ -23,10 +23,14 @@ def _apply_coordinates(user, latitude, longitude):
 
 
 def _apply_address(user, street, city, state, zip_code, country):
-    address = geocoding.build_address_string(street, city, state, zip_code, country)
-
     try:
-        coordinates = geocoding.geocode_address(address)
+        coordinates = geocoding.geocode_address(
+            street=street,
+            city=city,
+            state=state,
+            zip_code=zip_code,
+            country=country,
+        )
         if coordinates:
             user.latitude, user.longitude = coordinates
             user.geocoded_at = datetime.now(UTC)

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -101,7 +101,7 @@
         <div id="address-fields" class="mb-4">
             <h6 class="mb-3">Enter Address</h6>
             <p class="text-muted mb-3">
-                <small>Canadian addresses work too. Use your province and postal code, and change the country if needed.</small>
+                <small>Select the correct country from the list. If you're in Canada, choose Canada and use your province and postal code.</small>
             </p>
 
             <!-- Street Address -->
@@ -143,7 +143,7 @@
             <!-- Country -->
             <p>
                 {{ form.country.label }}<br>
-                {{ form.country(size=32) }}<br>
+                {{ form.country() }}<br>
                 {% for error in form.country.errors %}
                     <span style="color: red;">{{ error }}</span>
                 {% endfor %}

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -101,7 +101,7 @@
         <div id="address-fields" class="mb-4">
             <h6 class="mb-3">Enter Address</h6>
             <p class="text-muted mb-3">
-                <small>Select the correct country from the list. If you're in Canada, choose Canada and use your province and postal code.</small>
+                <small>Geocoding has been tested with addresses in USA and Canada.</small>
             </p>
 
             <!-- Street Address -->

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -18,7 +18,7 @@
                 <span style="color: red;">{{ error }}</span>
             {% endfor %}
         </p>
-        
+
         <!-- Last Name -->
         <p>
             {{ form.last_name.label }}<br>
@@ -45,7 +45,7 @@
                 <span style="color: red;">{{ error }}</span>
             {% endfor %}
         </p>
-        
+
         <!-- Confirm Password -->
         <p>
             {{ form.confirm_password.label }}<br>
@@ -69,19 +69,19 @@
             <h6><i class="fas fa-exclamation-triangle me-2"></i>Heads up</h6>
             <p class="mb-0">If you choose never, you may miss nearby requests, giveaways, and circle activity.</p>
         </div>
-        
+
         <!-- Location Method Choice -->
         <div class="mb-4">
             <h5>Location</h5>
             <div id="location-info" class="alert alert-info mb-3">
                 <h6><i class="fas fa-shield-alt me-2"></i>Your Privacy is Protected</h6>
                 <p class="mb-2">
-                    <strong>We never store your address.</strong> 
-                    If you provide an address, we use it only to look up coordinates from OpenStreetMap, then discard it. 
+                    <strong>We never store your address.</strong>
+                    If you provide an address, we use it only to look up coordinates from OpenStreetMap, then discard it.
                     We store only your latitude and longitude to calculate distances.
                 </p>
                 <p class="mb-0">
-                    <strong>We never share your location.</strong> 
+                    <strong>We never share your location.</strong>
                     Other users only see approximate distance ranges like "2-5 mi".
                 </p>
             </div>
@@ -96,11 +96,14 @@
                 <span style="color: red;">{{ error }}</span>
             {% endfor %}
         </div>
-        
+
         <!-- Address Fields (shown when address method is selected) -->
         <div id="address-fields" class="mb-4">
             <h6 class="mb-3">Enter Address</h6>
-            
+            <p class="text-muted mb-3">
+                <small>Canadian addresses work too. Use your province and postal code, and change the country if needed.</small>
+            </p>
+
             <!-- Street Address -->
             <p>
                 {{ form.street.label }}<br>
@@ -109,7 +112,7 @@
                     <span style="color: red;">{{ error }}</span>
                 {% endfor %}
             </p>
-            
+
             <!-- City -->
             <p>
                 {{ form.city.label }}<br>
@@ -118,8 +121,8 @@
                     <span style="color: red;">{{ error }}</span>
                 {% endfor %}
             </p>
-            
-            <!-- State -->
+
+            <!-- State/Province -->
             <p>
                 {{ form.state.label }}<br>
                 {{ form.state(size=32) }}<br>
@@ -127,8 +130,8 @@
                     <span style="color: red;">{{ error }}</span>
                 {% endfor %}
             </p>
-            
-            <!-- ZIP Code -->
+
+            <!-- Postal Code -->
             <p>
                 {{ form.zip_code.label }}<br>
                 {{ form.zip_code(size=10) }}<br>
@@ -136,7 +139,7 @@
                     <span style="color: red;">{{ error }}</span>
                 {% endfor %}
             </p>
-            
+
             <!-- Country -->
             <p>
                 {{ form.country.label }}<br>
@@ -146,7 +149,7 @@
                 {% endfor %}
             </p>
         </div>
-        
+
         <!-- Coordinate Fields (shown when coordinate method is selected) -->
         <div id="coordinate-fields" class="mb-4" style="display: none;">
             <h6 class="mb-3">Enter Coordinates</h6>
@@ -160,7 +163,7 @@
                     </ul>
                 </small>
             </div>
-            
+
             <!-- Latitude -->
             <p>
                 {{ form.latitude.label }}<br>
@@ -170,7 +173,7 @@
                     <span style="color: red;">{{ error }}</span>
                 {% endfor %}
             </p>
-            
+
             <!-- Longitude -->
             <p>
                 {{ form.longitude.label }}<br>
@@ -181,7 +184,7 @@
                 {% endfor %}
             </p>
         </div>
-        
+
         <!-- Warning for Skip Option -->
         <div id="skip-warning" class="alert alert-warning" style="display: none;">
             <h6><i class="fas fa-exclamation-triangle me-2"></i>Important Note</h6>
@@ -196,11 +199,11 @@
                 <strong>Note:</strong> You can always add your location later from your profile page.
             </p>
         </div>
-        
+
         <!-- Submit Button -->
         <p>{{ form.submit() }}</p>
     </form>
-    
+
     <script>
     // Show/hide fields based on location method selection
     document.addEventListener('DOMContentLoaded', function() {
@@ -213,7 +216,7 @@
         const locationInfo = document.getElementById('location-info');
         const digestFrequency = document.getElementById('digest_frequency');
         const digestNoneWarning = document.getElementById('digest-none-warning');
-        
+
         function toggleFields() {
             if (coordinateRadio.checked) {
                 addressFields.style.display = 'none';
@@ -232,10 +235,10 @@
                 locationInfo.style.display = 'block';
             }
         }
-        
+
         // Initial state
         toggleFields();
-        
+
         // Listen for changes
         addressRadio.addEventListener('change', toggleFields);
         coordinateRadio.addEventListener('change', toggleFields);

--- a/app/templates/circles/circles.html
+++ b/app/templates/circles/circles.html
@@ -313,7 +313,7 @@
             <p class="text-muted mb-4">Create a community for sharing items with friends, neighbors, or colleagues.</p>
             <form method="post">
         {{ circle_form.csrf_token }}
-        
+
         <!-- Circle Name -->
         <div class="mb-3">
             {{ circle_form.name.label(class="form-label") }}
@@ -322,7 +322,7 @@
                 <div class="text-danger">{{ error }}</div>
             {% endfor %}
         </div>
-        
+
         <!-- Description -->
         <div class="mb-3">
             {{ circle_form.description.label(class="form-label") }}
@@ -331,7 +331,7 @@
                 <div class="text-danger">{{ error }}</div>
             {% endfor %}
         </div>
-        
+
         <!-- Circle Type -->
         <div class="mb-3">
             {{ circle_form.circle_type.label(class="form-label") }}
@@ -340,12 +340,12 @@
                 <div class="text-danger">{{ error }}</div>
             {% endfor %}
         </div>
-        
+
         <!-- Location Section -->
         <div class="mb-4">
             <h5 class="mb-3"><i class="fas fa-map-marker-alt me-2"></i>Circle Location (Optional)</h5>
             <p class="text-muted small mb-3">Setting a location helps members find circles near them. This is optional and can be added or updated later.</p>
-            
+
             <!-- Location Method Choice -->
             {{ circle_form.location_method.label(class="form-label") }}
             {% for subfield in circle_form.location_method %}
@@ -358,10 +358,13 @@
                 <div class="text-danger small">{{ error }}</div>
             {% endfor %}
         </div>
-        
+
         <!-- Address Fields -->
         <div id="create-address-fields" class="mb-4" style="display: none;">
             <h6 class="mb-3">Enter Address</h6>
+            <p class="text-muted small mb-3">
+                Canadian addresses work too. Use your province and postal code, and change the country if needed.
+            </p>
             <div class="row">
                 <div class="col-12 mb-3">
                     {{ circle_form.street.label(class="form-label") }}
@@ -404,7 +407,7 @@
                 </div>
             </div>
         </div>
-        
+
         <!-- Coordinate Fields -->
         <div id="create-coordinate-fields" class="mb-4" style="display: none;">
             <h6 class="mb-3">Enter Coordinates</h6>
@@ -432,7 +435,7 @@
                 </div>
             </div>
         </div>
-        
+
                 <!-- Submit Button -->
                 <div class="mb-3">
                     <button type="submit" class="btn btn-primary" name="create_circle"><i class="fas fa-check me-2"></i>{{ circle_form.submit.label.text }}</button>
@@ -446,7 +449,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     // Determine which tab should be active
     let activeTab = 'your-circles-tab';  // Default tab
-    
+
     // Check if we should show a specific tab based on form submissions or search results
     {% if searched_circles or show_browse %}
         // If there are search results, show the Find Circles tab
@@ -461,26 +464,26 @@ document.addEventListener('DOMContentLoaded', function() {
             activeTab = savedTab;
         }
     {% endif %}
-    
+
     // Activate the determined tab
     const tabTrigger = document.getElementById(activeTab);
     if (tabTrigger) {
         const tab = new bootstrap.Tab(tabTrigger);
         tab.show();
     }
-    
+
     // Save the active tab to localStorage when user clicks a tab
     document.querySelectorAll('#circlesTabs button[data-bs-toggle="tab"]').forEach(function(tabButton) {
         tabButton.addEventListener('shown.bs.tab', function(event) {
             localStorage.setItem('activeCirclesTab', event.target.id);
         });
     });
-    
+
     // Show/hide location fields based on location method selection for circle creation
     const locationMethodRadios = document.querySelectorAll('.location-method-radio');
     const addressFields = document.getElementById('create-address-fields');
     const coordinateFields = document.getElementById('create-coordinate-fields');
-    
+
     function toggleLocationFields() {
         const selectedMethod = document.querySelector('.location-method-radio:checked');
         if (selectedMethod) {
@@ -497,10 +500,10 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
     }
-    
+
     // Initialize on page load
     toggleLocationFields();
-    
+
     // Update when radio selection changes
     locationMethodRadios.forEach(function(radio) {
         radio.addEventListener('change', toggleLocationFields);

--- a/app/templates/circles/circles.html
+++ b/app/templates/circles/circles.html
@@ -363,7 +363,7 @@
         <div id="create-address-fields" class="mb-4" style="display: none;">
             <h6 class="mb-3">Enter Address</h6>
             <p class="text-muted small mb-3">
-                Canadian addresses work too. Use your province and postal code, and change the country if needed.
+                Select the correct country from the list. If you're in Canada, choose Canada and use your province and postal code.
             </p>
             <div class="row">
                 <div class="col-12 mb-3">
@@ -400,7 +400,7 @@
             <div class="row">
                 <div class="col-md-6 mb-3">
                     {{ circle_form.country.label(class="form-label") }}
-                    {{ circle_form.country(class="form-control") }}
+                    {{ circle_form.country(class="form-select") }}
                     {% for error in circle_form.country.errors %}
                         <div class="text-danger small">{{ error }}</div>
                     {% endfor %}

--- a/app/templates/circles/circles.html
+++ b/app/templates/circles/circles.html
@@ -363,7 +363,7 @@
         <div id="create-address-fields" class="mb-4" style="display: none;">
             <h6 class="mb-3">Enter Address</h6>
             <p class="text-muted small mb-3">
-                Select the correct country from the list. If you're in Canada, choose Canada and use your province and postal code.
+                Geocoding has been tested with addresses in USA and Canada.
             </p>
             <div class="row">
                 <div class="col-12 mb-3">

--- a/app/templates/circles/edit_circle.html
+++ b/app/templates/circles/edit_circle.html
@@ -58,7 +58,7 @@
                         <div class="text-danger">{{ error }}</div>
                     {% endfor %}
                 </div>
-                
+
                 <!-- Location Section -->
                 <div class="mb-4">
                     <h5 class="mb-3"><i class="fas fa-map-marker-alt me-2"></i>Circle Location</h5>
@@ -69,7 +69,7 @@
                     {% else %}
                         <p class="text-muted small mb-3">No location set yet. Adding a location helps members find circles near them.</p>
                     {% endif %}
-                    
+
                     <!-- Location Method Choice -->
                     {{ form.location_method.label(class="form-label") }}
                     {% for subfield in form.location_method %}
@@ -82,10 +82,13 @@
                         <div class="text-danger small">{{ error }}</div>
                     {% endfor %}
                 </div>
-                
+
                 <!-- Address Fields -->
                 <div id="edit-address-fields" class="mb-4" style="display: none;">
                     <h6 class="mb-3">Enter Address</h6>
+                    <p class="text-muted small mb-3">
+                        Canadian addresses work too. Use your province and postal code, and change the country if needed.
+                    </p>
                     <div class="row">
                         <div class="col-12 mb-3">
                             {{ form.street.label(class="form-label") }}
@@ -128,7 +131,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <!-- Coordinate Fields -->
                 <div id="edit-coordinate-fields" class="mb-4" style="display: none;">
                     <h6 class="mb-3">Enter Coordinates</h6>
@@ -156,7 +159,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <!-- Submit -->
                 <div class="d-grid gap-2">
                     {{ form.submit(class="btn btn-primary") }}
@@ -178,7 +181,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const locationMethodRadios = document.querySelectorAll('.edit-location-method-radio');
     const addressFields = document.getElementById('edit-address-fields');
     const coordinateFields = document.getElementById('edit-coordinate-fields');
-    
+
     function toggleLocationFields() {
         const selectedMethod = document.querySelector('.edit-location-method-radio:checked');
         if (selectedMethod) {
@@ -195,10 +198,10 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
     }
-    
+
     // Initialize on page load
     toggleLocationFields();
-    
+
     // Update when radio selection changes
     locationMethodRadios.forEach(function(radio) {
         radio.addEventListener('change', toggleLocationFields);

--- a/app/templates/circles/edit_circle.html
+++ b/app/templates/circles/edit_circle.html
@@ -87,7 +87,7 @@
                 <div id="edit-address-fields" class="mb-4" style="display: none;">
                     <h6 class="mb-3">Enter Address</h6>
                     <p class="text-muted small mb-3">
-                        Canadian addresses work too. Use your province and postal code, and change the country if needed.
+                        Select the correct country from the list. If you're in Canada, choose Canada and use your province and postal code.
                     </p>
                     <div class="row">
                         <div class="col-12 mb-3">
@@ -124,7 +124,7 @@
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             {{ form.country.label(class="form-label") }}
-                            {{ form.country(class="form-control") }}
+                            {{ form.country(class="form-select") }}
                             {% for error in form.country.errors %}
                                 <div class="text-danger small">{{ error }}</div>
                             {% endfor %}

--- a/app/templates/circles/edit_circle.html
+++ b/app/templates/circles/edit_circle.html
@@ -87,7 +87,7 @@
                 <div id="edit-address-fields" class="mb-4" style="display: none;">
                     <h6 class="mb-3">Enter Address</h6>
                     <p class="text-muted small mb-3">
-                        Select the correct country from the list. If you're in Canada, choose Canada and use your province and postal code.
+                        Geocoding has been tested with addresses in USA and Canada.
                     </p>
                     <div class="row">
                         <div class="col-12 mb-3">

--- a/app/templates/main/update_location.html
+++ b/app/templates/main/update_location.html
@@ -47,7 +47,7 @@
                         <div id="address-fields" class="mb-4">
                             <h5 class="mb-3">Enter Address</h5>
                             <p class="text-muted small mb-3">
-                                Select the correct country from the list. If you're in Canada, choose Canada and use your province and postal code.
+                                Geocoding has been tested with addresses in USA and Canada.
                             </p>
                             <div class="row">
                                 <div class="col-12 mb-3">

--- a/app/templates/main/update_location.html
+++ b/app/templates/main/update_location.html
@@ -47,7 +47,7 @@
                         <div id="address-fields" class="mb-4">
                             <h5 class="mb-3">Enter Address</h5>
                             <p class="text-muted small mb-3">
-                                Canadian addresses work too. Use your province and postal code, and change the country if needed.
+                                Select the correct country from the list. If you're in Canada, choose Canada and use your province and postal code.
                             </p>
                             <div class="row">
                                 <div class="col-12 mb-3">
@@ -84,7 +84,7 @@
                             <div class="row">
                                 <div class="col-md-6 mb-3">
                                     {{ form.country.label(class="form-label") }}
-                                    {{ form.country(class="form-control") }}
+                                    {{ form.country(class="form-select") }}
                                     {% for error in form.country.errors %}
                                         <div class="text-danger small">{{ error }}</div>
                                     {% endfor %}

--- a/app/templates/main/update_location.html
+++ b/app/templates/main/update_location.html
@@ -14,11 +14,11 @@
                     <div class="alert alert-info">
                         <h6><i class="fas fa-info-circle me-2"></i>How we use your location</h6>
                         <p class="mb-2">
-                            Your coordinates are used to calculate distances to circles and items you might want to join or borrow. 
+                            Your coordinates are used to calculate distances to circles and items you might want to join or borrow.
                             This helps you find circles and items near you and helps others see how close they are to your items.
                         </p>
                         <p class="mb-2">
-                            <strong>Privacy note:</strong> We only store your latitude and longitude coordinates, not your address. 
+                            <strong>Privacy note:</strong> We only store your latitude and longitude coordinates, not your address.
                             Your exact location will never be shown to other users - they'll only see approximate distances.
                         </p>
                         <p class="mb-0">
@@ -28,7 +28,7 @@
 
                     <form method="post" id="locationForm">
                         {{ form.csrf_token }}
-                        
+
                         <!-- Location Method Choice -->
                         <div class="mb-4">
                             {{ form.location_method.label(class="form-label fw-bold") }}
@@ -42,10 +42,13 @@
                                 <div class="text-danger small">{{ error }}</div>
                             {% endfor %}
                         </div>
-                        
+
                         <!-- Address Fields (shown when address method is selected) -->
                         <div id="address-fields" class="mb-4">
                             <h5 class="mb-3">Enter Address</h5>
+                            <p class="text-muted small mb-3">
+                                Canadian addresses work too. Use your province and postal code, and change the country if needed.
+                            </p>
                             <div class="row">
                                 <div class="col-12 mb-3">
                                     {{ form.street.label(class="form-label") }}
@@ -88,7 +91,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                         <!-- Coordinate Fields (shown when coordinate method is selected) -->
                         <div id="coordinate-fields" class="mb-4" style="display: none;">
                             <h5 class="mb-3">Enter Coordinates</h5>
@@ -102,7 +105,7 @@
                                     </ul>
                                 </small>
                             </div>
-                            
+
                             <div class="row">
                                 <div class="col-md-6 mb-3">
                                     {{ form.latitude.label(class="form-label") }}
@@ -122,7 +125,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                         <!-- Remove Location Section (shown when remove method is selected) -->
                         <div id="remove-fields" class="mb-4" style="display: none;">
                             <div class="alert alert-warning">
@@ -136,7 +139,7 @@
                                 <p class="mb-0">You can always add your location back later.</p>
                             </div>
                         </div>
-                        
+
                         <div class="d-flex gap-2">
                             {{ form.submit(class="btn btn-primary") }}
                             <a href="{{ url_for('main.profile') }}" class="btn btn-secondary">Cancel</a>
@@ -157,7 +160,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const addressFields = document.getElementById('address-fields');
     const coordinateFields = document.getElementById('coordinate-fields');
     const removeFields = document.getElementById('remove-fields');
-    
+
     function toggleFields() {
         if (coordinateRadio.checked) {
             addressFields.style.display = 'none';
@@ -173,10 +176,10 @@ document.addEventListener('DOMContentLoaded', function() {
             removeFields.style.display = 'none';
         }
     }
-    
+
     // Initial state
     toggleFields();
-    
+
     // Listen for changes
     addressRadio.addEventListener('change', toggleFields);
     coordinateRadio.addEventListener('change', toggleFields);

--- a/app/utils/geocoding.py
+++ b/app/utils/geocoding.py
@@ -1,87 +1,177 @@
-"""
-Geocoding utilities using Nominatim API
-"""
-import requests
 import logging
-from typing import Optional, Tuple
 from time import sleep
+from typing import Optional, Tuple
+
+import requests
 
 logger = logging.getLogger(__name__)
 
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
+NOMINATIM_HEADERS = {
+    "User-Agent": "Meutch-ItemLending/1.0 (https://meutch.com; item-lending-platform)"
+}
+NOMINATIM_BASE_PARAMS = {
+    "format": "json",
+    "limit": 1,
+    "addressdetails": 1,
+}
+
+
 class GeocodingError(Exception):
     """Custom exception for geocoding errors"""
+
     pass
 
-def build_address_string(street: str, city: str, state: str, zip_code: str, country: str) -> str:
+
+def _clean_address_component(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+
+    stripped_value = value.strip()
+    return stripped_value or None
+
+
+def build_address_string(
+    street: Optional[str],
+    city: Optional[str],
+    state: Optional[str],
+    zip_code: Optional[str],
+    country: Optional[str],
+) -> str:
     """
     Build a complete address string from individual components
-    
+
     Args:
         street: Street address
         city: City name
         state: State or province
         zip_code: ZIP or postal code
         country: Country name
-        
+
     Returns:
         Formatted address string
     """
-    return f"{street}, {city}, {state} {zip_code}, {country}"
+    state_and_zip = " ".join(
+        component
+        for component in (_clean_address_component(state), _clean_address_component(zip_code))
+        if component
+    )
+    return ", ".join(
+        component
+        for component in (
+            _clean_address_component(street),
+            _clean_address_component(city),
+            state_and_zip or None,
+            _clean_address_component(country),
+        )
+        if component
+    )
 
-def geocode_address(address: str, max_retries: int = 3, delay: float = 1.0) -> Optional[Tuple[float, float]]:
+
+def _build_structured_queries(
+    street: Optional[str],
+    city: Optional[str],
+    state: Optional[str],
+    zip_code: Optional[str],
+    country: Optional[str],
+) -> list[dict[str, str]]:
+    query = {}
+
+    for key, value in (
+        ("street", street),
+        ("city", city),
+        ("state", state),
+        ("postalcode", zip_code),
+        ("country", country),
+    ):
+        cleaned_value = _clean_address_component(value)
+        if cleaned_value:
+            query[key] = cleaned_value
+
+    if not query:
+        return []
+
+    queries = [query]
+    if "postalcode" in query:
+        queries.append({key: value for key, value in query.items() if key != "postalcode"})
+
+    return queries
+
+
+def geocode_address(
+    address: Optional[str] = None,
+    *,
+    street: Optional[str] = None,
+    city: Optional[str] = None,
+    state: Optional[str] = None,
+    zip_code: Optional[str] = None,
+    country: Optional[str] = None,
+    max_retries: int = 3,
+    delay: float = 1.0,
+) -> Optional[Tuple[float, float]]:
     """
     Geocode an address using Nominatim API
-    
+
     Args:
-        address: Full address string to geocode
+        address: Full address string to geocode when components are not available
+        street: Street address for structured geocoding queries
+        city: City name for structured geocoding queries
+        state: State or province for structured geocoding queries
+        zip_code: ZIP or postal code for structured geocoding queries
+        country: Country name for structured geocoding queries
         max_retries: Maximum number of retry attempts
         delay: Delay between retries in seconds
-        
+
     Returns:
         Tuple of (latitude, longitude) if successful, None if failed
-        
+
     Raises:
         GeocodingError: If geocoding fails after all retries
     """
-    # Nominatim API endpoint
-    url = "https://nominatim.openstreetmap.org/search"
-    
-    # Parameters for the API request
-    params = {
-        'q': address,
-        'format': 'json',
-        'limit': 1,
-        'addressdetails': 1
-    }
-    
-    # Headers to identify our application (Nominatim policy compliance)
-    headers = {
-        'User-Agent': 'Meutch-ItemLending/1.0 (https://meutch.com; item-lending-platform)'
-    }
-    
+    query_variants = _build_structured_queries(street, city, state, zip_code, country)
+    normalized_address = _clean_address_component(address)
+    log_address = normalized_address or build_address_string(street, city, state, zip_code, country)
+
+    if not query_variants:
+        if not normalized_address:
+            raise GeocodingError(
+                "No geocoding query could be built from the supplied address data."
+            )
+        query_variants = [{"q": normalized_address}]
+        log_address = normalized_address
+
     for attempt in range(max_retries):
         try:
-            logger.info(f"Geocoding attempt {attempt + 1} for address: {address}")
-            
-            # Make the API request
-            response = requests.get(url, params=params, headers=headers, timeout=10)
-            response.raise_for_status()
-            
-            # Parse the JSON response
-            data = response.json()
-            
-            if not data:
-                logger.warning(f"No results found for address: {address}")
-                return None
-            
-            # Extract latitude and longitude from the first result
-            result = data[0]
-            lat = float(result['lat'])
-            lon = float(result['lon'])
-            
-            logger.info(f"Successfully geocoded address: {address} -> ({lat}, {lon})")
-            return (lat, lon)
-            
+            logger.info("Geocoding attempt %s for address: %s", attempt + 1, log_address)
+
+            for index, query_params in enumerate(query_variants):
+                response = requests.get(
+                    NOMINATIM_URL,
+                    params={**NOMINATIM_BASE_PARAMS, **query_params},
+                    headers=NOMINATIM_HEADERS,
+                    timeout=10,
+                )
+                response.raise_for_status()
+
+                data = response.json()
+                if not data:
+                    if index == 0 and len(query_variants) > 1 and "postalcode" in query_params:
+                        logger.info(
+                            "No result with postal code for address: %s; retrying without postal code",
+                            log_address,
+                        )
+                    continue
+
+                result = data[0]
+                lat = float(result["lat"])
+                lon = float(result["lon"])
+
+                logger.info("Successfully geocoded address: %s -> (%s, %s)", log_address, lat, lon)
+                return (lat, lon)
+
+            logger.warning("No results found for address: %s", log_address)
+            return None
+
         except requests.exceptions.RequestException as e:
             logger.error(f"Network error during geocoding attempt {attempt + 1}: {e}")
             if attempt < max_retries - 1:
@@ -89,11 +179,11 @@ def geocode_address(address: str, max_retries: int = 3, delay: float = 1.0) -> O
                 continue
             else:
                 raise GeocodingError(f"Failed to geocode address after {max_retries} attempts: {e}")
-                
+
         except (KeyError, ValueError, TypeError) as e:
             logger.error(f"Error parsing geocoding response: {e}")
             raise GeocodingError(f"Invalid response from geocoding service: {e}")
-            
+
         except Exception as e:
             logger.error(f"Unexpected error during geocoding: {e}")
             if attempt < max_retries - 1:
@@ -101,37 +191,39 @@ def geocode_address(address: str, max_retries: int = 3, delay: float = 1.0) -> O
                 continue
             else:
                 raise GeocodingError(f"Unexpected error during geocoding: {e}")
-    
+
     return None
+
 
 def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """
     Calculate distance between two points using Haversine formula
-    
+
     Args:
         lat1: Latitude of first point
         lon1: Longitude of first point
         lat2: Latitude of second point
         lon2: Longitude of second point
-        
+
     Returns:
         Distance in miles
     """
     import math
-    
+
     # Convert latitude and longitude to radians
     lat1_rad, lon1_rad = math.radians(lat1), math.radians(lon1)
     lat2_rad, lon2_rad = math.radians(lat2), math.radians(lon2)
-    
+
     # Haversine formula
     dlat = lat2_rad - lat1_rad
     dlon = lon2_rad - lon1_rad
-    a = math.sin(dlat/2)**2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon/2)**2
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2) ** 2
     c = 2 * math.asin(math.sqrt(a))
-    
+
     # Radius of earth in miles
     r = 3956
     return r * c
+
 
 def format_distance(distance_miles: float) -> str:
     """
@@ -162,59 +254,62 @@ def format_distance(distance_miles: float) -> str:
 def sort_by_distance(items, reference_user, distance_fn, radius=None):
     """
     Sort items by distance from a reference user's location.
-    
+
     This is a generic utility that can sort any objects by distance.
-    
+
     Args:
         items: List of objects to sort
         reference_user: User object with location (must have is_geocoded property)
         distance_fn: Function to calculate distance, takes (item, user) and returns distance in miles or None
         radius: Optional radius in miles to filter by
-        
+
     Returns:
         List of items sorted by distance (closest first, items without location at end)
     """
     if not reference_user.is_geocoded or not items:
         return list(items)
-    
+
     items_with_distance = []
     for item in items:
         distance = distance_fn(item, reference_user)
         items_with_distance.append((item, distance))
-    
+
     # Filter by radius if specified
     if radius:
         radius_miles = float(radius)
         items_with_distance = [
-            (item, dist) for item, dist in items_with_distance
+            (item, dist)
+            for item, dist in items_with_distance
             if dist is not None and dist <= radius_miles
         ]
-    
+
     # Sort by distance (None values at end)
-    items_with_distance.sort(key=lambda x: (x[1] is None, x[1] if x[1] is not None else float('inf')))
+    items_with_distance.sort(
+        key=lambda x: (x[1] is None, x[1] if x[1] is not None else float("inf"))
+    )
     return [item for item, _ in items_with_distance]
 
 
 def sort_items_by_owner_distance(items, reference_user, radius=None):
     """
     Sort items by distance from item owner to reference user.
-    
+
     Convenience wrapper around sort_by_distance for sorting items.
-    
+
     Args:
         items: List of Item objects to sort
         reference_user: User object with location
         radius: Optional radius in miles to filter by
-        
+
     Returns:
         List of items sorted by owner distance (closest first)
     """
+
     def item_owner_distance(item, user):
         if item.owner and item.owner.is_geocoded and user.is_geocoded:
             return calculate_distance(
-                item.owner.latitude, item.owner.longitude,
-                user.latitude, user.longitude
+                item.owner.latitude, item.owner.longitude, user.latitude, user.longitude
             )
         return None
-    
+
     return sort_by_distance(items, reference_user, item_owner_distance, radius)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-WTF==1.2.2
 gunicorn==21.2.0
 Pillow==10.4.0
 psycopg2-binary==2.9.7
+pycountry==26.2.16
 python-dotenv==1.0.0
 requests==2.31.0
 SQLAlchemy==2.0.23

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -140,7 +140,7 @@ class TestAuthenticationRoutes:
                         "city": "New City",
                         "state": "NC",
                         "zip_code": "12345",
-                        "country": "USA",
+                        "country": "United States of America",
                         "password": "newpassword123",
                         "confirm_password": "newpassword123",
                     },

--- a/tests/integration/test_routes.py
+++ b/tests/integration/test_routes.py
@@ -832,8 +832,10 @@ class TestTagAndCategoryBrowsing:
             # Create items with this tag - owned by user in shared circle
             item1 = ItemFactory(name="Laptop", category=electronics_category, owner=item_owner)
             item2 = ItemFactory(name="Phone", category=electronics_category, owner=item_owner)
-            ItemFactory(
-                name="Book", category=books_category, owner=item_owner
+            excluded_item = ItemFactory(
+                name="ZZZ_NOT_RENDERED_TAG_ITEM_ZZZ",
+                category=books_category,
+                owner=item_owner,
             )  # Different category, no tag
 
             item1.tags.append(tag)
@@ -847,7 +849,9 @@ class TestTagAndCategoryBrowsing:
             assert b'Items Tagged "electronics"' in response.data
             assert b"Laptop" in response.data
             assert b"Phone" in response.data
-            assert b"Book" not in response.data  # Should not appear since it doesn't have the tag
+            assert (
+                excluded_item.name.encode() not in response.data
+            )  # Should not appear since it doesn't have the tag
 
     def test_tag_items_page_invalid_tag(self, client, app):
         """Test tag items page with invalid tag ID."""
@@ -953,8 +957,10 @@ class TestTagAndCategoryBrowsing:
             # Create items in this category - owned by circle member
             ItemFactory(name="Laptop", category=category, owner=item_owner)
             ItemFactory(name="Phone", category=category, owner=item_owner)
-            ItemFactory(
-                name="Book", category=books_category, owner=item_owner
+            excluded_item = ItemFactory(
+                name="ZZZ_NOT_RENDERED_CATEGORY_ITEM_ZZZ",
+                category=books_category,
+                owner=item_owner,
             )  # Different category
 
             db.session.commit()
@@ -965,7 +971,7 @@ class TestTagAndCategoryBrowsing:
             assert b"Laptop" in response.data
             assert b"Phone" in response.data
             assert (
-                b"Book" not in response.data
+                excluded_item.name.encode() not in response.data
             )  # Should not appear since it's in a different category
 
     def test_category_items_page_invalid_category(self, client, app):

--- a/tests/test_geocoding_essentials.py
+++ b/tests/test_geocoding_essentials.py
@@ -31,6 +31,63 @@ class TestGeocodingEssentials:
         assert result == (40.7128, -74.0060)
 
     @patch("app.utils.geocoding.requests.get")
+    def test_geocode_address_uses_structured_query_when_components_are_available(self, mock_get):
+        """Test structured geocoding queries for address components."""
+        mock_response = Mock()
+        mock_response.json.return_value = [{"lat": "49.2570773", "lon": "-123.0787301"}]
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = geocode_address(
+            street="1255 E 15th Avenue",
+            city="Vancouver",
+            state="BC",
+            zip_code="V5T 2S7",
+            country="Canada",
+        )
+
+        assert result == (49.2570773, -123.0787301)
+        params = mock_get.call_args.kwargs["params"]
+        assert params["street"] == "1255 E 15th Avenue"
+        assert params["city"] == "Vancouver"
+        assert params["state"] == "BC"
+        assert params["postalcode"] == "V5T 2S7"
+        assert params["country"] == "Canada"
+        assert "q" not in params
+
+    @patch("app.utils.geocoding.requests.get")
+    def test_geocode_address_retries_without_postal_code_when_needed(self, mock_get):
+        """Test structured geocoding falls back without postal code after a miss."""
+        first_response = Mock()
+        first_response.json.return_value = []
+        first_response.raise_for_status.return_value = None
+
+        second_response = Mock()
+        second_response.json.return_value = [{"lat": "49.2322956", "lon": "-123.1864962"}]
+        second_response.raise_for_status.return_value = None
+
+        mock_get.side_effect = [first_response, second_response]
+
+        result = geocode_address(
+            street="5976 Alma St",
+            city="Vancouver",
+            state="BC",
+            zip_code="V6N 1Y",
+            country="Canada",
+        )
+
+        assert result == (49.2322956, -123.1864962)
+        assert mock_get.call_count == 2
+        first_params = mock_get.call_args_list[0].kwargs["params"]
+        second_params = mock_get.call_args_list[1].kwargs["params"]
+        assert first_params["postalcode"] == "V6N 1Y"
+        assert second_params["street"] == "5976 Alma St"
+        assert second_params["city"] == "Vancouver"
+        assert second_params["state"] == "BC"
+        assert second_params["country"] == "Canada"
+        assert "postalcode" not in second_params
+
+    @patch("app.utils.geocoding.requests.get")
     def test_geocode_address_no_results(self, mock_get):
         """Test geocoding when no results are found."""
         mock_response = Mock()
@@ -125,7 +182,11 @@ class TestLocationUpdateEssentials:
 
                 assert response.status_code == 200
                 mock_geocode.assert_called_once_with(
-                    "123 Main St, New York, NY 10001, United States of America"
+                    street="123 Main St",
+                    city="New York",
+                    state="NY",
+                    zip_code="10001",
+                    country="United States of America",
                 )
 
                 updated_user = db.session.get(User, user.id)
@@ -161,7 +222,11 @@ class TestLocationUpdateEssentials:
 
                 assert response.status_code == 200
                 mock_geocode.assert_called_once_with(
-                    "111 Wellington St, Ottawa, ON K1A 0A9, Canada"
+                    street="111 Wellington St",
+                    city="Ottawa",
+                    state="ON",
+                    zip_code="K1A 0A9",
+                    country="Canada",
                 )
 
                 updated_user = db.session.get(User, user.id)

--- a/tests/test_geocoding_essentials.py
+++ b/tests/test_geocoding_essentials.py
@@ -124,6 +124,9 @@ class TestLocationUpdateEssentials:
                 )
 
                 assert response.status_code == 200
+                mock_geocode.assert_called_once_with(
+                    "123 Main St, New York, NY 10001, United States of America"
+                )
 
                 updated_user = db.session.get(User, user.id)
                 assert updated_user.latitude == 40.7128
@@ -277,7 +280,7 @@ class TestWorkflowEssentials:
                         "city": "New York",
                         "state": "NY",
                         "zip_code": "10001",
-                        "country": "USA",
+                        "country": "United States of America",
                         "csrf_token": "test",
                     },
                 )

--- a/tests/test_geocoding_essentials.py
+++ b/tests/test_geocoding_essentials.py
@@ -129,6 +129,42 @@ class TestLocationUpdateEssentials:
                 assert updated_user.latitude == 40.7128
                 assert updated_user.longitude == -74.0060
 
+    def test_location_update_with_canadian_address_success(self, app, client):
+        """Test successful location update using Canadian address components."""
+        with app.app_context():
+            user = UserFactory(latitude=None, longitude=None)
+            db.session.commit()
+
+            with patch("app.utils.geocoding.geocode_address") as mock_geocode:
+                mock_geocode.return_value = (45.4215, -75.6972)
+
+                with client.session_transaction() as sess:
+                    sess["_user_id"] = str(user.id)
+                    sess["_fresh"] = True
+
+                response = client.post(
+                    url_for("main.update_location"),
+                    data={
+                        "location_method": "address",
+                        "street": "111 Wellington St",
+                        "city": "Ottawa",
+                        "state": "ON",
+                        "zip_code": "K1A 0A9",
+                        "country": "Canada",
+                        "csrf_token": "test",
+                    },
+                    follow_redirects=True,
+                )
+
+                assert response.status_code == 200
+                mock_geocode.assert_called_once_with(
+                    "111 Wellington St, Ottawa, ON K1A 0A9, Canada"
+                )
+
+                updated_user = db.session.get(User, user.id)
+                assert updated_user.latitude == 45.4215
+                assert updated_user.longitude == -75.6972
+
     def test_location_update_with_coordinates_success(self, app, client):
         """Test successful location update using direct coordinate input."""
         with app.app_context():

--- a/tests/unit/services/test_circle_service.py
+++ b/tests/unit/services/test_circle_service.py
@@ -11,6 +11,39 @@ from tests.factories import CircleFactory, UserFactory
 
 
 class TestCircleService:
+    def test_create_circle_with_address_uses_structured_geocoding(self, app):
+        with app.app_context():
+            creator = UserFactory()
+            db.session.commit()
+
+            with patch(
+                "app.services.circle_service.geocode_address",
+                return_value=(49.2570773, -123.0787301),
+            ) as mock_geocode:
+                result = circle_service.create_circle(
+                    creator,
+                    name="Vancouver Homes",
+                    description="",
+                    circle_type="open",
+                    location_method="address",
+                    street="1255 E 15th Avenue",
+                    city="Vancouver",
+                    state="BC",
+                    zip_code="V5T 2S7",
+                    country="Canada",
+                )
+
+            assert result["geocoding_failed"] is False
+            assert result["circle"].latitude == 49.2570773
+            assert result["circle"].longitude == -123.0787301
+            mock_geocode.assert_called_once_with(
+                street="1255 E 15th Avenue",
+                city="Vancouver",
+                state="BC",
+                zip_code="V5T 2S7",
+                country="Canada",
+            )
+
     def test_join_circle_with_approval_creates_request_and_sends_email(self, app):
         with app.app_context():
             requester = UserFactory()

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -1,188 +1,199 @@
 """Unit tests for forms."""
-import pytest
-from app.forms import (
-    LoginForm, RegistrationForm, ListItemForm, EditProfileForm,
-    MessageForm, CircleCreateForm, LoanRequestForm, OptionalFileAllowed
-)
-from app.models import Category
-from tests.factories import CategoryFactory, UserFactory
+
 from datetime import date, timedelta
-from werkzeug.datastructures import FileStorage
 from io import BytesIO
+
+import pytest
+from werkzeug.datastructures import FileStorage
+
+from app.forms import (
+    CircleCreateForm,
+    EditProfileForm,
+    ListItemForm,
+    LoanRequestForm,
+    LoginForm,
+    MessageForm,
+    OptionalFileAllowed,
+    RegistrationForm,
+)
+from tests.factories import CategoryFactory, UserFactory
+
 
 class TestLoginForm:
     """Test LoginForm."""
-    
+
     def test_valid_login_form(self, app):
         """Test valid login form."""
         with app.app_context():
-            form_data = {
-                'email': 'test@example.com',
-                'password': 'password123'
-            }
+            form_data = {"email": "test@example.com", "password": "password123"}
             form = LoginForm(data=form_data)
             assert form.validate() is True
-    
+
     def test_invalid_email_format(self, app):
         """Test invalid email format."""
         with app.app_context():
-            form_data = {
-                'email': 'invalid-email',
-                'password': 'password123'
-            }
+            form_data = {"email": "invalid-email", "password": "password123"}
             form = LoginForm(data=form_data)
             assert form.validate() is False
-            assert 'Invalid email format.' in form.email.errors
-    
+            assert "Invalid email format." in form.email.errors
+
     def test_missing_password(self, app):
         """Test missing password."""
         with app.app_context():
-            form_data = {
-                'email': 'test@example.com',
-                'password': ''
-            }
+            form_data = {"email": "test@example.com", "password": ""}
             form = LoginForm(data=form_data)
             assert form.validate() is False
-            assert 'Password is required.' in form.password.errors
+            assert "Password is required." in form.password.errors
 
     def test_login_form_with_remember_device(self, app):
         """Test valid login form with remember_device checked."""
         with app.app_context():
             form_data = {
-                'email': 'test@example.com',
-                'password': 'password123',
-                'remember_device': True
+                "email": "test@example.com",
+                "password": "password123",
+                "remember_device": True,
             }
             form = LoginForm(data=form_data)
             assert form.validate() is True
             assert form.remember_device.data is True
 
+
 class TestRegistrationForm:
     """Test RegistrationForm."""
-    
+
     def test_valid_registration_form(self, app):
         """Test valid registration form with address."""
         with app.app_context():
             form_data = {
-                'email': 'newuser@example.com',
-                'first_name': 'John',
-                'last_name': 'Doe',
-                'location_method': 'address',
-                'street': '123 Main St',
-                'city': 'Anytown',
-                'state': 'CA',
-                'zip_code': '12345',
-                'country': 'USA',
-                'password': 'password123',
-                'confirm_password': 'password123'
+                "email": "newuser@example.com",
+                "first_name": "John",
+                "last_name": "Doe",
+                "location_method": "address",
+                "street": "123 Main St",
+                "city": "Anytown",
+                "state": "CA",
+                "zip_code": "12345",
+                "country": "USA",
+                "password": "password123",
+                "confirm_password": "password123",
             }
             form = RegistrationForm(data=form_data)
             assert form.validate() is True
-    
+
     def test_valid_registration_form_coordinates(self, app):
         """Test valid registration form with coordinates."""
         with app.app_context():
             form_data = {
-                'email': 'newuser@example.com',
-                'first_name': 'John',
-                'last_name': 'Doe',
-                'location_method': 'coordinates',
-                'latitude': 40.7128,
-                'longitude': -74.0060,
-                'password': 'password123',
-                'confirm_password': 'password123'
+                "email": "newuser@example.com",
+                "first_name": "John",
+                "last_name": "Doe",
+                "location_method": "coordinates",
+                "latitude": 40.7128,
+                "longitude": -74.0060,
+                "password": "password123",
+                "confirm_password": "password123",
             }
             form = RegistrationForm(data=form_data)
             assert form.validate() is True
-    
+
     def test_password_confirmation_mismatch(self, app):
         """Test password confirmation mismatch."""
         with app.app_context():
             form_data = {
-                'email': 'newuser@example.com',
-                'first_name': 'John',
-                'last_name': 'Doe',
-                'location_method': 'address',
-                'street': '123 Main St',
-                'city': 'Anytown',
-                'state': 'CA',
-                'zip_code': '12345',
-                'country': 'USA',
-                'password': 'password123',
-                'confirm_password': 'differentpassword'
+                "email": "newuser@example.com",
+                "first_name": "John",
+                "last_name": "Doe",
+                "location_method": "address",
+                "street": "123 Main St",
+                "city": "Anytown",
+                "state": "CA",
+                "zip_code": "12345",
+                "country": "USA",
+                "password": "password123",
+                "confirm_password": "differentpassword",
             }
             form = RegistrationForm(data=form_data)
             assert form.validate() is False
-            assert 'Passwords must match.' in form.confirm_password.errors
-    
+            assert "Passwords must match." in form.confirm_password.errors
+
     def test_duplicate_email(self, app):
         """Test duplicate email validation."""
         with app.app_context():
             # Create existing user
-            existing_user = UserFactory(email='existing@example.com')
-            
+            UserFactory(email="existing@example.com")
+
             form_data = {
-                'email': 'existing@example.com',
-                'first_name': 'John',
-                'last_name': 'Doe',
-                'location_method': 'address',
-                'street': '123 Main St',
-                'city': 'Anytown',
-                'state': 'CA',
-                'zip_code': '12345',
-                'country': 'USA',
-                'password': 'password123',
-                'confirm_password': 'password123'
+                "email": "existing@example.com",
+                "first_name": "John",
+                "last_name": "Doe",
+                "location_method": "address",
+                "street": "123 Main St",
+                "city": "Anytown",
+                "state": "CA",
+                "zip_code": "12345",
+                "country": "USA",
+                "password": "password123",
+                "confirm_password": "password123",
             }
             form = RegistrationForm(data=form_data)
             assert form.validate() is False
-            assert 'This email is already registered. Please choose a different one.' in form.email.errors
-    
+            assert (
+                "This email is already registered. Please choose a different one."
+                in form.email.errors
+            )
+
     def test_address_method_missing_fields(self, app):
         """Test address method with missing required fields."""
         with app.app_context():
             form_data = {
-                'email': 'newuser@example.com',
-                'first_name': 'John',
-                'last_name': 'Doe',
-                'location_method': 'address',
-                'street': '123 Main St',
+                "email": "newuser@example.com",
+                "first_name": "John",
+                "last_name": "Doe",
+                "location_method": "address",
+                "street": "123 Main St",
                 # Missing city, state, zip_code, country
-                'password': 'password123',
-                'confirm_password': 'password123'
+                "password": "password123",
+                "confirm_password": "password123",
             }
             form = RegistrationForm(data=form_data)
             assert form.validate() is False
-            assert any('is required when entering an address' in str(error) for error in form.errors.values())
-    
+            assert any(
+                "is required when entering an address" in str(error)
+                for error in form.errors.values()
+            )
+
     def test_coordinates_method_missing_fields(self, app):
         """Test coordinates method with missing required fields."""
         with app.app_context():
             form_data = {
-                'email': 'newuser@example.com',
-                'first_name': 'John',
-                'last_name': 'Doe',
-                'location_method': 'coordinates',
+                "email": "newuser@example.com",
+                "first_name": "John",
+                "last_name": "Doe",
+                "location_method": "coordinates",
                 # Missing latitude and longitude
-                'password': 'password123',
-                'confirm_password': 'password123'
+                "password": "password123",
+                "confirm_password": "password123",
             }
             form = RegistrationForm(data=form_data)
             assert form.validate() is False
-            assert 'Latitude is required when entering coordinates directly.' in form.latitude.errors
-            assert 'Longitude is required when entering coordinates directly.' in form.longitude.errors
+            assert (
+                "Latitude is required when entering coordinates directly." in form.latitude.errors
+            )
+            assert (
+                "Longitude is required when entering coordinates directly." in form.longitude.errors
+            )
 
     def test_skip_location_method(self, app):
         """Test skip location method (no location fields required)."""
         with app.app_context():
             form_data = {
-                'email': 'newuser@example.com',
-                'first_name': 'John',
-                'last_name': 'Doe',
-                'location_method': 'skip',
+                "email": "newuser@example.com",
+                "first_name": "John",
+                "last_name": "Doe",
+                "location_method": "skip",
                 # No location fields provided
-                'password': 'password123',
-                'confirm_password': 'password123'
+                "password": "password123",
+                "confirm_password": "password123",
             }
             form = RegistrationForm(data=form_data)
             assert form.validate() is True
@@ -191,19 +202,19 @@ class TestRegistrationForm:
         """Test registration form defaults digest frequency to weekly."""
         with app.app_context():
             form = RegistrationForm()
-            assert form.digest_frequency.data == 'weekly'
+            assert form.digest_frequency.data == "weekly"
 
     def test_registration_digest_frequency_none_is_valid(self, app):
         """Test registration form accepts explicit digest opt-out."""
         with app.app_context():
             form_data = {
-                'email': 'digestnone@example.com',
-                'first_name': 'Digest',
-                'last_name': 'None',
-                'location_method': 'skip',
-                'digest_frequency': 'none',
-                'password': 'password123',
-                'confirm_password': 'password123'
+                "email": "digestnone@example.com",
+                "first_name": "Digest",
+                "last_name": "None",
+                "location_method": "skip",
+                "digest_frequency": "none",
+                "password": "password123",
+                "confirm_password": "password123",
             }
             form = RegistrationForm(data=form_data)
             assert form.validate() is True
@@ -211,82 +222,89 @@ class TestRegistrationForm:
 
 class TestListItemForm:
     """Test ListItemForm."""
-    
+
     def test_valid_list_item_form(self, app):
         """Test valid list item form."""
         with app.app_context():
             category = CategoryFactory()
             form_data = {
-                'name': 'Test Item',
-                'description': 'A test item description',
-                'category': str(category.id),
-                'tags': 'electronics, vintage'
+                "name": "Test Item",
+                "description": "A test item description",
+                "category": str(category.id),
+                "tags": "electronics, vintage",
             }
             form = ListItemForm(data=form_data)
             assert form.validate() is True
-    
+
     def test_missing_required_fields(self, app):
         """Test missing required fields."""
         with app.app_context():
             form_data = {
-                'name': '',  # Required field
-                'description': 'A test item description',
-                'category': '',  # Required field
-                'tags': 'electronics, vintage'
+                "name": "",  # Required field
+                "description": "A test item description",
+                "category": "",  # Required field
+                "tags": "electronics, vintage",
             }
             form = ListItemForm(data=form_data)
             assert form.validate() is False
-            assert any('This field is required.' in error for error in form.name.errors)
-            assert any('This field is required.' in error for error in form.category.errors)
-    
+            assert any("This field is required." in error for error in form.name.errors)
+            assert any("This field is required." in error for error in form.category.errors)
+
     def test_giveaway_without_visibility(self, app):
         """Test giveaway item without visibility selection (should fail)."""
         with app.app_context():
             category = CategoryFactory()
             form_data = {
-                'name': 'Free Item',
-                'description': 'A giveaway item',
-                'category': str(category.id),
-                'is_giveaway': True,
-                'giveaway_visibility': ''  # Missing required visibility
+                "name": "Free Item",
+                "description": "A giveaway item",
+                "category": str(category.id),
+                "is_giveaway": True,
+                "giveaway_visibility": "",  # Missing required visibility
             }
             form = ListItemForm(data=form_data)
             assert form.validate() is False
-            assert 'Please select a visibility option for this giveaway.' in form.giveaway_visibility.errors
+            assert (
+                "Please select a visibility option for this giveaway."
+                in form.giveaway_visibility.errors
+            )
 
     def test_public_giveaway_without_location(self, app):
         """Test that public giveaway fails validation when user has no location set."""
         with app.app_context():
             import flask_login
+
             user = UserFactory(latitude=None, longitude=None)
             category = CategoryFactory()
             with app.test_request_context():
                 flask_login.login_user(user)
                 form_data = {
-                    'name': 'Free Item',
-                    'description': 'A giveaway item',
-                    'category': str(category.id),
-                    'is_giveaway': True,
-                    'giveaway_visibility': 'public',
+                    "name": "Free Item",
+                    "description": "A giveaway item",
+                    "category": str(category.id),
+                    "is_giveaway": True,
+                    "giveaway_visibility": "public",
                 }
                 form = ListItemForm(data=form_data)
                 assert form.validate() is False
-                assert any('You must set your location' in e for e in form.giveaway_visibility.errors)
+                assert any(
+                    "You must set your location" in e for e in form.giveaway_visibility.errors
+                )
 
     def test_public_giveaway_with_location(self, app):
         """Test that public giveaway passes validation when user has location set."""
         with app.app_context():
             import flask_login
+
             user = UserFactory(latitude=40.7128, longitude=-74.0060)
             category = CategoryFactory()
             with app.test_request_context():
                 flask_login.login_user(user)
                 form_data = {
-                    'name': 'Free Item',
-                    'description': 'A giveaway item',
-                    'category': str(category.id),
-                    'is_giveaway': True,
-                    'giveaway_visibility': 'public',
+                    "name": "Free Item",
+                    "description": "A giveaway item",
+                    "category": str(category.id),
+                    "is_giveaway": True,
+                    "giveaway_visibility": "public",
                 }
                 form = ListItemForm(data=form_data)
                 assert form.validate() is True
@@ -295,92 +313,91 @@ class TestListItemForm:
         """Test that circles-only giveaway passes validation even without location."""
         with app.app_context():
             import flask_login
+
             user = UserFactory(latitude=None, longitude=None)
             category = CategoryFactory()
             with app.test_request_context():
                 flask_login.login_user(user)
                 form_data = {
-                    'name': 'Free Item',
-                    'description': 'A giveaway item',
-                    'category': str(category.id),
-                    'is_giveaway': True,
-                    'giveaway_visibility': 'default',
+                    "name": "Free Item",
+                    "description": "A giveaway item",
+                    "category": str(category.id),
+                    "is_giveaway": True,
+                    "giveaway_visibility": "default",
                 }
                 form = ListItemForm(data=form_data)
                 assert form.validate() is True
 
+
 class TestEditProfileForm:
     """Test EditProfileForm."""
-    
+
     def test_valid_edit_profile_form(self, app):
         """Test valid edit profile form."""
         with app.app_context():
-            form_data = {
-                'about_me': 'This is my bio'
-            }
+            form_data = {"about_me": "This is my bio"}
             form = EditProfileForm(data=form_data)
             assert form.validate() is True
-    
+
     def test_about_me_too_long(self, app):
         """Test about_me field too long."""
         with app.app_context():
             form_data = {
-                'about_me': 'x' * 501  # Exceeds 500 character limit
+                "about_me": "x" * 501  # Exceeds 500 character limit
             }
             form = EditProfileForm(data=form_data)
             assert form.validate() is False
 
+
 class TestMessageForm:
     """Test MessageForm."""
-    
+
     def test_valid_message_form(self, app):
         """Test valid message form."""
         with app.app_context():
-            form_data = {
-                'body': 'This is a test message'
-            }
+            form_data = {"body": "This is a test message"}
             form = MessageForm(data=form_data)
             assert form.validate() is True
-    
+
     def test_empty_message(self, app):
         """Test empty message."""
         with app.app_context():
-            form_data = {
-                'body': ''
-            }
+            form_data = {"body": ""}
             form = MessageForm(data=form_data)
             assert form.validate() is False
-            assert any('This field is required.' in error for error in form.body.errors)
+            assert any("This field is required." in error for error in form.body.errors)
+
 
 class TestCircleCreateForm:
     """Test CircleCreateForm."""
-    
+
     def test_valid_circle_create_form(self, app):
         """Test valid circle create form."""
         with app.app_context():
             form_data = {
-                'name': 'Test Circle',
-                'description': 'A test circle description',
-                'circle_type': 'open'
+                "name": "Test Circle",
+                "description": "A test circle description",
+                "circle_type": "open",
             }
             form = CircleCreateForm(data=form_data)
             assert form.validate() is True
-    
+
     def test_missing_circle_name(self, app):
         """Test missing circle name."""
         with app.app_context():
             form_data = {
-                'name': '',
-                'description': 'A test circle description',
-                'circle_type': 'open'
+                "name": "",
+                "description": "A test circle description",
+                "circle_type": "open",
             }
             form = CircleCreateForm(data=form_data)
             assert form.validate() is False
-            assert 'Circle name is required.' in form.name.errors
+            assert "Circle name is required." in form.name.errors
+
 
 class TestLoanRequestForm:
     """Test LoanRequestForm date validations."""
-    
+
     def test_valid_loan_request_form(self, app):
         """Test valid loan request form."""
         with app.app_context():
@@ -389,31 +406,34 @@ class TestLoanRequestForm:
                 end_date = date.today() + timedelta(days=7)
 
                 form_data = {
-                    'start_date': start_date,
-                    'end_date': end_date,
-                    'message': 'I would like to borrow this item for a week.',
-                    'csrf_token': 'test_token'
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "message": "I would like to borrow this item for a week.",
+                    "csrf_token": "test_token",
                 }
                 form = LoanRequestForm(data=form_data)
                 assert form.validate() is True
-    
+
     def test_start_date_in_past(self, app):
         """Test start date in the past."""
         with app.app_context():
             with app.test_request_context():
                 start_date = date.today() - timedelta(days=1)
                 end_date = date.today() + timedelta(days=7)
-                
+
                 form_data = {
-                    'start_date': start_date,
-                    'end_date': end_date,
-                    'message': 'Test message',
-                    'csrf_token': 'test_token'
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "message": "Test message",
+                    "csrf_token": "test_token",
                 }
                 form = LoanRequestForm(data=form_data)
                 assert form.validate() is False
-                assert any('Start date cannot be in the past' in str(error) for error in form.start_date.errors)
-    
+                assert any(
+                    "Start date cannot be in the past" in str(error)
+                    for error in form.start_date.errors
+                )
+
     def test_end_date_in_past(self, app):
         """Test end date in the past."""
         with app.app_context():
@@ -422,31 +442,37 @@ class TestLoanRequestForm:
                 end_date = date.today() - timedelta(days=1)
 
                 form_data = {
-                    'start_date': start_date,
-                    'end_date': end_date,
-                    'message': 'Test message',
-                    'csrf_token': 'test_token'
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "message": "Test message",
+                    "csrf_token": "test_token",
                 }
                 form = LoanRequestForm(data=form_data)
                 assert form.validate() is False
-                assert any('End date must be after start date' in str(error) for error in form.end_date.errors)
-    
+                assert any(
+                    "End date must be after start date" in str(error)
+                    for error in form.end_date.errors
+                )
+
     def test_end_date_before_start_date(self, app):
         """Test end date before start date."""
         with app.app_context():
             with app.test_request_context():
                 start_date = date.today() + timedelta(days=7)
                 end_date = date.today() + timedelta(days=1)
-                
+
                 form_data = {
-                    'start_date': start_date,
-                    'end_date': end_date,
-                    'message': 'Test message',
-                    'csrf_token': 'test_token'
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "message": "Test message",
+                    "csrf_token": "test_token",
                 }
                 form = LoanRequestForm(data=form_data)
                 assert form.validate() is False
-                assert any('End date must be after start date' in str(error) for error in form.end_date.errors)
+                assert any(
+                    "End date must be after start date" in str(error)
+                    for error in form.end_date.errors
+                )
 
     def test_empty_message_fails_validation(self, app):
         """Test that an empty message fails validation with an informative error."""
@@ -456,14 +482,17 @@ class TestLoanRequestForm:
                 end_date = date.today() + timedelta(days=7)
 
                 form_data = {
-                    'start_date': start_date,
-                    'end_date': end_date,
-                    'message': '',
-                    'csrf_token': 'test_token'
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "message": "",
+                    "csrf_token": "test_token",
                 }
                 form = LoanRequestForm(data=form_data)
                 assert form.validate() is False
-                assert any('Please include a message with your request' in str(error) for error in form.message.errors)
+                assert any(
+                    "Please include a message with your request" in str(error)
+                    for error in form.message.errors
+                )
 
     def test_message_too_short_fails_validation(self, app):
         """Test that a message shorter than 10 characters fails validation."""
@@ -473,87 +502,90 @@ class TestLoanRequestForm:
                 end_date = date.today() + timedelta(days=7)
 
                 form_data = {
-                    'start_date': start_date,
-                    'end_date': end_date,
-                    'message': 'Hi',
-                    'csrf_token': 'test_token'
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "message": "Hi",
+                    "csrf_token": "test_token",
                 }
                 form = LoanRequestForm(data=form_data)
                 assert form.validate() is False
-                assert any('Message must be between 10 and 1000 characters' in str(error) for error in form.message.errors)
+                assert any(
+                    "Message must be between 10 and 1000 characters" in str(error)
+                    for error in form.message.errors
+                )
+
 
 class TestOptionalFileAllowed:
     """Test OptionalFileAllowed validator."""
-    
+
     def test_empty_file_allowed(self, app):
         """Test that empty file is allowed."""
         with app.app_context():
             with app.test_request_context():
-                validator = OptionalFileAllowed(['jpg', 'png'])
-                
+                validator = OptionalFileAllowed(["jpg", "png"])
+
                 class MockForm:
                     pass
-                
+
                 class MockField:
                     data = None
-                
+
                 form = MockForm()
                 field = MockField()
-                
+
                 # Should not raise any exception
                 validator(form, field)
-    
+
     def test_valid_file_extension(self, app):
         """Test valid file extension."""
         with app.app_context():
             with app.test_request_context():
-                validator = OptionalFileAllowed(['jpg', 'png'])
-                
+                validator = OptionalFileAllowed(["jpg", "png"])
+
                 # Create a proper mock file
                 mock_file = FileStorage(
-                    stream=BytesIO(b'fake image data'),
-                    filename='test.jpg',
-                    content_type='image/jpeg'
+                    stream=BytesIO(b"fake image data"),
+                    filename="test.jpg",
+                    content_type="image/jpeg",
                 )
-                
+
                 class MockForm:
                     pass
-                
+
                 class MockField:
                     data = mock_file
-                
+
                 form = MockForm()
                 field = MockField()
-                
+
                 # Should not raise ValidationError for valid extension
                 validator(form, field)
-    
+
     def test_invalid_file_extension(self, app):
         """Test invalid file extension."""
         with app.app_context():
             with app.test_request_context():
                 from wtforms.validators import StopValidation
-                validator = OptionalFileAllowed(['jpg', 'png'])
-                
+
+                validator = OptionalFileAllowed(["jpg", "png"])
+
                 # Create a mock file with invalid extension
                 mock_file = FileStorage(
-                    stream=BytesIO(b'fake data'),
-                    filename='test.txt',
-                    content_type='text/plain'
+                    stream=BytesIO(b"fake data"), filename="test.txt", content_type="text/plain"
                 )
-                
+
                 class MockForm:
                     pass
-                
+
                 class MockField:
                     data = mock_file
-                    
+
                     def gettext(self, text):
                         return text
-                
+
                 form = MockForm()
                 field = MockField()
-                
+
                 # Should raise StopValidation for invalid extension
                 with pytest.raises(StopValidation):
                     validator(form, field)

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -4,7 +4,7 @@ from datetime import date, timedelta
 from io import BytesIO
 
 import pytest
-from werkzeug.datastructures import FileStorage
+from werkzeug.datastructures import FileStorage, MultiDict
 
 from app.forms import (
     CircleCreateForm,
@@ -73,12 +73,22 @@ class TestRegistrationForm:
                 "city": "Anytown",
                 "state": "CA",
                 "zip_code": "12345",
-                "country": "USA",
+                "country": "United States of America",
                 "password": "password123",
                 "confirm_password": "password123",
             }
             form = RegistrationForm(data=form_data)
             assert form.validate() is True
+
+    def test_registration_country_dropdown_prioritizes_us_and_canada(self, app):
+        """Test the country dropdown keeps the two most common countries first."""
+        with app.app_context():
+            form = RegistrationForm()
+
+            assert form.country.choices[:2] == [
+                ("United States of America", "United States of America"),
+                ("Canada", "Canada"),
+            ]
 
     def test_valid_registration_form_coordinates(self, app):
         """Test valid registration form with coordinates."""
@@ -108,7 +118,7 @@ class TestRegistrationForm:
                 "city": "Anytown",
                 "state": "CA",
                 "zip_code": "12345",
-                "country": "USA",
+                "country": "United States of America",
                 "password": "password123",
                 "confirm_password": "differentpassword",
             }
@@ -131,7 +141,7 @@ class TestRegistrationForm:
                 "city": "Anytown",
                 "state": "CA",
                 "zip_code": "12345",
-                "country": "USA",
+                "country": "United States of America",
                 "password": "password123",
                 "confirm_password": "password123",
             }
@@ -141,6 +151,30 @@ class TestRegistrationForm:
                 "This email is already registered. Please choose a different one."
                 in form.email.errors
             )
+
+    def test_registration_form_rejects_invalid_country_choice(self, app):
+        """Test registration rejects arbitrary free-text country values."""
+        with app.app_context():
+            form = RegistrationForm(
+                formdata=MultiDict(
+                    {
+                        "email": "newuser@example.com",
+                        "first_name": "John",
+                        "last_name": "Doe",
+                        "location_method": "address",
+                        "street": "123 Main St",
+                        "city": "Anytown",
+                        "state": "CA",
+                        "zip_code": "12345",
+                        "country": "Atlantis",
+                        "password": "password123",
+                        "confirm_password": "password123",
+                    }
+                )
+            )
+
+            assert form.validate() is False
+            assert "Please choose a country from the list." in form.country.errors
 
     def test_address_method_missing_fields(self, app):
         """Test address method with missing required fields."""


### PR DESCRIPTION
Fix #359. This also contains some unrelated linting.

In addition to renaming to Postal Code and State/Province, I converted the country free-text field with USA placeholder to a dropdown of all countries, forcing USA and Canada to the top of the list. This should pave the way for further internationalization, even though I haven't test Nominatim geocoding outside of USA and CA. 

I also improved the calls to Nominatim, including sending the components as structured data and re-trying without postal code upon failure.

Not done: it would be nice if state/province was a dropdown, and when you picked your value, it selected either USA or Canada. But I need to land this.