### PR TITLE
fix: show rehomed badge instead of borrowed for completed giveaway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Public giveaways from user without circles now appear in home feed and digest, consistent with how requests are treated ([#369](https://github.com/sfirke/meutch/pull/369)).
 - Fixes to block block dual-item creation: adopt idempotency token, disable form submission button ([#377](https://github.com/sfirke/meutch/pull/377)).
 - Delete item modal is no longer grayed out and untouchable when deleting an item from profile page (fixes #376) ([#377](https://github.com/sfirke/meutch/pull/377)).
+- Claimed giveaways no longer show a "Borrowed" status badge in the conversation "Item Status" card — they now correctly display "Rehomed" ([#39X](https://github.com/sfirke/meutch/pull/39X)).
 
 
 ### Developer Experience

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Public giveaways from user without circles now appear in home feed and digest, consistent with how requests are treated ([#369](https://github.com/sfirke/meutch/pull/369)).
 - Fixes to block block dual-item creation: adopt idempotency token, disable form submission button ([#377](https://github.com/sfirke/meutch/pull/377)).
 - Delete item modal is no longer grayed out and untouchable when deleting an item from profile page (fixes #376) ([#377](https://github.com/sfirke/meutch/pull/377)).
-- Claimed giveaways no longer show a "Borrowed" status badge in the conversation "Item Status" card — they now correctly display "Rehomed" ([#39X](https://github.com/sfirke/meutch/pull/39X)).
+- Claimed giveaways no longer show a "Borrowed" status badge in the conversation "Item Status" card — they now correctly display "Rehomed" ([#398](https://github.com/sfirke/meutch/pull/398)).
 
 
 ### Developer Experience

--- a/app/templates/messaging/view_conversation.html
+++ b/app/templates/messaging/view_conversation.html
@@ -111,11 +111,7 @@
                                                     <span class="badge bg-warning text-dark">
                                                         <i class="fas fa-clock me-1"></i>Pending Pickup
                                                     </span>
-                                                {% elif conversation_item.is_giveaway %}
-                                                    <span class="badge bg-warning text-dark">
-                                                        <i class="fas fa-clock me-1"></i>Pending Pickup
-                                                    </span>
-                                                {% else %}
+                                                {% elif not conversation_item.is_giveaway %}
                                                     <span class="badge bg-warning text-dark">
                                                         <i class="fas fa-clock me-1"></i>Borrowed
                                                     </span>

--- a/app/templates/messaging/view_conversation.html
+++ b/app/templates/messaging/view_conversation.html
@@ -103,7 +103,15 @@
                                             {% if conversation_item.current_loan and conversation_item.current_loan.borrower == current_user %}
                                                 <span class="badge bg-info">You are currently borrowing this item</span>
                                             {% elif not conversation_item.available %}
-                                                {% if conversation_item.is_giveaway and conversation_item.claim_status == 'pending_pickup' %}
+                                                {% if conversation_item.is_giveaway and conversation_item.claim_status == 'claimed' %}
+                                                    <span class="badge bg-success">
+                                                        <i class="fas fa-heart me-1"></i>Rehomed
+                                                    </span>
+                                                {% elif conversation_item.is_giveaway and conversation_item.claim_status == 'pending_pickup' %}
+                                                    <span class="badge bg-warning text-dark">
+                                                        <i class="fas fa-clock me-1"></i>Pending Pickup
+                                                    </span>
+                                                {% elif conversation_item.is_giveaway %}
                                                     <span class="badge bg-warning text-dark">
                                                         <i class="fas fa-clock me-1"></i>Pending Pickup
                                                     </span>

--- a/tests/integration/test_request_routes.py
+++ b/tests/integration/test_request_routes.py
@@ -863,6 +863,33 @@ class TestRequestConversations:
             assert b"You are the selected recipient for this giveaway." in response.data
             assert b"Mark Handoff Complete" not in response.data
 
+    def test_view_conversation_claimed_giveaway_shows_rehomed(self, client, app):
+        """Claimed giveaways should show Rehomed, not Borrowed, in conversation header."""
+        with app.app_context():
+            owner = UserFactory()
+            claimant = UserFactory()
+            giveaway = ItemFactory(
+                owner=owner,
+                is_giveaway=True,
+                claim_status="claimed",
+                claimed_by=claimant,
+                available=False,
+            )
+            first_message = MessageFactory(
+                sender=owner,
+                recipient=claimant,
+                item=giveaway,
+                body="Thanks for taking it off my hands!",
+            )
+            db.session.commit()
+
+            login_user(client, claimant.email)
+            response = client.get(f"/message/{first_message.id}")
+
+            assert response.status_code == 200
+            assert b"Rehomed" in response.data
+            assert b"Borrowed" not in response.data
+
     def test_view_conversation_owner_loan_request_uses_consolidated_summary(self, client, app):
         """Owner loan conversations should keep the request context in one summary card without a borrower row."""
         with app.app_context():


### PR DESCRIPTION
Fix #347

Before:
<img width="842" height="408" alt="image" src="https://github.com/user-attachments/assets/e6c2bae6-0b8c-4d20-b0e2-068261c50c50" />

After:
<img width="842" height="408" alt="image" src="https://github.com/user-attachments/assets/53fb2e17-d104-463e-a7d6-33f365686718" />