### PR TITLE
Add claimed giveaway feed filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 ### Features
 **Minor**:
 - Added a Privacy Policy and Terms & Conditions, linked from the site footer ([#421](https://github.com/sfirke/meutch/pull/421)).
+- Community Activity now hides claimed giveaways by default and includes a filter to show them when desired ([#372](https://github.com/sfirke/meutch/issues/372)).
 - Make it the default to view one's own activity in feed, add a toggle to disable if desired ([#414](https://github.com/sfirke/meutch/pull/414)).
 - New members who have not joined any circles yet are now redirected into circle discovery after login, with a stronger onboarding prompt and personalized recommendations that preview what each suggested circle would unlock ([#395](https://github.com/sfirke/meutch/pull/395)).
 - Introduced "regional" circles that are stand-ins for e.g., a Craigslist region. Admins promote these circles to official regional status, at which point they get pinned at the top of zero-circle onboarding recommendations ([#400](https://github.com/sfirke/meutch/pull/400)).

--- a/app/api/v1/feed.py
+++ b/app/api/v1/feed.py
@@ -35,6 +35,7 @@ def list_feed_events():
         giveaway_distance_explicit=distance_explicit,
         included_event_types=query_data["types"],
         include_own_activity=query_data["show_own_activity"],
+        include_claimed_giveaways=query_data["show_claimed_giveaways"],
         max_events=None,
     )
     pagination = ListPagination(

--- a/app/api/v1/schemas/query.py
+++ b/app/api/v1/schemas/query.py
@@ -36,6 +36,7 @@ class FeedQuerySchema(PaginationQuerySchema):
         validate=validate.OneOf(FEED_DISTANCE_CHOICES),
     )
     show_own_activity = fields.Boolean(load_default=True)
+    show_claimed_giveaways = fields.Boolean(load_default=False)
     per_page = fields.Integer(
         load_default=DEFAULT_FEED_PER_PAGE,
         validate=validate.Range(min=1, max=MAX_COLLECTION_PER_PAGE),

--- a/app/main/views/browse.py
+++ b/app/main/views/browse.py
@@ -40,6 +40,7 @@ def index():
     selected_feed_types = ["requests", "giveaways", "circle_joins", "loans"]
     selected_feed_distance = "none"
     selected_show_own_activity = True
+    selected_show_claimed_giveaways = False
     feed_distance_options = sorted(HOMEPAGE_DISTANCE_OPTIONS)
 
     user_circles = sorted(
@@ -64,6 +65,7 @@ def index():
     selected_feed_types = filter_state["selected_feed_types"]
     selected_feed_distance = filter_state["distance_param_value"]
     selected_show_own_activity = filter_state["show_own_activity"]
+    selected_show_claimed_giveaways = filter_state["show_claimed_giveaways"]
 
     feed_events = build_homepage_feed_events(
         current_user,
@@ -73,6 +75,7 @@ def index():
         giveaway_distance_explicit=filter_state["distance_explicit"],
         included_event_types=selected_feed_types,
         include_own_activity=selected_show_own_activity,
+        include_claimed_giveaways=selected_show_claimed_giveaways,
     )
 
     return render_template(
@@ -97,6 +100,7 @@ def index():
         selected_feed_types=selected_feed_types,
         selected_feed_distance=selected_feed_distance,
         selected_show_own_activity=selected_show_own_activity,
+        selected_show_claimed_giveaways=selected_show_claimed_giveaways,
         feed_distance_options=feed_distance_options,
     )
 

--- a/app/main/views/helpers.py
+++ b/app/main/views/helpers.py
@@ -136,6 +136,7 @@ def _parse_homepage_feed_filters(user):
     show_own_activity = True
     if "own_activity_present" in request.args:
         show_own_activity = request.args.get("show_own_activity") == "1"
+    show_claimed_giveaways = request.args.get("show_claimed_giveaways") == "1"
 
     return {
         "scope": scope,
@@ -144,6 +145,7 @@ def _parse_homepage_feed_filters(user):
         "distance_explicit": distance_explicit,
         "distance_param_value": distance_param_value,
         "show_own_activity": show_own_activity,
+        "show_claimed_giveaways": show_claimed_giveaways,
     }
 
 

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -90,6 +90,10 @@
                         <input class="form-check-input" type="checkbox" role="switch" id="feed-show-own-activity" name="show_own_activity" value="1" {% if selected_show_own_activity %}checked{% endif %}>
                         <label class="form-check-label" for="feed-show-own-activity">Show my own activity</label>
                     </div>
+                    <div class="form-check form-switch mt-2">
+                        <input class="form-check-input" type="checkbox" role="switch" id="feed-show-claimed-giveaways" name="show_claimed_giveaways" value="1" {% if selected_show_claimed_giveaways %}checked{% endif %}>
+                        <label class="form-check-label" for="feed-show-claimed-giveaways">Show claimed giveaways</label>
+                    </div>
                 </div>
             </form>
             </div>

--- a/app/utils/home_feed.py
+++ b/app/utils/home_feed.py
@@ -243,6 +243,7 @@ def build_visible_giveaway_events(
     max_distance=None,
     distance_explicit=False,
     include_own_activity=True,
+    include_claimed_giveaways=False,
     since=None,
     until=None,
 ):
@@ -259,20 +260,25 @@ def build_visible_giveaway_events(
             visibility_filter = own_activity_filter
         else:
             visibility_filter = or_(own_activity_filter, visibility_filter)
+    claim_status_filter = or_(
+        Item.claim_status == "unclaimed",
+        Item.claim_status.is_(None),
+    )
+    if include_claimed_giveaways:
+        claim_status_filter = or_(
+            claim_status_filter,
+            and_(
+                Item.claim_status == "claimed",
+                Item.claimed_at.isnot(None),
+                Item.claimed_at > claimed_cutoff,
+            ),
+        )
 
     base_query = Item.query.join(User, Item.owner_id == User.id).filter(
         Item.is_giveaway.is_(True),
         User.vacation_mode.is_(False),
         and_(
-            or_(
-                Item.claim_status == "unclaimed",
-                Item.claim_status.is_(None),
-                and_(
-                    Item.claim_status == "claimed",
-                    Item.claimed_at.isnot(None),
-                    Item.claimed_at > claimed_cutoff,
-                ),
-            ),
+            claim_status_filter,
             visibility_filter,
         ),
     )
@@ -773,6 +779,7 @@ def _assemble_feed_events(
     giveaway_distance_explicit=False,
     included_event_types=None,
     include_own_activity=True,
+    include_claimed_giveaways=False,
     since=None,
     until=None,
     max_events=100,
@@ -803,6 +810,7 @@ def _assemble_feed_events(
                 max_distance=giveaway_distance,
                 distance_explicit=giveaway_distance_explicit,
                 include_own_activity=include_own_activity,
+                include_claimed_giveaways=include_claimed_giveaways,
                 since=since,
                 until=until,
             )
@@ -844,6 +852,7 @@ def build_homepage_feed_events(
     giveaway_distance_explicit=False,
     included_event_types=None,
     include_own_activity=True,
+    include_claimed_giveaways=False,
     max_events=100,
 ):
     return _assemble_feed_events(
@@ -855,6 +864,7 @@ def build_homepage_feed_events(
         giveaway_distance_explicit=giveaway_distance_explicit,
         included_event_types=included_event_types,
         include_own_activity=include_own_activity,
+        include_claimed_giveaways=include_claimed_giveaways,
         max_events=max_events,
     )
 

--- a/tests/integration/test_api_feed.py
+++ b/tests/integration/test_api_feed.py
@@ -1,5 +1,7 @@
 """Integration tests for API feed endpoints."""
 
+from datetime import UTC, datetime, timedelta
+
 from app import db
 from tests.factories import (
     CategoryFactory,
@@ -137,3 +139,49 @@ class TestApiFeed:
         assert "My own API giveaway" not in hidden_titles
         assert "Other API request" in hidden_titles
         assert "Other API giveaway" in hidden_titles
+
+    def test_feed_show_claimed_giveaways_toggle(self, client, app):
+        """API feed hides claimed giveaways by default and can include them."""
+        with app.app_context():
+            viewer = UserFactory(email_confirmed=True)
+            owner = UserFactory()
+            claimer = UserFactory()
+            circle = CircleFactory()
+            circle.members.extend([viewer, owner, claimer])
+
+            ItemFactory(
+                owner=owner,
+                name="API unclaimed giveaway",
+                is_giveaway=True,
+                giveaway_visibility="default",
+                claim_status="unclaimed",
+            )
+            ItemFactory(
+                owner=owner,
+                name="API claimed giveaway",
+                is_giveaway=True,
+                giveaway_visibility="default",
+                claim_status="claimed",
+                claimed_by=claimer,
+                claimed_at=datetime.now(UTC) - timedelta(days=2),
+            )
+            db.session.commit()
+            access_token = login_api_user(client, viewer.email)
+
+        default_response = client.get(
+            "/api/v1/feed?types=giveaways",
+            headers=auth_headers(access_token),
+        )
+        assert default_response.status_code == 200
+        default_titles = {e["title"] for e in default_response.get_json()["events"]}
+        assert "API unclaimed giveaway" in default_titles
+        assert "API claimed giveaway" not in default_titles
+
+        shown_response = client.get(
+            "/api/v1/feed?types=giveaways&show_claimed_giveaways=true",
+            headers=auth_headers(access_token),
+        )
+        assert shown_response.status_code == 200
+        shown_titles = {e["title"] for e in shown_response.get_json()["events"]}
+        assert "API unclaimed giveaway" in shown_titles
+        assert "API claimed giveaway" in shown_titles

--- a/tests/integration/test_completed_giveaway_visibility.py
+++ b/tests/integration/test_completed_giveaway_visibility.py
@@ -10,8 +10,8 @@ from tests.factories import CircleFactory, ItemFactory, UserFactory
 class TestCompletedGiveawayVisibility:
     """Test that completed giveaways stay hidden in browse surfaces but can appear in the home feed."""
 
-    def test_claimed_giveaway_shows_as_claimed_on_home_page(self, client, app, auth_user):
-        """Test that recently claimed giveaways appear on home page with a resolved label."""
+    def test_claimed_giveaway_hidden_by_default_on_home_page(self, client, app, auth_user):
+        """Test that recently claimed giveaways are hidden by default on home page."""
         user_email = None
         with app.app_context():
             # Create a circle and users
@@ -69,13 +69,46 @@ class TestCompletedGiveawayVisibility:
         # Unclaimed should appear
         assert unclaimed_name in html
 
-        # Recently claimed should appear with a visible resolved state
-        assert claimed_name in html
-        assert "Claimed" in html
-        assert "gave away" in html
+        # Recently claimed is hidden unless the claimed-giveaway filter is enabled
+        assert claimed_name not in html
 
         # Pending pickup should NOT appear to other users
         assert pending_name not in html
+
+    def test_claimed_giveaway_can_show_on_home_page_when_filter_enabled(
+        self, client, app, auth_user
+    ):
+        """Test that recently claimed giveaways appear when the filter is enabled."""
+        user_email = None
+        with app.app_context():
+            circle = CircleFactory()
+            owner = UserFactory()
+            claimer = UserFactory()
+            current_user = auth_user()
+            user_email = current_user.email
+
+            circle.members.extend([owner, claimer, current_user])
+
+            claimed_giveaway = ItemFactory(
+                owner=owner,
+                is_giveaway=True,
+                giveaway_visibility="default",
+                claim_status="claimed",
+                claimed_by=claimer,
+                claimed_at=datetime.now(UTC) - timedelta(days=5),
+            )
+            claimed_name = claimed_giveaway.name
+
+            db.session.commit()
+
+        login_user(client, email=user_email)
+        response = client.get("/?distance=&show_claimed_giveaways=1")
+        assert response.status_code == 200
+        html = response.data.decode()
+
+        assert claimed_name in html
+        assert "Claimed" in html
+        assert "gave away" in html
 
     def test_claimed_giveaway_not_in_authenticated_home_feed_after_visibility_window(
         self, client, app, auth_user
@@ -118,7 +151,7 @@ class TestCompletedGiveawayVisibility:
             db.session.commit()
 
             login_user(client, email=current_user.email)
-            response = client.get("/?distance=")
+            response = client.get("/?distance=&show_claimed_giveaways=1")
             assert response.status_code == 200
             html = response.data.decode()
 
@@ -128,7 +161,7 @@ class TestCompletedGiveawayVisibility:
             # Pending pickup should NOT appear to other users
             assert pending.name not in html
 
-            # Claimed should age out of the feed after the recent-activity window
+            # Claimed should still age out after the recent-activity window
             assert claimed.name not in html
 
     def test_claimed_giveaway_not_in_search_results(self, client, app, auth_user):

--- a/tests/unit/test_home_feed.py
+++ b/tests/unit/test_home_feed.py
@@ -99,7 +99,47 @@ def test_build_visible_giveaway_events_defaults_to_20_miles(app):
         assert far_item.id in explicit_item_ids
 
 
-def test_build_visible_giveaway_events_include_recently_claimed_items(app):
+def test_build_visible_giveaway_events_hides_claimed_items_by_default(app):
+    with app.app_context():
+        viewer = UserFactory()
+        owner = UserFactory()
+        claimer = UserFactory()
+        category = CategoryFactory()
+        circle = CircleFactory()
+        circle.members.extend([viewer, owner, claimer])
+
+        now = datetime.now(UTC)
+        claimed_item = ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility="default",
+            claim_status="claimed",
+            claimed_by=claimer,
+            claimed_at=now - timedelta(days=2),
+            name="Recently Claimed Giveaway",
+        )
+        unclaimed_item = ItemFactory(
+            owner=owner,
+            category=category,
+            is_giveaway=True,
+            giveaway_visibility="default",
+            claim_status="unclaimed",
+            name="Unclaimed Giveaway",
+        )
+        db.session.commit()
+
+        events = build_visible_giveaway_events(
+            viewer,
+            scoped_circle_ids={circle.id},
+        )
+
+        item_ids = {event["item_id"] for event in events}
+        assert claimed_item.id not in item_ids
+        assert unclaimed_item.id in item_ids
+
+
+def test_build_visible_giveaway_events_can_include_recently_claimed_items(app):
     with app.app_context():
         viewer = UserFactory()
         owner = UserFactory()
@@ -134,6 +174,7 @@ def test_build_visible_giveaway_events_include_recently_claimed_items(app):
         events = build_visible_giveaway_events(
             viewer,
             scoped_circle_ids={circle.id},
+            include_claimed_giveaways=True,
         )
 
         item_ids = {event["item_id"] for event in events}


### PR DESCRIPTION
Fixes #372

<img width="1160" height="481" alt="image" src="https://github.com/user-attachments/assets/5210732d-f012-4eb8-80d8-51057cd2b86e" />


## Summary
- hide claimed giveaways from Community Activity by default
- add a Show claimed giveaways filter for the web feed
- add matching API feed support with show_claimed_giveaways
- keep existing age-out behavior covered when claimed giveaways are explicitly shown

## Notes from #414
- kept the filtering in the shared feed helper, not just the web route
- added API parity and API tests
- updated old tests so they still cover the intended gap after the default behavior changed
- added a changelog entry

## Tests
- FLASK_ENV=testing SECRET_KEY=test-secret-key PYTHONPATH=/scratch/meutch TEST_DATABASE_URL=postgresql://test_user:test_password@localhost:5433/meutch_test uv run pytest tests/unit/test_home_feed.py tests/integration/test_completed_giveaway_visibility.py tests/integration/test_request_routes.py tests/integration/test_api_feed.py
- FLASK_ENV=testing SECRET_KEY=test-secret-key PYTHONPATH=/scratch/meutch TEST_DATABASE_URL=postgresql://test_user:test_password@localhost:5433/meutch_test uv run pytest tests/integration/test_giveaway_routes.py
- uv run ruff check app/main/views/helpers.py app/main/views/browse.py app/utils/home_feed.py app/api/v1/feed.py app/api/v1/schemas/query.py tests/unit/test_home_feed.py tests/integration/test_completed_giveaway_visibility.py tests/integration/test_api_feed.py
- git diff --check