### PR TITLE
Add own activity feed toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 
 ### Features
 **Minor**:
+- Make it the default to view one's own activity in feed, add a toggle to disable if desired ([#414](https://github.com/sfirke/meutch/pull/414)).
 - New members who have not joined any circles yet are now redirected into circle discovery after login, with a stronger onboarding prompt and personalized recommendations that preview what each suggested circle would unlock ([#395](https://github.com/sfirke/meutch/pull/395)).
 
 ### Bug fixes

--- a/app/api/v1/feed.py
+++ b/app/api/v1/feed.py
@@ -34,6 +34,7 @@ def list_feed_events():
         giveaway_distance=selected_distance,
         giveaway_distance_explicit=distance_explicit,
         included_event_types=query_data["types"],
+        include_own_activity=query_data["show_own_activity"],
         max_events=None,
     )
     pagination = ListPagination(

--- a/app/api/v1/schemas/query.py
+++ b/app/api/v1/schemas/query.py
@@ -35,6 +35,7 @@ class FeedQuerySchema(PaginationQuerySchema):
         allow_none=True,
         validate=validate.OneOf(FEED_DISTANCE_CHOICES),
     )
+    show_own_activity = fields.Boolean(load_default=True)
     per_page = fields.Integer(
         load_default=DEFAULT_FEED_PER_PAGE,
         validate=validate.Range(min=1, max=MAX_COLLECTION_PER_PAGE),

--- a/app/main/views/browse.py
+++ b/app/main/views/browse.py
@@ -39,6 +39,7 @@ def index():
     selected_feed_scope = "all"
     selected_feed_types = ["requests", "giveaways", "circle_joins", "loans"]
     selected_feed_distance = "none"
+    selected_show_own_activity = True
     feed_distance_options = sorted(HOMEPAGE_DISTANCE_OPTIONS)
 
     user_circles = sorted(
@@ -62,6 +63,7 @@ def index():
     selected_feed_scope = filter_state["scope"]
     selected_feed_types = filter_state["selected_feed_types"]
     selected_feed_distance = filter_state["distance_param_value"]
+    selected_show_own_activity = filter_state["show_own_activity"]
 
     feed_events = build_homepage_feed_events(
         current_user,
@@ -70,6 +72,7 @@ def index():
         giveaway_distance=filter_state["distance"],
         giveaway_distance_explicit=filter_state["distance_explicit"],
         included_event_types=selected_feed_types,
+        include_own_activity=selected_show_own_activity,
     )
 
     return render_template(
@@ -93,6 +96,7 @@ def index():
         selected_feed_scope=selected_feed_scope,
         selected_feed_types=selected_feed_types,
         selected_feed_distance=selected_feed_distance,
+        selected_show_own_activity=selected_show_own_activity,
         feed_distance_options=feed_distance_options,
     )
 

--- a/app/main/views/helpers.py
+++ b/app/main/views/helpers.py
@@ -133,6 +133,9 @@ def _parse_homepage_feed_filters(user):
         selected_distance = 20
 
     distance_param_value = "none" if selected_distance is None else str(selected_distance)
+    show_own_activity = True
+    if "own_activity_present" in request.args:
+        show_own_activity = request.args.get("show_own_activity") == "1"
 
     return {
         "scope": scope,
@@ -140,6 +143,7 @@ def _parse_homepage_feed_filters(user):
         "distance": selected_distance,
         "distance_explicit": distance_explicit,
         "distance_param_value": distance_param_value,
+        "show_own_activity": show_own_activity,
     }
 
 

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -71,6 +71,7 @@
 
                 <div class="col-12">
                     <input type="hidden" name="types_present" value="1">
+                    <input type="hidden" name="own_activity_present" value="1">
                     <span class="form-label d-block fw-semibold mb-2">Show activity types</span>
                     <div class="d-flex flex-wrap gap-2">
                         <input class="btn-check" type="checkbox" id="feed-type-requests" name="types" value="requests" autocomplete="off" {% if 'requests' in selected_feed_types %}checked{% endif %}>
@@ -84,6 +85,10 @@
 
                         <input class="btn-check" type="checkbox" id="feed-type-loans" name="types" value="loans" autocomplete="off" {% if 'loans' in selected_feed_types %}checked{% endif %}>
                         <label class="btn btn-sm feed-type-pill feed-type-pill--loans rounded-pill" for="feed-type-loans"><i class="fas fa-handshake me-1"></i>Loans</label>
+                    </div>
+                    <div class="form-check form-switch mt-3">
+                        <input class="form-check-input" type="checkbox" role="switch" id="feed-show-own-activity" name="show_own_activity" value="1" {% if selected_show_own_activity %}checked{% endif %}>
+                        <label class="form-check-label" for="feed-show-own-activity">Show my own activity</label>
                     </div>
                 </div>
             </form>

--- a/app/utils/home_feed.py
+++ b/app/utils/home_feed.py
@@ -137,6 +137,7 @@ def build_visible_requests_events(
     scope="all",
     max_distance=None,
     distance_explicit=False,
+    include_own_activity=True,
     since=None,
     until=None,
 ):
@@ -147,7 +148,6 @@ def build_visible_requests_events(
     normalized_scope = _normalize_scope(scope)
 
     base_query = ItemRequest.query.join(User, ItemRequest.user_id == User.id).filter(
-        ItemRequest.user_id != user.id,
         User.is_deleted.is_(False),
         User.vacation_mode.is_(False),
         or_(
@@ -161,20 +161,34 @@ def build_visible_requests_events(
             ),
         ),
     )
+    if not include_own_activity:
+        base_query = base_query.filter(ItemRequest.user_id != user.id)
 
     if until_utc is not None:
         base_query = base_query.filter(ItemRequest.created_at <= until_utc)
 
     if normalized_scope == "circles":
         if shared_circle_user_ids is None:
-            return []
-        base_query = base_query.filter(ItemRequest.user_id.in_(shared_circle_user_ids))
-    else:
-        if shared_circle_user_ids is None:
-            base_query = base_query.filter(ItemRequest.visibility == "public")
+            base_query = base_query.filter(ItemRequest.user_id == user.id)
         else:
             base_query = base_query.filter(
                 or_(
+                    ItemRequest.user_id == user.id,
+                    ItemRequest.user_id.in_(shared_circle_user_ids),
+                )
+            )
+    else:
+        if shared_circle_user_ids is None:
+            base_query = base_query.filter(
+                or_(
+                    ItemRequest.user_id == user.id,
+                    ItemRequest.visibility == "public",
+                )
+            )
+        else:
+            base_query = base_query.filter(
+                or_(
+                    ItemRequest.user_id == user.id,
                     ItemRequest.visibility == "public",
                     and_(
                         ItemRequest.visibility == "circles",
@@ -228,6 +242,7 @@ def build_visible_giveaway_events(
     scope="all",
     max_distance=None,
     distance_explicit=False,
+    include_own_activity=True,
     since=None,
     until=None,
 ):
@@ -236,8 +251,14 @@ def build_visible_giveaway_events(
     shared_circle_user_ids = _shared_circle_user_ids_query(scoped_circle_ids)
     normalized_scope = _normalize_scope(scope)
     visibility_filter = _build_giveaway_visibility_filter(shared_circle_user_ids, normalized_scope)
-    if visibility_filter is None:
+    if visibility_filter is None and not include_own_activity:
         return []
+    if include_own_activity:
+        own_activity_filter = Item.owner_id == user.id
+        if visibility_filter is None:
+            visibility_filter = own_activity_filter
+        else:
+            visibility_filter = or_(own_activity_filter, visibility_filter)
 
     base_query = Item.query.join(User, Item.owner_id == User.id).filter(
         Item.is_giveaway.is_(True),
@@ -253,9 +274,10 @@ def build_visible_giveaway_events(
                 ),
             ),
             visibility_filter,
-            Item.owner_id != user.id,
         ),
     )
+    if not include_own_activity:
+        base_query = base_query.filter(Item.owner_id != user.id)
 
     until_utc = _utc(until)
     if until_utc is not None:
@@ -570,7 +592,14 @@ def build_digest_giveaway_events(
     return events
 
 
-def build_recent_lent_events(user, scoped_circle_ids=None, days=30, since=None, until=None):
+def build_recent_lent_events(
+    user,
+    scoped_circle_ids=None,
+    days=30,
+    include_own_activity=True,
+    since=None,
+    until=None,
+):
     if not scoped_circle_ids:
         return []
 
@@ -585,11 +614,12 @@ def build_recent_lent_events(user, scoped_circle_ids=None, days=30, since=None, 
             LoanRequest.status == "approved",
             LoanRequest.borrower_id.isnot(None),
             LoanRequest.created_at >= recent_cutoff,
-            Item.owner_id != user.id,
             User.vacation_mode.is_(False),
             Item.owner_id.in_(shared_circle_user_ids),
         )
     )
+    if not include_own_activity:
+        base_query = base_query.filter(Item.owner_id != user.id)
 
     if until_utc is not None:
         base_query = base_query.filter(LoanRequest.created_at <= until_utc)
@@ -663,7 +693,14 @@ def consolidate_circle_join_activity(join_rows, circle_sizes):
     return events
 
 
-def build_circle_join_events(user, scoped_circle_ids=None, days=30, since=None, until=None):
+def build_circle_join_events(
+    user,
+    scoped_circle_ids=None,
+    days=30,
+    include_own_activity=True,
+    since=None,
+    until=None,
+):
     if not scoped_circle_ids:
         return []
 
@@ -676,11 +713,12 @@ def build_circle_join_events(user, scoped_circle_ids=None, days=30, since=None, 
         .filter(
             CircleJoinRequest.status == "approved",
             CircleJoinRequest.created_at >= recent_cutoff,
-            CircleJoinRequest.user_id != user.id,
             CircleJoinRequest.circle_id.in_(scoped_circle_ids),
             User.is_deleted.is_(False),
         )
     )
+    if not include_own_activity:
+        base_query = base_query.filter(CircleJoinRequest.user_id != user.id)
 
     if until_utc is not None:
         base_query = base_query.filter(CircleJoinRequest.created_at <= until_utc)
@@ -734,6 +772,7 @@ def _assemble_feed_events(
     giveaway_distance=None,
     giveaway_distance_explicit=False,
     included_event_types=None,
+    include_own_activity=True,
     since=None,
     until=None,
     max_events=100,
@@ -750,6 +789,7 @@ def _assemble_feed_events(
                 scope=request_scope,
                 max_distance=giveaway_distance,
                 distance_explicit=giveaway_distance_explicit,
+                include_own_activity=include_own_activity,
                 since=since,
                 until=until,
             )
@@ -762,6 +802,7 @@ def _assemble_feed_events(
                 scope=giveaway_scope,
                 max_distance=giveaway_distance,
                 distance_explicit=giveaway_distance_explicit,
+                include_own_activity=include_own_activity,
                 since=since,
                 until=until,
             )
@@ -771,6 +812,7 @@ def _assemble_feed_events(
             build_recent_lent_events(
                 user,
                 scoped_circle_ids=scoped_circle_ids,
+                include_own_activity=include_own_activity,
                 since=since,
                 until=until,
             )
@@ -780,6 +822,7 @@ def _assemble_feed_events(
             build_circle_join_events(
                 user,
                 scoped_circle_ids=scoped_circle_ids,
+                include_own_activity=include_own_activity,
                 since=since,
                 until=until,
             )
@@ -800,6 +843,7 @@ def build_homepage_feed_events(
     giveaway_distance=None,
     giveaway_distance_explicit=False,
     included_event_types=None,
+    include_own_activity=True,
     max_events=100,
 ):
     return _assemble_feed_events(
@@ -810,6 +854,7 @@ def build_homepage_feed_events(
         giveaway_distance=giveaway_distance,
         giveaway_distance_explicit=giveaway_distance_explicit,
         included_event_types=included_event_types,
+        include_own_activity=include_own_activity,
         max_events=max_events,
     )
 
@@ -867,6 +912,7 @@ def build_digest_payload(user, since=None, until=None, max_events=200):
             build_recent_lent_events(
                 user,
                 scoped_circle_ids=scoped_circle_ids,
+                include_own_activity=False,
                 since=window_start,
                 until=window_end,
             )
@@ -876,6 +922,7 @@ def build_digest_payload(user, since=None, until=None, max_events=200):
             build_circle_join_events(
                 user,
                 scoped_circle_ids=scoped_circle_ids,
+                include_own_activity=False,
                 since=window_start,
                 until=window_end,
             )

--- a/app/utils/home_feed.py
+++ b/app/utils/home_feed.py
@@ -57,6 +57,25 @@ def _normalize_scope(scope):
     return "circles" if scope == "circles" else "all"
 
 
+def _build_request_visibility_filter(shared_circle_user_ids, normalized_scope):
+    if normalized_scope == "circles":
+        if shared_circle_user_ids is None:
+            return None
+        return ItemRequest.user_id.in_(shared_circle_user_ids)
+
+    public_filter = ItemRequest.visibility == "public"
+    if shared_circle_user_ids is None:
+        return public_filter
+
+    return or_(
+        and_(
+            ItemRequest.visibility == "circles",
+            ItemRequest.user_id.in_(shared_circle_user_ids),
+        ),
+        public_filter,
+    )
+
+
 def _build_giveaway_visibility_filter(shared_circle_user_ids, normalized_scope):
     if normalized_scope == "circles":
         if shared_circle_user_ids is None:
@@ -147,6 +166,16 @@ def build_visible_requests_events(
     shared_circle_user_ids = _shared_circle_user_ids_query(scoped_circle_ids)
     normalized_scope = _normalize_scope(scope)
 
+    visibility_filter = _build_request_visibility_filter(shared_circle_user_ids, normalized_scope)
+    if visibility_filter is None and not include_own_activity:
+        return []
+    if include_own_activity:
+        own_activity_filter = ItemRequest.user_id == user.id
+        if visibility_filter is None:
+            visibility_filter = own_activity_filter
+        else:
+            visibility_filter = or_(own_activity_filter, visibility_filter)
+
     base_query = ItemRequest.query.join(User, ItemRequest.user_id == User.id).filter(
         User.is_deleted.is_(False),
         User.vacation_mode.is_(False),
@@ -160,42 +189,13 @@ def build_visible_requests_events(
                 ItemRequest.fulfilled_at > fulfilled_cutoff,
             ),
         ),
+        visibility_filter,
     )
     if not include_own_activity:
         base_query = base_query.filter(ItemRequest.user_id != user.id)
 
     if until_utc is not None:
         base_query = base_query.filter(ItemRequest.created_at <= until_utc)
-
-    if normalized_scope == "circles":
-        if shared_circle_user_ids is None:
-            base_query = base_query.filter(ItemRequest.user_id == user.id)
-        else:
-            base_query = base_query.filter(
-                or_(
-                    ItemRequest.user_id == user.id,
-                    ItemRequest.user_id.in_(shared_circle_user_ids),
-                )
-            )
-    else:
-        if shared_circle_user_ids is None:
-            base_query = base_query.filter(
-                or_(
-                    ItemRequest.user_id == user.id,
-                    ItemRequest.visibility == "public",
-                )
-            )
-        else:
-            base_query = base_query.filter(
-                or_(
-                    ItemRequest.user_id == user.id,
-                    ItemRequest.visibility == "public",
-                    and_(
-                        ItemRequest.visibility == "circles",
-                        ItemRequest.user_id.in_(shared_circle_user_ids),
-                    ),
-                )
-            )
 
     visible_requests = base_query.order_by(ItemRequest.created_at.desc()).all()
     effective_distance = _effective_giveaway_distance(max_distance, distance_explicit)

--- a/tests/integration/test_api_feed.py
+++ b/tests/integration/test_api_feed.py
@@ -80,3 +80,60 @@ class TestApiFeed:
         response = client.get("/api/v1/feed")
 
         assert response.status_code == 401
+
+    def test_feed_show_own_activity_toggle(self, client, app):
+        """API feed respects show_own_activity — default includes own, false hides it."""
+        with app.app_context():
+            viewer = UserFactory(email_confirmed=True)
+            other_user = UserFactory()
+            circle = CircleFactory()
+            circle.members.extend([viewer, other_user])
+
+            ItemRequestFactory(
+                user=viewer,
+                title="My own API request",
+                visibility="circles",
+            )
+            ItemRequestFactory(
+                user=other_user,
+                title="Other API request",
+                visibility="circles",
+            )
+            ItemFactory(
+                owner=viewer,
+                name="My own API giveaway",
+                is_giveaway=True,
+                giveaway_visibility="default",
+                claim_status="unclaimed",
+            )
+            ItemFactory(
+                owner=other_user,
+                name="Other API giveaway",
+                is_giveaway=True,
+                giveaway_visibility="default",
+                claim_status="unclaimed",
+            )
+            db.session.commit()
+            access_token = login_api_user(client, viewer.email)
+
+        # Default: own activity is included
+        default_response = client.get(
+            "/api/v1/feed",
+            headers=auth_headers(access_token),
+        )
+        assert default_response.status_code == 200
+        default_titles = {e["title"] for e in default_response.get_json()["events"]}
+        assert "My own API request" in default_titles
+        assert "My own API giveaway" in default_titles
+
+        # Explicit false: own activity is hidden, others' still visible
+        hidden_response = client.get(
+            "/api/v1/feed?show_own_activity=false",
+            headers=auth_headers(access_token),
+        )
+        assert hidden_response.status_code == 200
+        hidden_titles = {e["title"] for e in hidden_response.get_json()["events"]}
+        assert "My own API request" not in hidden_titles
+        assert "My own API giveaway" not in hidden_titles
+        assert "Other API request" in hidden_titles
+        assert "Other API giveaway" in hidden_titles

--- a/tests/integration/test_request_routes.py
+++ b/tests/integration/test_request_routes.py
@@ -239,8 +239,8 @@ class TestRequestsFeedFiltering:
             assert response.status_code == 200
             assert b"Old fulfilled request" not in response.data
 
-    def test_feed_excludes_own_fulfilled_requests(self, client, app, auth_user):
-        """Test that the homepage feed never shows a user's own fulfilled requests."""
+    def test_feed_excludes_old_fulfilled_requests_even_when_own(self, client, app, auth_user):
+        """Own fulfilled requests past the 7-day window are still hidden by time filtering."""
         with app.app_context():
             user = auth_user()
             db.session.commit()
@@ -259,8 +259,30 @@ class TestRequestsFeedFiltering:
             assert response.status_code == 200
             assert b"My request from 30 days ago" not in response.data
 
-    def test_feed_excludes_own_expired_requests(self, client, app, auth_user):
-        """Test that the homepage feed never shows a user's own expired requests."""
+    def test_feed_shows_own_recently_fulfilled_request(self, client, app, auth_user):
+        """Own fulfilled requests within the 7-day window are shown by default."""
+        with app.app_context():
+            user = auth_user()
+            circle = CircleFactory()
+            circle.members.append(user)
+            db.session.commit()
+
+            ItemRequestFactory(
+                user=user,
+                title="My recently fulfilled request",
+                visibility="circles",
+                status="fulfilled",
+                fulfilled_at=datetime.now(UTC) - timedelta(days=3),
+            )
+            db.session.commit()
+
+            login_user(client, user.email)
+            response = client.get("/")
+            assert response.status_code == 200
+            assert b"My recently fulfilled request" in response.data
+
+    def test_feed_excludes_expired_requests_even_when_own(self, client, app, auth_user):
+        """Own expired requests (expires_at in the past) are still hidden by time filtering."""
         with app.app_context():
             user = auth_user()
             db.session.commit()

--- a/tests/integration/test_request_routes.py
+++ b/tests/integration/test_request_routes.py
@@ -322,8 +322,8 @@ class TestRequestsFeedFiltering:
             assert response.status_code == 200
             assert b"Vacation request" not in response.data
 
-    def test_feed_never_shows_own_requests(self, client, app, auth_user):
-        """Test that the homepage feed never shows a user's own open requests."""
+    def test_feed_shows_own_open_requests(self, client, app, auth_user):
+        """Test that the homepage feed shows a user's own open requests."""
         with app.app_context():
             user = auth_user()
             circle = CircleFactory()
@@ -331,13 +331,58 @@ class TestRequestsFeedFiltering:
             db.session.commit()
 
             ItemRequestFactory(user=user, title="My own request")
+            ItemFactory(
+                owner=user,
+                name="My own giveaway",
+                is_giveaway=True,
+                giveaway_visibility="default",
+                claim_status="unclaimed",
+            )
             db.session.commit()
 
             login_user(client, user.email)
             response = client.get("/")
             assert response.status_code == 200
-            assert b"My own request" not in response.data
-            assert b"My Requests" not in response.data
+            assert b"My own request" in response.data
+            assert b"My own giveaway" in response.data
+            assert b"Show my own activity" in response.data
+
+    def test_feed_can_hide_own_open_requests(self, client, app, auth_user):
+        """Test that the homepage feed can hide a user's own activity."""
+        with app.app_context():
+            user = auth_user()
+            other_user = UserFactory()
+            circle = CircleFactory()
+            circle.members.extend([user, other_user])
+            db.session.commit()
+
+            ItemRequestFactory(user=user, title="My hidden request")
+            ItemRequestFactory(user=other_user, title="Other visible request", visibility="circles")
+            ItemFactory(
+                owner=user,
+                name="My hidden giveaway",
+                is_giveaway=True,
+                giveaway_visibility="default",
+                claim_status="unclaimed",
+            )
+            ItemFactory(
+                owner=other_user,
+                name="Other visible giveaway",
+                is_giveaway=True,
+                giveaway_visibility="default",
+                claim_status="unclaimed",
+            )
+            db.session.commit()
+
+            login_user(client, user.email)
+            response = client.get(
+                "/?own_activity_present=1&types_present=1&types=requests&types=giveaways&distance=none"
+            )
+            assert response.status_code == 200
+            assert b"My hidden request" not in response.data
+            assert b"My hidden giveaway" not in response.data
+            assert b"Other visible request" in response.data
+            assert b"Other visible giveaway" in response.data
 
     def test_feed_public_distance_filter(self, client, app, auth_user):
         """Test homepage distance controls can narrow and expand visible public requests."""

--- a/tests/unit/test_home_feed.py
+++ b/tests/unit/test_home_feed.py
@@ -273,6 +273,51 @@ def test_build_visible_requests_events_defaults_to_20_miles_for_geocoded_user(ap
         assert far_request.id in explicit_request_ids
 
 
+def test_build_visible_requests_events_includes_viewers_own_request(app):
+    with app.app_context():
+        viewer = UserFactory()
+        item_request = ItemRequestFactory(
+            user=viewer,
+            title="My own feed request",
+            visibility="circles",
+        )
+        db.session.commit()
+
+        events = build_visible_requests_events(viewer, scoped_circle_ids=set(), scope="all")
+
+        assert [event["request_id"] for event in events] == [item_request.id]
+
+
+def test_build_visible_requests_events_can_hide_viewers_own_request(app):
+    with app.app_context():
+        viewer = UserFactory()
+        other_user = UserFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, other_user])
+        own_request = ItemRequestFactory(
+            user=viewer,
+            title="My hidden feed request",
+            visibility="circles",
+        )
+        other_request = ItemRequestFactory(
+            user=other_user,
+            title="Other visible feed request",
+            visibility="circles",
+        )
+        db.session.commit()
+
+        events = build_visible_requests_events(
+            viewer,
+            scoped_circle_ids={circle.id},
+            scope="all",
+            include_own_activity=False,
+        )
+
+        request_ids = {event["request_id"] for event in events}
+        assert own_request.id not in request_ids
+        assert other_request.id in request_ids
+
+
 def test_build_digest_payload_respects_window_and_include_toggles(app):
     with app.app_context():
         viewer = UserFactory(


### PR DESCRIPTION
Fixes #413

## Summary
- add a Community Activity filter for showing or hiding the signed-in user's own activity:
  <img width="1153" height="307" alt="image" src="https://github.com/user-attachments/assets/07dd771e-770b-4d0b-bd94-48141d9b37fd" />
- include own requests/giveaways in the feed by default
- keep the toggle wired through request, giveaway, loan, and circle join feed builders

## Tests
- FLASK_ENV=testing SECRET_KEY=test-secret-key PYTHONPATH=/scratch/meutch TEST_DATABASE_URL=postgresql://test_user:test_password@localhost:5433/meutch_test uv run pytest tests/unit/test_home_feed.py tests/integration/test_request_routes.py
- FLASK_ENV=testing SECRET_KEY=test-secret-key PYTHONPATH=/scratch/meutch TEST_DATABASE_URL=postgresql://test_user:test_password@localhost:5433/meutch_test uv run pytest tests/integration/test_api_feed.py tests/integration/test_api_requests.py
- uv run ruff check app/main/views/helpers.py app/main/views/browse.py app/utils/home_feed.py tests/unit/test_home_feed.py tests/integration/test_request_routes.py