### PR TITLE
fix: public giveaways show in feed and digest even if owner has no circles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 
 ### Bug fixes
 - Geocoding now sends structured address components to Nominatim and retries without the postal code when that field blocks an otherwise valid street-level match ([#362](https://github.com/sfirke/meutch/pull/362)).
-- Public giveaways from user without circles now appear in home feed and digest, consistent with how requests are treated.
+- Public giveaways from user without circles now appear in home feed and digest, consistent with how requests are treated ([#369](https://github.com/sfirke/meutch/pull/369)).
 
 ### Developer Experience
 - Massive refactor that split `routes.py` into many views and pushed the app logic down into a new service layer ([#352](https://github.com/sfirke/meutch/pull/352)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 
 ### Bug fixes
 - Geocoding now sends structured address components to Nominatim and retries without the postal code when that field blocks an otherwise valid street-level match ([#362](https://github.com/sfirke/meutch/pull/362)).
+- Public giveaways from user without circles now appear in home feed and digest, consistent with how requests are treated.
 
 ### Developer Experience
 - Massive refactor that split `routes.py` into many views and pushed the app logic down into a new service layer ([#352](https://github.com/sfirke/meutch/pull/352)).

--- a/app/main/views/browse.py
+++ b/app/main/views/browse.py
@@ -2,7 +2,7 @@ from flask import redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 
 from app.main import bp as main_bp
-from app.models import Category, Tag
+from app.models import Category, Item, Tag
 from app.utils.home_feed import build_homepage_feed_events
 from app.utils.item_queries import build_category_items_pagination, build_tag_items_pagination
 
@@ -31,6 +31,7 @@ def index():
     selected_circles = []
     item_type = "both"
     has_circles = False
+    show_public_giveaway_nudge = False
     result_count = 0
     selected_feed_scope = "all"
     selected_feed_types = ["requests", "giveaways", "circle_joins", "loans"]
@@ -41,6 +42,15 @@ def index():
         list(current_user.circles), key=lambda circle: (circle.name or "").lower()
     )
     has_circles = len(user_circles) > 0
+    if not has_circles:
+        show_public_giveaway_nudge = (
+            Item.query.filter(
+                Item.owner_id == current_user.id,
+                Item.is_giveaway.is_(True),
+                Item.giveaway_visibility == "public",
+            ).first()
+            is not None
+        )
     selected_circles = request.args.getlist("circles")
     filter_state = _parse_homepage_feed_filters(current_user)
     selected_feed_scope = filter_state["scope"]
@@ -71,6 +81,7 @@ def index():
         selected_circles=selected_circles,
         item_type=item_type,
         has_circles=has_circles,
+        show_public_giveaway_nudge=show_public_giveaway_nudge,
         result_count=result_count,
         selected_feed_scope=selected_feed_scope,
         selected_feed_types=selected_feed_types,

--- a/app/templates/main/_join_circle_prompt.html
+++ b/app/templates/main/_join_circle_prompt.html
@@ -1,8 +1,15 @@
+{% set show_public_giveaway_nudge = show_public_giveaway_nudge|default(false) %}
+
 <div class="card border-info mb-4">
     <div class="card-body text-center py-4">
         <i class="fas fa-users text-info mb-2" style="font-size: 2rem;"></i>
-        <h5>Join a circle to get started</h5>
-        <p class="text-muted mb-3">Circles connect you with nearby people who share and lend items.</p>
+        {% if show_public_giveaway_nudge %}
+            <h5>Your giveaway is live. Join a circle to unlock the rest of Meutch.</h5>
+            <p class="text-muted mb-3">Public giveaways can help you get started, but circles connect you with trusted nearby people, surface more requests, and let you borrow too.</p>
+        {% else %}
+            <h5>Join a circle to get started</h5>
+            <p class="text-muted mb-3">Circles connect you with nearby people who share, request, and lend items.</p>
+        {% endif %}
         <a href="{{ url_for('circles.manage_circles') }}#find-circles-tab" class="btn btn-primary">
             <i class="fas fa-search me-1"></i>Find Circles to Join
         </a>

--- a/app/utils/home_feed.py
+++ b/app/utils/home_feed.py
@@ -57,6 +57,25 @@ def _normalize_scope(scope):
     return "circles" if scope == "circles" else "all"
 
 
+def _build_giveaway_visibility_filter(shared_circle_user_ids, normalized_scope):
+    if normalized_scope == "circles":
+        if shared_circle_user_ids is None:
+            return None
+        return Item.owner_id.in_(shared_circle_user_ids)
+
+    public_filter = Item.giveaway_visibility == "public"
+    if shared_circle_user_ids is None:
+        return public_filter
+
+    return or_(
+        and_(
+            or_(Item.giveaway_visibility == "default", Item.giveaway_visibility.is_(None)),
+            Item.owner_id.in_(shared_circle_user_ids),
+        ),
+        public_filter,
+    )
+
+
 def _normalize_event_types(included_event_types):
     if included_event_types is None:
         return HOMEPAGE_FEED_EVENT_TYPES
@@ -212,28 +231,13 @@ def build_visible_giveaway_events(
     since=None,
     until=None,
 ):
-    if not scoped_circle_ids:
-        return []
-
     now = datetime.now(UTC)
     claimed_cutoff = _utc(since) or (now - timedelta(days=RESOLVED_FEED_WINDOW_DAYS))
     shared_circle_user_ids = _shared_circle_user_ids_query(scoped_circle_ids)
-    all_circle_user_ids = select(circle_members.c.user_id).distinct()
     normalized_scope = _normalize_scope(scope)
-
-    if normalized_scope == "circles":
-        visibility_filter = Item.owner_id.in_(shared_circle_user_ids)
-    else:
-        visibility_filter = or_(
-            and_(
-                or_(Item.giveaway_visibility == "default", Item.giveaway_visibility.is_(None)),
-                Item.owner_id.in_(shared_circle_user_ids),
-            ),
-            and_(
-                Item.giveaway_visibility == "public",
-                Item.owner_id.in_(all_circle_user_ids),
-            ),
-        )
+    visibility_filter = _build_giveaway_visibility_filter(shared_circle_user_ids, normalized_scope)
+    if visibility_filter is None:
+        return []
 
     base_query = Item.query.join(User, Item.owner_id == User.id).filter(
         Item.is_giveaway.is_(True),
@@ -469,28 +473,13 @@ def build_digest_giveaway_events(
     since=None,
     until=None,
 ):
-    if not scoped_circle_ids:
-        return []
-
     since_utc = _utc(since)
     until_utc = _utc(until)
     shared_circle_user_ids = _shared_circle_user_ids_query(scoped_circle_ids)
-    all_circle_user_ids = select(circle_members.c.user_id).distinct()
     normalized_scope = _normalize_scope(scope)
-
-    if normalized_scope == "circles":
-        visibility_filter = Item.owner_id.in_(shared_circle_user_ids)
-    else:
-        visibility_filter = or_(
-            and_(
-                or_(Item.giveaway_visibility == "default", Item.giveaway_visibility.is_(None)),
-                Item.owner_id.in_(shared_circle_user_ids),
-            ),
-            and_(
-                Item.giveaway_visibility == "public",
-                Item.owner_id.in_(all_circle_user_ids),
-            ),
-        )
+    visibility_filter = _build_giveaway_visibility_filter(shared_circle_user_ids, normalized_scope)
+    if visibility_filter is None:
+        return []
 
     base_query = Item.query.join(User, Item.owner_id == User.id).filter(
         Item.is_giveaway.is_(True),

--- a/tests/integration/test_giveaway_routes.py
+++ b/tests/integration/test_giveaway_routes.py
@@ -79,6 +79,34 @@ class TestGiveawayItemCreation:
             assert item.giveaway_visibility == "public"
             assert item.claim_status == "unclaimed"
 
+    def test_create_public_giveaway_shows_join_circle_nudge_for_no_circle_user(
+        self, client, app, auth_user
+    ):
+        """Posting a public giveaway without circles should land on the persistent join-circle nudge."""
+        with app.app_context():
+            user = auth_user()
+            category = CategoryFactory()
+            login_user(client, user.email)
+
+            response = client.post(
+                "/list-item",
+                data={
+                    "name": "Starter Giveaway",
+                    "description": "Still useful and ready to share",
+                    "category": str(category.id),
+                    "is_giveaway": True,
+                    "giveaway_visibility": "public",
+                    "tags": "",
+                },
+                follow_redirects=True,
+            )
+
+            assert response.status_code == 200
+            content = response.data.decode("utf-8")
+            assert "Starter Giveaway" in content
+            assert "Your giveaway is live. Join a circle to unlock the rest of Meutch." in content
+            assert "Find Circles to Join" in content
+
     def test_create_loan_item(self, client, app, auth_user):
         """Test creating a regular loan item (not giveaway)."""
         with app.app_context():

--- a/tests/integration/test_routes.py
+++ b/tests/integration/test_routes.py
@@ -122,6 +122,41 @@ class TestMainRoutes:
             assert "Shared Scope Giveaway" in circles_scope_content
             assert "Outsider Scope Giveaway" not in circles_scope_content
 
+    def test_home_feed_no_circle_viewer_sees_public_request_and_giveaway_with_join_prompt(
+        self, client, app, auth_user
+    ):
+        """No-circle viewers should still see public activity while being nudged to join a circle."""
+        with app.app_context():
+            viewer = auth_user()
+            requester = UserFactory()
+            giveaway_owner = UserFactory()
+            category = CategoryFactory()
+
+            ItemRequestFactory(
+                user=requester,
+                title="No Circle Public Request",
+                visibility="public",
+            )
+            ItemFactory(
+                owner=giveaway_owner,
+                category=category,
+                is_giveaway=True,
+                giveaway_visibility="public",
+                claim_status="unclaimed",
+                name="No Circle Public Giveaway",
+            )
+            db.session.commit()
+
+            login_user(client, viewer.email)
+            response = client.get("/")
+            content = response.data.decode("utf-8")
+
+            assert response.status_code == 200
+            assert "No Circle Public Request" in content
+            assert "No Circle Public Giveaway" in content
+            assert "Join a circle to get started" in content
+            assert "Find Circles to Join" in content
+
     def test_home_feed_distance_filter_hides_far_requests_and_giveaways(
         self, client, app, auth_user
     ):

--- a/tests/unit/test_home_feed.py
+++ b/tests/unit/test_home_feed.py
@@ -146,6 +146,62 @@ def test_build_visible_giveaway_events_include_recently_claimed_items(app):
         assert claimed_event["created_at"] == claimed_item.claimed_at.replace(tzinfo=UTC)
 
 
+def test_build_visible_giveaway_events_include_public_giveaways_for_no_circle_viewer(app):
+    with app.app_context():
+        viewer = UserFactory()
+        public_owner = UserFactory()
+        default_owner = UserFactory()
+        category = CategoryFactory()
+
+        public_item = ItemFactory(
+            owner=public_owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility="public",
+            claim_status="unclaimed",
+            name="Public No Circle Giveaway",
+        )
+        default_item = ItemFactory(
+            owner=default_owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility="default",
+            claim_status="unclaimed",
+            name="Default No Circle Giveaway",
+        )
+        db.session.commit()
+
+        events = build_visible_giveaway_events(viewer, scoped_circle_ids=set(), scope="all")
+
+        item_ids = {event["item_id"] for event in events}
+        assert public_item.id in item_ids
+        assert default_item.id not in item_ids
+
+
+def test_build_visible_giveaway_events_include_public_giveaway_from_no_circle_owner(app):
+    with app.app_context():
+        viewer = UserFactory()
+        shared_circle_member = UserFactory()
+        public_owner = UserFactory()
+        category = CategoryFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, shared_circle_member])
+
+        public_item = ItemFactory(
+            owner=public_owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility="public",
+            claim_status="unclaimed",
+            name="Public Giveaway From No Circle Owner",
+        )
+        db.session.commit()
+
+        events = build_visible_giveaway_events(viewer, scoped_circle_ids={circle.id}, scope="all")
+
+        assert public_item.id in {event["item_id"] for event in events}
+
+
 def test_build_recent_lent_events_hides_borrower_identity(app):
     with app.app_context():
         viewer = UserFactory()
@@ -270,6 +326,69 @@ def test_build_digest_payload_respects_window_and_include_toggles(app):
         assert payload["requests"] == []
         assert payload["circle_joins"] == []
         assert payload["loans"] == []
+
+
+def test_build_digest_payload_includes_public_giveaway_from_no_circle_user_when_enabled(app):
+    with app.app_context():
+        viewer = UserFactory(
+            digest_include_giveaways=True,
+            digest_include_requests=False,
+            digest_include_circle_joins=False,
+            digest_include_loans=False,
+            digest_giveaways_include_public=True,
+        )
+        shared_circle_member = UserFactory()
+        owner = UserFactory()
+        category = CategoryFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, shared_circle_member])
+        now = datetime.now(UTC)
+
+        public_item = ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility="public",
+            claim_status="unclaimed",
+            name="Digest Public Giveaway",
+            created_at=now - timedelta(hours=2),
+        )
+        db.session.commit()
+
+        payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
+
+        assert [event["item_id"] for event in payload["giveaways"]] == [public_item.id]
+        assert payload["summary_stats"]["giveaways_count"] == 1
+
+
+def test_build_digest_payload_excludes_public_giveaway_from_no_circle_user_when_disabled(app):
+    with app.app_context():
+        viewer = UserFactory(
+            digest_include_giveaways=True,
+            digest_include_requests=False,
+            digest_include_circle_joins=False,
+            digest_include_loans=False,
+            digest_giveaways_include_public=False,
+        )
+        owner = UserFactory()
+        category = CategoryFactory()
+        now = datetime.now(UTC)
+
+        ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility="public",
+            claim_status="unclaimed",
+            name="Digest Hidden Giveaway",
+            created_at=now - timedelta(hours=2),
+        )
+        db.session.commit()
+
+        payload = build_digest_payload(viewer, since=now - timedelta(days=1), until=now)
+
+        assert payload["giveaways"] == []
+        assert payload["events"] == []
 
 
 def test_build_digest_payload_summary_stats_counts_requests_and_giveaways(app):


### PR DESCRIPTION
A user joined today, didn't join a circle but did list a public giveaway. I'd like them to join a circle but this is better than nothing - and right now their giveaway can't be seen by anyone.

**TESTING**
Deployed to staging and verified that I can now see the item that is failing to appear in production.