### PR TITLE
fix: guard against duplicate item creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 ### Bug fixes
 - Geocoding now sends structured address components to Nominatim and retries without the postal code when that field blocks an otherwise valid street-level match ([#362](https://github.com/sfirke/meutch/pull/362)).
 - Public giveaways from user without circles now appear in home feed and digest, consistent with how requests are treated ([#369](https://github.com/sfirke/meutch/pull/369)).
+- Fixes to block block dual-item creation: adopt idempotency token, disable form submission button ([#377](https://github.com/sfirke/meutch/pull/377)).
+- Delete item modal is no longer grayed out and untouchable when deleting an item from profile page (fixes #376) ([#377](https://github.com/sfirke/meutch/pull/377)).
+
 
 ### Developer Experience
 - Massive refactor that split `routes.py` into many views and pushed the app logic down into a new service layer ([#352](https://github.com/sfirke/meutch/pull/352)).

--- a/app/forms_items.py
+++ b/app/forms_items.py
@@ -21,6 +21,7 @@ class ListItemForm(FlaskForm):
     category = SelectField("Category", coerce=str, validators=[DataRequired()])
     tags = StringField("Tags (comma-separated)", validators=[Length(max=200)])
     image = MultipleFileField("Images", validators=[])
+    creation_token = HiddenField("Creation Token", validators=[Optional()])
     delete_images = HiddenField("Delete Images")
     image_order = HiddenField("Image Order")
     is_giveaway = BooleanField("This is a giveaway (free item)")

--- a/app/main/views/items.py
+++ b/app/main/views/items.py
@@ -17,7 +17,7 @@ from app.forms import (
 from app.main import bp as main_bp
 from app.models import GiveawayInterest, Item, Message
 from app.services import item_service, message_service
-from app.services.exceptions import AuthorizationError, ConflictError, InformationalError
+from app.services.exceptions import AuthorizationError, ConflictError
 from app.utils.giveaway_visibility import get_unavailable_giveaway_suggestions
 from app.utils.item_share import ITEM_SHARE_TOKEN_MAX_AGE_DAYS
 from app.utils.item_visibility import build_item_access_state
@@ -63,13 +63,6 @@ def list_item():
     creation_token = _ensure_item_creation_token(form)
 
     if form.validate_on_submit():
-        existing_item = item_service.get_item_by_creation_token(current_user.id, creation_token)
-        if existing_item is not None:
-            return _duplicate_item_creation_response(
-                existing_item,
-                form.submit_and_create_another.data,
-            )
-
         uploaded_files, upload_errors = _collect_item_image_uploads(form.image.data)
         if upload_errors:
             for error in upload_errors:
@@ -81,7 +74,7 @@ def list_item():
             return render_template("main/list_item.html", form=form)
 
         try:
-            new_item = item_service.create_item(
+            creation_result = item_service.create_item(
                 current_user,
                 form.name.data,
                 form.description.data,
@@ -98,23 +91,6 @@ def list_item():
                 "error",
             )
             return render_template("main/list_item.html", form=form)
-        except InformationalError:
-            existing_item = item_service.get_item_by_creation_token(current_user.id, creation_token)
-            if existing_item is not None:
-                return _duplicate_item_creation_response(
-                    existing_item,
-                    form.submit_and_create_another.data,
-                )
-
-            current_app.logger.warning(
-                "Duplicate item creation was reported for user %s without a matching creation token row.",
-                current_user.id,
-            )
-            flash(
-                "We could not confirm whether this item was already created. Please check your profile.",
-                "warning",
-            )
-            return redirect(url_for("main.profile", tab="my-items"))
         except Exception as exc:
             current_app.logger.error(
                 f"Failed to create item for user {current_user.id}: {str(exc)}"
@@ -122,12 +98,18 @@ def list_item():
             flash("We could not save your item. Please try again.", "error")
             return render_template("main/list_item.html", form=form)
 
+        if not creation_result.was_created:
+            return _duplicate_item_creation_response(
+                creation_result.item,
+                form.submit_and_create_another.data,
+            )
+
         from markupsafe import Markup, escape
 
-        item_link = url_for("main.item_detail", item_id=new_item.id)
+        item_link = url_for("main.item_detail", item_id=creation_result.item.id)
         message = Markup(
             'Item "<a href="{}" class="alert-link">{}</a>" has been listed successfully!'
-        ).format(item_link, escape(new_item.name))
+        ).format(item_link, escape(creation_result.item.name))
 
         if form.submit_and_create_another.data:
             flash(message, "success")

--- a/app/main/views/items.py
+++ b/app/main/views/items.py
@@ -1,3 +1,5 @@
+import uuid
+
 from flask import abort, current_app, flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 
@@ -15,7 +17,7 @@ from app.forms import (
 from app.main import bp as main_bp
 from app.models import GiveawayInterest, Item, Message
 from app.services import item_service, message_service
-from app.services.exceptions import AuthorizationError, ConflictError
+from app.services.exceptions import AuthorizationError, ConflictError, InformationalError
 from app.utils.giveaway_visibility import get_unavailable_giveaway_suggestions
 from app.utils.item_share import ITEM_SHARE_TOKEN_MAX_AGE_DAYS
 from app.utils.item_visibility import build_item_access_state
@@ -29,11 +31,45 @@ from .helpers import (
 )
 
 
+def _ensure_item_creation_token(form):
+    try:
+        creation_token = uuid.UUID(str(form.creation_token.data))
+    except (AttributeError, TypeError, ValueError):
+        creation_token = uuid.uuid4()
+
+    form.creation_token.data = str(creation_token)
+    return creation_token
+
+
+def _duplicate_item_creation_response(item, submit_and_create_another):
+    from markupsafe import Markup, escape
+
+    item_link = url_for("main.item_detail", item_id=item.id)
+    message = Markup(
+        'We already listed this item from your earlier submission: <a href="{}" class="alert-link">{}</a>.'
+    ).format(item_link, escape(item.name))
+    flash(message, "info")
+
+    if submit_and_create_another:
+        return redirect(url_for("main.list_item"))
+
+    return redirect(url_for("main.index"))
+
+
 @main_bp.route("/list-item", methods=["GET", "POST"])
 @login_required
 def list_item():
     form = ListItemForm()
+    creation_token = _ensure_item_creation_token(form)
+
     if form.validate_on_submit():
+        existing_item = item_service.get_item_by_creation_token(current_user.id, creation_token)
+        if existing_item is not None:
+            return _duplicate_item_creation_response(
+                existing_item,
+                form.submit_and_create_another.data,
+            )
+
         uploaded_files, upload_errors = _collect_item_image_uploads(form.image.data)
         if upload_errors:
             for error in upload_errors:
@@ -54,6 +90,7 @@ def list_item():
                 form.giveaway_visibility.data,
                 form.tags.data,
                 uploaded_files,
+                creation_token=creation_token,
             )
         except ValueError:
             flash(
@@ -61,6 +98,23 @@ def list_item():
                 "error",
             )
             return render_template("main/list_item.html", form=form)
+        except InformationalError:
+            existing_item = item_service.get_item_by_creation_token(current_user.id, creation_token)
+            if existing_item is not None:
+                return _duplicate_item_creation_response(
+                    existing_item,
+                    form.submit_and_create_another.data,
+                )
+
+            current_app.logger.warning(
+                "Duplicate item creation was reported for user %s without a matching creation token row.",
+                current_user.id,
+            )
+            flash(
+                "We could not confirm whether this item was already created. Please check your profile.",
+                "warning",
+            )
+            return redirect(url_for("main.profile", tab="my-items"))
         except Exception as exc:
             current_app.logger.error(
                 f"Failed to create item for user {current_user.id}: {str(exc)}"

--- a/app/models.py
+++ b/app/models.py
@@ -352,6 +352,7 @@ class Item(db.Model):
     owner_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=False)
     available = db.Column(db.Boolean, default=True)
     created_at = db.Column(db.DateTime, default=func.now())
+    creation_token = db.Column(UUID(as_uuid=True), unique=True, nullable=True)
     category_id = db.Column(UUID(as_uuid=True), db.ForeignKey("category.id"), nullable=False)
     loan_requests = db.relationship("LoanRequest", backref="item")
     is_giveaway = db.Column(db.Boolean, nullable=False, default=False, server_default="false")

--- a/app/services/item_service.py
+++ b/app/services/item_service.py
@@ -1,7 +1,16 @@
+from sqlalchemy.exc import IntegrityError
+
 from app import db
 from app.models import GiveawayInterest, Item, ItemImage, LoanRequest, Message, Tag
-from app.services.exceptions import AuthorizationError, ConflictError
+from app.services.exceptions import AuthorizationError, ConflictError, InformationalError
 from app.utils.storage import delete_item_images, upload_item_images
+
+
+def get_item_by_creation_token(owner_id, creation_token):
+    if creation_token is None:
+        return None
+
+    return Item.query.filter_by(owner_id=owner_id, creation_token=creation_token).first()
 
 
 def get_giveaway_conversion_blocker(item):
@@ -85,12 +94,13 @@ def _sync_item_tags(item, raw_tag_input):
         return
 
     tag_names = [tag.strip().lower() for tag in tag_input.split(",") if tag.strip()]
-    for tag_name in tag_names:
-        tag = Tag.query.filter_by(name=tag_name).first()
-        if not tag:
-            tag = Tag(name=tag_name)
-            db.session.add(tag)
-        item.tags.append(tag)
+    with db.session.no_autoflush:
+        for tag_name in tag_names:
+            tag = Tag.query.filter_by(name=tag_name).first()
+            if not tag:
+                tag = Tag(name=tag_name)
+                db.session.add(tag)
+            item.tags.append(tag)
 
 
 def create_item(
@@ -102,7 +112,12 @@ def create_item(
     giveaway_visibility,
     raw_tag_input,
     uploaded_files,
+    creation_token=None,
 ):
+    existing_item = get_item_by_creation_token(owner.id, creation_token)
+    if existing_item is not None:
+        raise InformationalError("This item was already listed from your earlier submission.")
+
     image_urls = []
     if uploaded_files:
         image_urls = upload_item_images(uploaded_files)
@@ -112,6 +127,7 @@ def create_item(
         description=description.strip(),
         owner=owner,
         category_id=category_id,
+        creation_token=creation_token,
         is_giveaway=is_giveaway,
         giveaway_visibility=giveaway_visibility if is_giveaway else None,
         claim_status="unclaimed" if is_giveaway else None,
@@ -125,6 +141,18 @@ def create_item(
 
     try:
         db.session.commit()
+    except IntegrityError as exc:
+        db.session.rollback()
+        if image_urls:
+            delete_item_images(image_urls)
+
+        existing_item = get_item_by_creation_token(owner.id, creation_token)
+        if existing_item is not None:
+            raise InformationalError(
+                "This item was already listed from your earlier submission."
+            ) from exc
+
+        raise
     except Exception:
         db.session.rollback()
         if image_urls:

--- a/app/services/item_service.py
+++ b/app/services/item_service.py
@@ -1,12 +1,20 @@
+from dataclasses import dataclass
+
 from sqlalchemy.exc import IntegrityError
 
 from app import db
 from app.models import GiveawayInterest, Item, ItemImage, LoanRequest, Message, Tag
-from app.services.exceptions import AuthorizationError, ConflictError, InformationalError
+from app.services.exceptions import AuthorizationError, ConflictError
 from app.utils.storage import delete_item_images, upload_item_images
 
 
-def get_item_by_creation_token(owner_id, creation_token):
+@dataclass
+class ItemCreationResult:
+    item: Item
+    was_created: bool
+
+
+def _get_item_by_creation_token(owner_id, creation_token):
     if creation_token is None:
         return None
 
@@ -114,9 +122,9 @@ def create_item(
     uploaded_files,
     creation_token=None,
 ):
-    existing_item = get_item_by_creation_token(owner.id, creation_token)
+    existing_item = _get_item_by_creation_token(owner.id, creation_token)
     if existing_item is not None:
-        raise InformationalError("This item was already listed from your earlier submission.")
+        return ItemCreationResult(item=existing_item, was_created=False)
 
     image_urls = []
     if uploaded_files:
@@ -141,16 +149,14 @@ def create_item(
 
     try:
         db.session.commit()
-    except IntegrityError as exc:
+    except IntegrityError:
         db.session.rollback()
         if image_urls:
             delete_item_images(image_urls)
 
-        existing_item = get_item_by_creation_token(owner.id, creation_token)
+        existing_item = _get_item_by_creation_token(owner.id, creation_token)
         if existing_item is not None:
-            raise InformationalError(
-                "This item was already listed from your earlier submission."
-            ) from exc
+            return ItemCreationResult(item=existing_item, was_created=False)
 
         raise
     except Exception:
@@ -159,7 +165,7 @@ def create_item(
             delete_item_images(image_urls)
         raise
 
-    return new_item
+    return ItemCreationResult(item=new_item, was_created=True)
 
 
 def update_item(

--- a/app/static/js/multi-image-upload.js
+++ b/app/static/js/multi-image-upload.js
@@ -28,6 +28,7 @@
     var newFiles = new Map();
     var deletedIds = new Set();
     var clickedSubmitBtn = null;
+    var isSubmitting = false;
     var pendingFilesCount = 0;
     var maxImages = parsePositiveInt(container.dataset.maxImages, DEFAULT_MAX_IMAGES);
     var maxFileSize = parsePositiveInt(container.dataset.maxFileSizeBytes, DEFAULT_MAX_FILE_SIZE);
@@ -38,6 +39,15 @@
     var compressMaxWidth = parsePositiveInt(container.dataset.compressMaxWidth, DEFAULT_COMPRESS_MAX_WIDTH);
     var compressMaxHeight = parsePositiveInt(container.dataset.compressMaxHeight, DEFAULT_COMPRESS_MAX_HEIGHT);
     var compressionQuality = parseQuality(container.dataset.compressionQuality, DEFAULT_COMPRESSION_QUALITY);
+    var singleSubmit = form && form.dataset.singleSubmit === 'true';
+
+    function setSubmitControlsDisabled(disabled) {
+      if (!form) return;
+
+      form.querySelectorAll('button[type=submit], input[type=submit]').forEach(function (control) {
+        control.disabled = disabled;
+      });
+    }
 
     // Parse existing images from data attribute
     var existingImages = [];
@@ -631,6 +641,13 @@
 
     // Form submission
     if (form) {
+      window.addEventListener('pageshow', function () {
+        isSubmitting = false;
+        if (singleSubmit) {
+          setSubmitControlsDisabled(false);
+        }
+      });
+
       // Track which submit button was clicked
       form.addEventListener('click', function (e) {
         var btn = e.target.closest('button[type=submit], input[type=submit]');
@@ -643,6 +660,11 @@
         if (pendingFilesCount > 0) {
           e.preventDefault();
           showNotification('Please wait for photos to finish processing.', 'warning');
+          return;
+        }
+
+        if (singleSubmit && isSubmitting) {
+          e.preventDefault();
           return;
         }
 
@@ -683,6 +705,11 @@
           hidden.value = clickedSubmitBtn.value;
           hidden.className = 'multi-image-submit-proxy';
           form.appendChild(hidden);
+        }
+
+        if (singleSubmit) {
+          isSubmitting = true;
+          setSubmitControlsDisabled(true);
         }
 
         // Let the form submit naturally

--- a/app/templates/main/_item_card.html
+++ b/app/templates/main/_item_card.html
@@ -52,13 +52,13 @@
             </div>
         </a>
     {% endif %}
-    
+
     <div class="card-body d-flex flex-column">
         <h5 class="card-title">
             <a href="{{ item_url }}" class="text-decoration-none text-reset">{{ item.name }}</a>
         </h5>
         <p class="card-text text-muted">{{ item.description|truncate(100) }}</p>
-        
+
         <!-- Distance indicator (only for other users' items) -->
         <div class="mb-2">
             {% if current_user.is_authenticated and current_user.id != item.owner_id %}
@@ -70,7 +70,7 @@
                 {% endif %}
             {% endif %}
         </div>
-        
+
         {% if item.category %}
             <div class="mb-2">
                 <a href="{{ url_for('main.category_items', category_id=item.category.id) }}" class="category text-decoration-none">
@@ -78,7 +78,7 @@
                 </a>
             </div>
         {% endif %}
-        
+
         {% if item.tags %}
             <div class="mb-3">
                 {% for tag in item.tags[:3] %}
@@ -93,7 +93,7 @@
                 {% endif %}
             </div>
         {% endif %}
-        
+
         {% if show_owner_controls and delete_forms %}
             <!-- Owner controls: Loan (if active), Edit, Delete -->
             <div class="mt-auto d-flex gap-2 justify-content-end">
@@ -110,11 +110,15 @@
                     <button type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal" data-bs-target="#{{ delete_modal_id }}" title="Delete item">
                         <i class="fas fa-trash me-1"></i>Delete
                     </button>
-                    {% set item_delete_form = delete_forms[item.id] %}
-                    {% set item_confirm_handoff_form = confirm_handoff_forms[item.id] if confirm_handoff_forms is defined and item.id in confirm_handoff_forms else none %}
-                    {% include 'main/_delete_item_modal.html' %}
                 {% endif %}
             </div>
         {% endif %}
     </div>
 </div>
+
+{% if show_owner_controls and delete_forms and item.id in delete_forms %}
+    {% set delete_modal_id = 'deleteItemModal-' ~ item.id %}
+    {% set item_delete_form = delete_forms[item.id] %}
+    {% set item_confirm_handoff_form = confirm_handoff_forms[item.id] if confirm_handoff_forms is defined and item.id in confirm_handoff_forms else none %}
+    {% include 'main/_delete_item_modal.html' %}
+{% endif %}

--- a/app/templates/main/list_item.html
+++ b/app/templates/main/list_item.html
@@ -7,9 +7,10 @@
 {% block content %}
 <div class="container mt-5">
     <h2>List a New Item</h2>
-    <form method="post" enctype="multipart/form-data">
+    <form method="post" enctype="multipart/form-data" data-single-submit="true">
         {{ form.csrf_token }}
-        
+        {{ form.creation_token() }}
+
         <!-- Item Name -->
         <div class="mb-3">
             {{ form.name.label(class="form-label") }}
@@ -18,7 +19,7 @@
                 <div class="text-danger">{{ error }}</div>
             {% endfor %}
         </div>
-        
+
         <!-- Description -->
         <div class="mb-3">
             {{ form.description.label(class="form-label") }}
@@ -27,7 +28,7 @@
                 <div class="text-danger">{{ error }}</div>
             {% endfor %}
         </div>
-        
+
         <!-- Images -->
         <div class="mb-3 multi-image-upload"
              data-max-images="{{ item_upload_limits.max_images }}"
@@ -60,7 +61,7 @@
                 <div class="text-danger">{{ error }}</div>
             {% endfor %}
         </div>
-        
+
         <!-- Tags -->
         <div class="mb-3">
             {{ form.tags.label(class="form-label") }}
@@ -69,7 +70,7 @@
                 <div class="text-danger">{{ error }}</div>
             {% endfor %}
         </div>
-        
+
         <!-- Giveaway Option -->
         <div class="mb-3">
             <div class="form-check">
@@ -80,7 +81,7 @@
                 <div class="text-danger">{{ error }}</div>
             {% endfor %}
         </div>
-        
+
         <!-- Giveaway Visibility (conditional) -->
         <div class="mb-3" id="giveawayVisibilitySection" style="display: none;">
             {{ form.giveaway_visibility.label(class="form-label") }}
@@ -94,7 +95,7 @@
                 <div class="text-danger">{{ error }}</div>
             {% endfor %}
         </div>
-        
+
         <!-- Submit Buttons -->
         <div class="mb-3 d-grid gap-2 d-md-flex justify-content-md-start">
             {{ form.submit(class="btn btn-primary") }}
@@ -108,7 +109,7 @@
     document.addEventListener('DOMContentLoaded', function() {
         const giveawayCheckbox = document.getElementById('isGiveawayCheckbox');
         const visibilitySection = document.getElementById('giveawayVisibilitySection');
-        
+
         function toggleVisibilitySection() {
             if (giveawayCheckbox.checked) {
                 visibilitySection.style.display = 'block';
@@ -116,10 +117,10 @@
                 visibilitySection.style.display = 'none';
             }
         }
-        
+
         // Initialize on page load
         toggleVisibilitySection();
-        
+
         // Update when checkbox changes
         giveawayCheckbox.addEventListener('change', toggleVisibilitySection);
     });

--- a/migrations/versions/20260520_add_item_creation_token.py
+++ b/migrations/versions/20260520_add_item_creation_token.py
@@ -1,0 +1,30 @@
+"""add item creation token for idempotent listing
+
+Revision ID: 20260520_item_creation_token
+Revises: 20260516_api_jwt_auth
+Create Date: 2026-05-20 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20260520_item_creation_token"
+down_revision = "20260516_api_jwt_auth"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "item",
+        sa.Column("creation_token", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_unique_constraint("uq_item_creation_token", "item", ["creation_token"])
+
+
+def downgrade():
+    op.drop_constraint("uq_item_creation_token", "item", type_="unique")
+    op.drop_column("item", "creation_token")

--- a/tests/integration/test_profile_giveaways.py
+++ b/tests/integration/test_profile_giveaways.py
@@ -1,109 +1,117 @@
 """Integration tests for profile giveaway display."""
-import pytest
-from datetime import datetime, UTC, timedelta
+
+import re
+from datetime import UTC, datetime, timedelta
+
 from app import db
 from app.models import Item
-from tests.factories import UserFactory, ItemFactory, CategoryFactory
 from conftest import login_user
+from tests.factories import CategoryFactory, ItemFactory, UserFactory
 
 
 class TestProfileGiveawaysSeparation:
     """Test that profile separates active and past giveaways."""
-    
+
     def test_profile_shows_active_giveaways(self, client, app, auth_user):
         """Test that profile displays unclaimed giveaways in active section."""
         with app.app_context():
             user = auth_user()
             category = CategoryFactory()
-            
+
             # Create unclaimed giveaway
-            unclaimed_giveaway = ItemFactory(
+            ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='unclaimed',
-                name='Unclaimed Item'
+                claim_status="unclaimed",
+                name="Unclaimed Item",
             )
             db.session.commit()
-            
+
             login_user(client, user.email)
-            response = client.get('/profile')
-            
+            response = client.get("/profile")
+
             assert response.status_code == 200
-            assert b'My Active Giveaways' in response.data
-            assert b'Unclaimed Item' in response.data
-    
+            assert b"My Active Giveaways" in response.data
+            assert b"Unclaimed Item" in response.data
+
     def test_profile_claimed_giveaways_cannot_be_deleted(self, client, app, auth_user):
         """Test that claimed giveaways don't have delete/edit buttons and can't be deleted."""
         with app.app_context():
             user = auth_user()
             recipient = UserFactory()
             category = CategoryFactory()
-            
+
             # Create claimed giveaway
             claimed_giveaway = ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='claimed',
+                claim_status="claimed",
                 claimed_by=recipient,
                 claimed_at=datetime.now(UTC) - timedelta(days=5),
-                name='Claimed Giveaway'
+                name="Claimed Giveaway",
             )
             item_id = claimed_giveaway.id
             db.session.commit()
-            
+
             login_user(client, user.email)
-            
+
             # Check profile page shows the claimed giveaway in past section
-            response = client.get('/profile')
+            response = client.get("/profile")
             assert response.status_code == 200
-            assert b'Claimed Giveaway' in response.data
-            assert b'My Past Giveaways' in response.data
-            
+            assert b"Claimed Giveaway" in response.data
+            assert b"My Past Giveaways" in response.data
+
             # Verify no edit or delete buttons are present on page
-            assert b'btn-warning' not in response.data, "Edit button should not appear for past giveaways"
-            assert b'btn-danger' not in response.data, "Delete button should not appear for past giveaways"
-            
+            assert (
+                b"btn-warning" not in response.data
+            ), "Edit button should not appear for past giveaways"
+            assert (
+                b"btn-danger" not in response.data
+            ), "Delete button should not appear for past giveaways"
+
             # Try to delete the claimed giveaway via POST
-            response = client.post(
-                f'/item/{item_id}/delete',
-                follow_redirects=True
-            )
-            
+            response = client.post(f"/item/{item_id}/delete", follow_redirects=True)
+
             # Should get an error message
-            assert b'cannot delete a giveaway that has been claimed' in response.data or b'completed transaction' in response.data
-            
+            assert (
+                b"cannot delete a giveaway that has been claimed" in response.data
+                or b"completed transaction" in response.data
+            )
+
             # Verify the item still exists
             item = db.session.get(Item, item_id)
             assert item is not None
-    
+
     def test_profile_shows_pending_pickup_in_active(self, client, app, auth_user):
         """Test that profile displays pending_pickup giveaways in active section."""
         with app.app_context():
             user = auth_user()
             recipient = UserFactory()
             category = CategoryFactory()
-            
+
             # Create pending_pickup giveaway
-            pending_giveaway = ItemFactory(
+            ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='pending_pickup',
+                claim_status="pending_pickup",
                 claimed_by=recipient,
-                name='Pending Pickup Item'
+                name="Pending Pickup Item",
             )
             db.session.commit()
-            
-            login_user(client, user.email)
-            response = client.get('/profile')
-            
-            assert response.status_code == 200
-            assert b'My Active Giveaways' in response.data
-            assert b'Pending Pickup Item' in response.data
 
-    def test_profile_pending_pickup_delete_modal_offers_handoff_completion(self, client, app, auth_user):
+            login_user(client, user.email)
+            response = client.get("/profile")
+
+            assert response.status_code == 200
+            assert b"My Active Giveaways" in response.data
+            assert b"Pending Pickup Item" in response.data
+
+    def test_profile_pending_pickup_delete_modal_offers_handoff_completion(
+        self, client, app, auth_user
+    ):
         """Pending-pickup giveaway cards should steer owners to complete the handoff instead of deleting."""
         with app.app_context():
             user = auth_user()
@@ -114,199 +122,217 @@ class TestProfileGiveawaysSeparation:
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='pending_pickup',
+                claim_status="pending_pickup",
                 claimed_by=recipient,
-                name='Pending Pickup Item'
+                name="Pending Pickup Item",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/profile')
+            response = client.get("/profile")
 
             assert response.status_code == 200
-            assert b'This giveaway is still pending pickup' in response.data
-            assert b'Mark Handoff Complete' in response.data
-    
+            assert b"This giveaway is still pending pickup" in response.data
+            assert b"Mark Handoff Complete" in response.data
+
+    def test_profile_delete_modal_renders_after_card_markup(self, client, app, auth_user):
+        """Profile item cards should render the delete modal outside the card so Bootstrap can own the backdrop."""
+        with app.app_context():
+            user = auth_user()
+            category = CategoryFactory()
+            item = ItemFactory(
+                owner=user, category=category, is_giveaway=False, name="Modal Placement Item"
+            )
+            db.session.commit()
+
+            login_user(client, user.email)
+            response = client.get("/profile")
+
+            assert response.status_code == 200
+
+            content = response.data.decode("utf-8")
+            pattern = re.compile(
+                rf'</div>\s*</div>\s*</div>\s*<div class="modal fade" id="deleteItemModal-{item.id}"'
+            )
+            assert pattern.search(content)
+
     def test_profile_shows_recently_claimed_in_past(self, client, app, auth_user):
         """Test that profile displays recently claimed giveaways in past section."""
         with app.app_context():
             user = auth_user()
             recipient = UserFactory()
             category = CategoryFactory()
-            
+
             # Create claimed giveaway (10 days ago)
-            claimed_giveaway = ItemFactory(
+            ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='claimed',
+                claim_status="claimed",
                 claimed_by=recipient,
                 claimed_at=datetime.now(UTC) - timedelta(days=10),
-                name='Recently Claimed Item'
+                name="Recently Claimed Item",
             )
             db.session.commit()
-            
+
             login_user(client, user.email)
-            response = client.get('/profile')
-            
+            response = client.get("/profile")
+
             assert response.status_code == 200
-            assert b'My Past Giveaways' in response.data
+            assert b"My Past Giveaways" in response.data
             # Check that the visible "My Active Giveaways" heading is NOT present
             # (the HTML comment contains this text, so we check for the actual h4 heading)
-            assert b'>My Active Giveaways<' not in response.data
-            assert b'Recently Claimed Item' in response.data
-    
+            assert b">My Active Giveaways<" not in response.data
+            assert b"Recently Claimed Item" in response.data
+
     def test_profile_hides_old_claimed_giveaways(self, client, app, auth_user):
         """Test that profile does not display giveaways claimed > 90 days ago."""
         with app.app_context():
             user = auth_user()
             recipient = UserFactory()
             category = CategoryFactory()
-            
+
             # Create old claimed giveaway (91 days ago)
-            old_claimed_giveaway = ItemFactory(
+            ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='claimed',
+                claim_status="claimed",
                 claimed_by=recipient,
                 claimed_at=datetime.now(UTC) - timedelta(days=91),
-                name='Old Claimed Item'
+                name="Old Claimed Item",
             )
             db.session.commit()
-            
+
             login_user(client, user.email)
-            response = client.get('/profile')
-            
+            response = client.get("/profile")
+
             assert response.status_code == 200
-            assert b'Old Claimed Item' not in response.data
-    
+            assert b"Old Claimed Item" not in response.data
+
     def test_profile_shows_giveaway_exactly_90_days_old(self, client, app, auth_user):
         """Test that profile displays giveaways claimed exactly 90 days ago."""
         with app.app_context():
             user = auth_user()
             recipient = UserFactory()
             category = CategoryFactory()
-            
+
             # Create giveaway claimed exactly 90 days ago (minus 1 hour to avoid timing issues)
-            ninety_day_giveaway = ItemFactory(
+            ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='claimed',
+                claim_status="claimed",
                 claimed_by=recipient,
                 claimed_at=datetime.now(UTC) - timedelta(days=90, hours=-1),
-                name='Ninety Day Item'
+                name="Ninety Day Item",
             )
             db.session.commit()
-            
+
             login_user(client, user.email)
-            response = client.get('/profile')
-            
+            response = client.get("/profile")
+
             assert response.status_code == 200
-            assert b'My Past Giveaways' in response.data
-            assert b'Ninety Day Item' in response.data
-    
+            assert b"My Past Giveaways" in response.data
+            assert b"Ninety Day Item" in response.data
+
     def test_profile_shows_both_active_and_past_giveaways(self, client, app, auth_user):
         """Test that profile displays both sections when user has both types."""
         with app.app_context():
             user = auth_user()
             recipient = UserFactory()
             category = CategoryFactory()
-            
+
             # Create unclaimed giveaway
-            unclaimed = ItemFactory(
+            ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='unclaimed',
-                name='Active Item'
+                claim_status="unclaimed",
+                name="Active Item",
             )
-            
+
             # Create claimed giveaway
-            claimed = ItemFactory(
+            ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='claimed',
+                claim_status="claimed",
                 claimed_by=recipient,
                 claimed_at=datetime.now(UTC) - timedelta(days=5),
-                name='Past Item'
+                name="Past Item",
             )
             db.session.commit()
-            
+
             login_user(client, user.email)
-            response = client.get('/profile')
-            
+            response = client.get("/profile")
+
             assert response.status_code == 200
-            assert b'My Active Giveaways' in response.data
-            assert b'My Past Giveaways' in response.data
-            assert b'Active Item' in response.data
-            assert b'Past Item' in response.data
-    
+            assert b"My Active Giveaways" in response.data
+            assert b"My Past Giveaways" in response.data
+            assert b"Active Item" in response.data
+            assert b"Past Item" in response.data
+
     def test_profile_no_giveaways_shows_regular_items(self, client, app, auth_user):
         """Test that profile shows regular items section when no giveaways exist."""
         with app.app_context():
             user = auth_user()
             category = CategoryFactory()
-            
+
             # Create regular item (not a giveaway)
-            regular_item = ItemFactory(
-                owner=user,
-                category=category,
-                is_giveaway=False,
-                name='Regular Lending Item'
+            ItemFactory(
+                owner=user, category=category, is_giveaway=False, name="Regular Lending Item"
             )
             db.session.commit()
-            
+
             login_user(client, user.email)
-            response = client.get('/profile')
-            
+            response = client.get("/profile")
+
             assert response.status_code == 200
-            assert b'Regular Lending Item' in response.data
-    
+            assert b"Regular Lending Item" in response.data
+
     def test_profile_past_giveaways_sorted_by_claimed_date(self, client, app, auth_user):
         """Test that past giveaways are sorted by claimed date (newest first)."""
         with app.app_context():
             user = auth_user()
             recipient = UserFactory()
             category = CategoryFactory()
-            
+
             # Create giveaways with different claimed dates
-            older_giveaway = ItemFactory(
+            ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='claimed',
+                claim_status="claimed",
                 claimed_by=recipient,
                 claimed_at=datetime.now(UTC) - timedelta(days=20),
-                name='Older Claimed Item'
+                name="Older Claimed Item",
             )
-            
-            newer_giveaway = ItemFactory(
+
+            ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='claimed',
+                claim_status="claimed",
                 claimed_by=recipient,
                 claimed_at=datetime.now(UTC) - timedelta(days=5),
-                name='Newer Claimed Item'
+                name="Newer Claimed Item",
             )
             db.session.commit()
-            
+
             login_user(client, user.email)
-            response = client.get('/profile')
-            
+            response = client.get("/profile")
+
             assert response.status_code == 200
-            content = response.data.decode('utf-8')
-            
+            content = response.data.decode("utf-8")
+
             # Verify both appear
-            assert 'Newer Claimed Item' in content
-            assert 'Older Claimed Item' in content
-            
+            assert "Newer Claimed Item" in content
+            assert "Older Claimed Item" in content
+
             # Verify newer appears before older in the HTML
-            newer_pos = content.find('Newer Claimed Item')
-            older_pos = content.find('Older Claimed Item')
+            newer_pos = content.find("Newer Claimed Item")
+            older_pos = content.find("Older Claimed Item")
             assert newer_pos < older_pos
 
 
@@ -325,25 +351,25 @@ class TestProfileGiveawayPagination:
                     owner=user,
                     category=category,
                     is_giveaway=True,
-                    claim_status='unclaimed',
-                    name=f'Giveaway {i}'
+                    claim_status="unclaimed",
+                    name=f"Giveaway {i}",
                 )
             db.session.commit()
 
             login_user(client, user.email)
 
             # First page should show 12 items
-            response = client.get('/profile')
+            response = client.get("/profile")
             assert response.status_code == 200
-            content = response.data.decode('utf-8')
-            assert 'My Active Giveaways' in content
-            assert 'giveaway_page=2' in content
+            content = response.data.decode("utf-8")
+            assert "My Active Giveaways" in content
+            assert "giveaway_page=2" in content
 
             # Second page should show remaining 2 items
-            response = client.get('/profile?giveaway_page=2&tab=my-items')
+            response = client.get("/profile?giveaway_page=2&tab=my-items")
             assert response.status_code == 200
-            content = response.data.decode('utf-8')
-            assert 'My Active Giveaways' in content
+            content = response.data.decode("utf-8")
+            assert "My Active Giveaways" in content
 
     def test_past_giveaways_paginate_at_12(self, client, app, auth_user):
         """Test that past giveaways paginate in pages of 12."""
@@ -358,27 +384,27 @@ class TestProfileGiveawayPagination:
                     owner=user,
                     category=category,
                     is_giveaway=True,
-                    claim_status='claimed',
+                    claim_status="claimed",
                     claimed_by=recipient,
                     claimed_at=datetime.now(UTC) - timedelta(days=5),
-                    name=f'Past Giveaway {i}'
+                    name=f"Past Giveaway {i}",
                 )
             db.session.commit()
 
             login_user(client, user.email)
 
             # First page should show 12 items and pagination
-            response = client.get('/profile')
+            response = client.get("/profile")
             assert response.status_code == 200
-            content = response.data.decode('utf-8')
-            assert 'My Past Giveaways' in content
-            assert 'past_giveaway_page=2' in content
+            content = response.data.decode("utf-8")
+            assert "My Past Giveaways" in content
+            assert "past_giveaway_page=2" in content
 
             # Second page should show remaining items
-            response = client.get('/profile?past_giveaway_page=2&tab=my-items')
+            response = client.get("/profile?past_giveaway_page=2&tab=my-items")
             assert response.status_code == 200
-            content = response.data.decode('utf-8')
-            assert 'My Past Giveaways' in content
+            content = response.data.decode("utf-8")
+            assert "My Past Giveaways" in content
 
 
 class TestProfileMyItemsSearch:
@@ -395,33 +421,33 @@ class TestProfileMyItemsSearch:
                 owner=user,
                 category=category,
                 is_giveaway=False,
-                name='Blue Ladder',
-                description='Useful ladder'
+                name="Blue Ladder",
+                description="Useful ladder",
             )
             ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=False,
-                name='Red Drill',
-                description='Power tool'
+                name="Red Drill",
+                description="Power tool",
             )
             ItemFactory(
                 owner=other_user,
                 category=category,
                 is_giveaway=False,
-                name='Blue Saw',
-                description='Should not show in my profile results'
+                name="Blue Saw",
+                description="Should not show in my profile results",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/profile?tab=my-items&search=  Blue  ')
+            response = client.get("/profile?tab=my-items&search=  Blue  ")
 
             assert response.status_code == 200
-            content = response.data.decode('utf-8')
-            assert 'Blue Ladder' in content
-            assert 'Red Drill' not in content
-            assert 'Blue Saw' not in content
+            content = response.data.decode("utf-8")
+            assert "Blue Ladder" in content
+            assert "Red Drill" not in content
+            assert "Blue Saw" not in content
 
     def test_profile_search_matches_description(self, client, app, auth_user):
         """Search should match item description, not just name."""
@@ -433,25 +459,25 @@ class TestProfileMyItemsSearch:
                 owner=user,
                 category=category,
                 is_giveaway=False,
-                name='Toolbox',
-                description='Contains a rare cobalt wrench'
+                name="Toolbox",
+                description="Contains a rare cobalt wrench",
             )
             ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=False,
-                name='Hammer',
-                description='Basic hardware tool'
+                name="Hammer",
+                description="Basic hardware tool",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/profile?tab=my-items&search=cobalt')
+            response = client.get("/profile?tab=my-items&search=cobalt")
 
             assert response.status_code == 200
-            content = response.data.decode('utf-8')
-            assert 'Toolbox' in content
-            assert 'Hammer' not in content
+            content = response.data.decode("utf-8")
+            assert "Toolbox" in content
+            assert "Hammer" not in content
 
     def test_profile_search_applies_to_active_past_and_regular_items(self, client, app, auth_user):
         """Search should filter all three My Items sections."""
@@ -464,66 +490,66 @@ class TestProfileMyItemsSearch:
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='unclaimed',
-                name='Needle Active Giveaway',
-                description='Active section match'
+                claim_status="unclaimed",
+                name="Needle Active Giveaway",
+                description="Active section match",
             )
             ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='claimed',
+                claim_status="claimed",
                 claimed_by=recipient,
                 claimed_at=datetime.now(UTC) - timedelta(days=2),
-                name='Needle Past Giveaway',
-                description='Past section match'
+                name="Needle Past Giveaway",
+                description="Past section match",
             )
             ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=False,
-                name='Needle Lending Item',
-                description='Regular items section match'
+                name="Needle Lending Item",
+                description="Regular items section match",
             )
 
             ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='unclaimed',
-                name='Other Active',
-                description='Not a match'
+                claim_status="unclaimed",
+                name="Other Active",
+                description="Not a match",
             )
             ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=True,
-                claim_status='claimed',
+                claim_status="claimed",
                 claimed_by=recipient,
                 claimed_at=datetime.now(UTC) - timedelta(days=2),
-                name='Other Past',
-                description='Not a match'
+                name="Other Past",
+                description="Not a match",
             )
             ItemFactory(
                 owner=user,
                 category=category,
                 is_giveaway=False,
-                name='Other Lending Item',
-                description='Not a match'
+                name="Other Lending Item",
+                description="Not a match",
             )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/profile?tab=my-items&search=Needle')
+            response = client.get("/profile?tab=my-items&search=Needle")
 
             assert response.status_code == 200
-            content = response.data.decode('utf-8')
-            assert 'Needle Active Giveaway' in content
-            assert 'Needle Past Giveaway' in content
-            assert 'Needle Lending Item' in content
-            assert 'Other Active' not in content
-            assert 'Other Past' not in content
-            assert 'Other Lending Item' not in content
+            content = response.data.decode("utf-8")
+            assert "Needle Active Giveaway" in content
+            assert "Needle Past Giveaway" in content
+            assert "Needle Lending Item" in content
+            assert "Other Active" not in content
+            assert "Other Past" not in content
+            assert "Other Lending Item" not in content
 
     def test_profile_search_pagination_links_include_search_param(self, client, app, auth_user):
         """When searching, all My Items pagination links should preserve search query."""
@@ -537,34 +563,34 @@ class TestProfileMyItemsSearch:
                     owner=user,
                     category=category,
                     is_giveaway=True,
-                    claim_status='unclaimed',
-                    name=f'Needle Active {i}',
-                    description='Active pagination'
+                    claim_status="unclaimed",
+                    name=f"Needle Active {i}",
+                    description="Active pagination",
                 )
                 ItemFactory(
                     owner=user,
                     category=category,
                     is_giveaway=True,
-                    claim_status='claimed',
+                    claim_status="claimed",
                     claimed_by=recipient,
                     claimed_at=datetime.now(UTC) - timedelta(days=3),
-                    name=f'Needle Past {i}',
-                    description='Past pagination'
+                    name=f"Needle Past {i}",
+                    description="Past pagination",
                 )
                 ItemFactory(
                     owner=user,
                     category=category,
                     is_giveaway=False,
-                    name=f'Needle Lending {i}',
-                    description='Regular pagination'
+                    name=f"Needle Lending {i}",
+                    description="Regular pagination",
                 )
             db.session.commit()
 
             login_user(client, user.email)
-            response = client.get('/profile?tab=my-items&search=needle')
+            response = client.get("/profile?tab=my-items&search=needle")
 
             assert response.status_code == 200
-            content = response.data.decode('utf-8')
-            assert 'giveaway_page=2&amp;tab=my-items&amp;search=needle' in content
-            assert 'past_giveaway_page=2&amp;tab=my-items&amp;search=needle' in content
-            assert 'page=2&amp;tab=my-items&amp;search=needle' in content
+            content = response.data.decode("utf-8")
+            assert "giveaway_page=2&amp;tab=my-items&amp;search=needle" in content
+            assert "past_giveaway_page=2&amp;tab=my-items&amp;search=needle" in content
+            assert "page=2&amp;tab=my-items&amp;search=needle" in content

--- a/tests/integration/test_routes.py
+++ b/tests/integration/test_routes.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import uuid
 from datetime import date, timedelta
 from unittest.mock import patch
 
@@ -482,6 +483,72 @@ class TestItemRoutes:
             item = Item.query.filter_by(name="Another Item").first()
             assert item is not None
             assert item.owner_id == user.id
+
+    def test_list_item_post_duplicate_creation_token_reuses_existing_item(
+        self, client, app, auth_user
+    ):
+        """Posting the same creation token twice should reuse the original item instead of creating a duplicate."""
+        with app.app_context():
+            user = auth_user()
+            category = CategoryFactory()
+            creation_token = uuid.uuid4()
+            login_user(client, user.email)
+
+            post_data = {
+                "name": "Duplicate Guard Item",
+                "description": "A test item",
+                "category": str(category.id),
+                "tags": "electronics, test",
+                "creation_token": str(creation_token),
+            }
+
+            first_response = client.post("/list-item", data=post_data, follow_redirects=True)
+            assert first_response.status_code == 200
+            assert b"has been listed successfully!" in first_response.data
+
+            second_response = client.post("/list-item", data=post_data, follow_redirects=True)
+
+            assert second_response.status_code == 200
+            assert (
+                b"We already listed this item from your earlier submission" in second_response.data
+            )
+
+            item = Item.query.filter_by(owner_id=user.id, creation_token=creation_token).one()
+            assert item.name == "Duplicate Guard Item"
+            assert Item.query.filter_by(owner_id=user.id, name="Duplicate Guard Item").count() == 1
+
+    def test_list_item_duplicate_creation_token_create_another_redirects_back_to_form(
+        self, client, app, auth_user
+    ):
+        """Duplicate retries should preserve the create-another flow without creating a second item."""
+        with app.app_context():
+            user = auth_user()
+            category = CategoryFactory()
+            creation_token = uuid.uuid4()
+            login_user(client, user.email)
+
+            post_data = {
+                "name": "Duplicate Create Another",
+                "description": "A test item",
+                "category": str(category.id),
+                "creation_token": str(creation_token),
+                "submit_and_create_another": "List Item & Create Another",
+            }
+
+            first_response = client.post("/list-item", data=post_data, follow_redirects=True)
+            assert first_response.status_code == 200
+            assert b"List a New Item" in first_response.data
+
+            second_response = client.post("/list-item", data=post_data, follow_redirects=True)
+
+            assert second_response.status_code == 200
+            assert b"List a New Item" in second_response.data
+            assert (
+                b"We already listed this item from your earlier submission" in second_response.data
+            )
+            assert (
+                Item.query.filter_by(owner_id=user.id, name="Duplicate Create Another").count() == 1
+            )
 
     def test_item_detail_requires_login(self, client, app):
         """Test that item detail requires login."""

--- a/tests/unit/services/test_item_service.py
+++ b/tests/unit/services/test_item_service.py
@@ -6,7 +6,7 @@ import pytest
 from app import db
 from app.models import GiveawayInterest, Item, LoanRequest, Message
 from app.services import item_service
-from app.services.exceptions import ConflictError, InformationalError
+from app.services.exceptions import ConflictError
 from tests.factories import (
     CategoryFactory,
     GiveawayInterestFactory,
@@ -28,7 +28,7 @@ class TestItemService:
                 "app.services.item_service.upload_item_images",
                 return_value=["https://example.com/1.jpg", "https://example.com/2.jpg"],
             ) as mock_upload:
-                item = item_service.create_item(
+                result = item_service.create_item(
                     owner,
                     "Cordless Drill",
                     "Still works great",
@@ -39,7 +39,9 @@ class TestItemService:
                     [object(), object()],
                 )
 
-            db_item = db.session.get(Item, item.id)
+            assert result.was_created is True
+
+            db_item = db.session.get(Item, result.item.id)
             assert db_item is not None
             assert [image.url for image in db_item.images] == [
                 "https://example.com/1.jpg",
@@ -63,19 +65,20 @@ class TestItemService:
             db.session.commit()
 
             with patch("app.services.item_service.upload_item_images") as mock_upload_images:
-                with pytest.raises(InformationalError, match="already listed"):
-                    item_service.create_item(
-                        owner,
-                        "Cordless Drill",
-                        "Still works great",
-                        category.id,
-                        False,
-                        None,
-                        "Drill, Repair",
-                        [object()],
-                        creation_token=creation_token,
-                    )
+                result = item_service.create_item(
+                    owner,
+                    "Cordless Drill",
+                    "Still works great",
+                    category.id,
+                    False,
+                    None,
+                    "Drill, Repair",
+                    [object()],
+                    creation_token=creation_token,
+                )
 
+            assert result.was_created is False
+            assert result.item.id == existing_item.id
             assert db.session.get(Item, existing_item.id) is not None
             assert (
                 Item.query.filter_by(owner_id=owner.id, creation_token=creation_token).count() == 1

--- a/tests/unit/services/test_item_service.py
+++ b/tests/unit/services/test_item_service.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import patch
 
 import pytest
@@ -5,7 +6,7 @@ import pytest
 from app import db
 from app.models import GiveawayInterest, Item, LoanRequest, Message
 from app.services import item_service
-from app.services.exceptions import ConflictError
+from app.services.exceptions import ConflictError, InformationalError
 from tests.factories import (
     CategoryFactory,
     GiveawayInterestFactory,
@@ -46,6 +47,40 @@ class TestItemService:
             ]
             assert {tag.name for tag in db_item.tags} == {"drill", "repair"}
             mock_upload.assert_called_once()
+
+    def test_create_item_reuses_existing_item_when_creation_token_already_exists(self, app):
+        with app.app_context():
+            owner = UserFactory()
+            category = CategoryFactory()
+            creation_token = uuid.uuid4()
+
+            existing_item = ItemFactory(
+                owner=owner,
+                category=category,
+                creation_token=creation_token,
+                name="Cordless Drill",
+            )
+            db.session.commit()
+
+            with patch("app.services.item_service.upload_item_images") as mock_upload_images:
+                with pytest.raises(InformationalError, match="already listed"):
+                    item_service.create_item(
+                        owner,
+                        "Cordless Drill",
+                        "Still works great",
+                        category.id,
+                        False,
+                        None,
+                        "Drill, Repair",
+                        [object()],
+                        creation_token=creation_token,
+                    )
+
+            assert db.session.get(Item, existing_item.id) is not None
+            assert (
+                Item.query.filter_by(owner_id=owner.id, creation_token=creation_token).count() == 1
+            )
+            mock_upload_images.assert_not_called()
 
     def test_update_item_reorders_images_and_replaces_tags(self, app):
         with app.app_context():


### PR DESCRIPTION
Fix #376

This fixes two unrelated bugs:
- Item delete modal is grayed-out and unclickable

Fixed the modal, now you can click the buttons, X out of it, or click away.

- Duplicate item creation

Fixed in two ways: disable the form button upon clicking AND add an idempotency token to the DB (the gold-plated fix).

**TESTING**
Tested locally for item creation (disabled button, flow still works) and deletion modal now works from profile page. I did not test the tokens manually.

I think this will merge just in time to get picked up on the API item creation flow PR.