### PR TITLE
fix: can't edit fulfilled requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 
 ### Bug fixes
 - Claimed giveaways no longer show a "Borrowed" status badge in the conversation "Item Status" card — they now correctly display "Rehomed" ([#398](https://github.com/sfirke/meutch/pull/398)).
+- Can no longer edit a fulfilled giveaway
 
 ### API development (continued)
 - Add API loan activity reads and loan actions, including active borrowing/lending views plus loan request, approve/deny, cancel, complete, and extend endpoints ([#393](https://github.com/sfirke/meutch/pull/393)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 
 ### Bug fixes
 - Claimed giveaways no longer show a "Borrowed" status badge in the conversation "Item Status" card — they now correctly display "Rehomed" ([#398](https://github.com/sfirke/meutch/pull/398)).
-- Can no longer edit a fulfilled giveaway
+- Can no longer edit a fulfilled giveaway ([#406](https://github.com/sfirke/meutch/pull/406)).
 
 ### API development (continued)
 - Add API loan activity reads and loan actions, including active borrowing/lending views plus loan request, approve/deny, cancel, complete, and extend endpoints ([#393](https://github.com/sfirke/meutch/pull/393)).

--- a/app/services/request_service.py
+++ b/app/services/request_service.py
@@ -53,6 +53,8 @@ def update_request(item_request, acting_user, title, description, expires_on, se
     _ensure_public_request_owner_is_geocoded(acting_user, visibility)
     if item_request.status == "deleted":
         raise ConflictError("This request has already been removed.")
+    if item_request.status == "fulfilled":
+        raise ConflictError("Fulfilled requests cannot be edited.")
 
     item_request.title = title.strip()
     item_request.description = _normalize_description(description)

--- a/tests/integration/test_api_requests.py
+++ b/tests/integration/test_api_requests.py
@@ -143,7 +143,7 @@ class TestApiRequests:
         assert response.status_code == 422
         assert response.get_json()["error"]["code"] == "VALIDATION_ERROR"
 
-    def test_fulfilled_request_can_still_be_updated(self, client, app):
+    def test_fulfilled_request_cannot_be_updated(self, client, app):
         with app.app_context():
             owner = UserFactory(email_confirmed=True)
             item_request = ItemRequestFactory(user=owner, status="open")
@@ -166,8 +166,8 @@ class TestApiRequests:
             headers=auth_headers(access_token),
         )
 
-        assert update_response.status_code == 200
-        assert update_response.get_json()["request"]["title"] == "Updated after fulfillment"
+        assert update_response.status_code == 409
+        assert update_response.get_json()["error"]["code"] == "CONFLICT"
 
     def test_request_create_rejects_public_visibility_for_non_geocoded_user(self, client, app):
         with app.app_context():


### PR DESCRIPTION
Fix #383