### PR TITLE
Enable replying to messages by email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 
 ### Features
 **Minor**:
+- Message notification emails can now be replied to by email; Mailgun inbound replies create normal conversation replies in Meutch ([#423](https://github.com/sfirke/meutch/issues/423)).
 - Added a Privacy Policy and Terms & Conditions, linked from the site footer ([#421](https://github.com/sfirke/meutch/pull/421)).
 - Make it the default to view one's own activity in feed, add a toggle to disable if desired ([#414](https://github.com/sfirke/meutch/pull/414)).
 - New members who have not joined any circles yet are now redirected into circle discovery after login, with a stronger onboarding prompt and personalized recommendations that preview what each suggested circle would unlock ([#395](https://github.com/sfirke/meutch/pull/395)).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -40,6 +40,16 @@ DO_SPACES_BUCKET=<your-bucket-name>
 ```bash
 MAILGUN_API_KEY=<your-mailgun-api-key>
 MAILGUN_DOMAIN=<your-mailgun-domain>
+MAILGUN_WEBHOOK_SIGNING_KEY=<your-mailgun-webhook-signing-key>
+
+# Optional: use a separate inbound domain for reply-by-email addresses.
+MAILGUN_INBOUND_DOMAIN=<your-inbound-mailgun-domain>
+```
+
+For reply-by-email, configure a Mailgun inbound route that forwards parsed messages to:
+
+```text
+https://your-domain.com/webhooks/mailgun/messages
 ```
 
 ### Optional: Mobile API JWT Auth

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -88,6 +88,11 @@ def create_app(config_class=None):
 
     app.register_blueprint(share_bp, url_prefix="/share")
 
+    from app.webhooks import bp as webhooks_bp
+
+    app.register_blueprint(webhooks_bp, url_prefix="/webhooks")
+    csrf.exempt(webhooks_bp)
+
     from app.api import v1_bp as api_v1_bp
     from app.api.v1.errors import build_http_error_response, is_api_request_path
 

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -4,7 +4,7 @@ from flask import current_app, url_for
 from app.utils.digest_tokens import generate_digest_manage_token
 
 
-def send_email(to_email, subject, text_content, html_content=None):
+def send_email(to_email, subject, text_content, html_content=None, reply_to=None):
     """Send email using Mailgun API"""
     try:
         api_key = current_app.config.get("MAILGUN_API_KEY")
@@ -29,6 +29,9 @@ def send_email(to_email, subject, text_content, html_content=None):
 
         if html_content:
             data["html"] = html_content
+
+        if reply_to:
+            data["h:Reply-To"] = reply_to
 
         response = requests.post(
             f"https://api.mailgun.net/v3/{domain}/messages", auth=("api", api_key), data=data
@@ -113,6 +116,15 @@ The Meutch Team
     """.strip()
 
     return send_email(user.email, subject, text_content)
+
+
+def build_message_reply_address(message):
+    domain = current_app.config.get("MAILGUN_INBOUND_DOMAIN") or current_app.config.get(
+        "MAILGUN_DOMAIN"
+    )
+    if not domain:
+        return None
+    return f"Meutch Replies <reply+{message.id}@{domain}>"
 
 
 def send_message_notification_email(message):
@@ -235,7 +247,13 @@ The Meutch Team
     </html>
     """
 
-    return send_email(recipient.email, subject, text_content, html_content)
+    return send_email(
+        recipient.email,
+        subject,
+        text_content,
+        html_content,
+        reply_to=build_message_reply_address(message),
+    )
 
 
 def send_circle_join_request_notification_email(join_request):

--- a/app/webhooks/__init__.py
+++ b/app/webhooks/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("webhooks", __name__)
+
+from app.webhooks import mailgun  # noqa: E402, F401

--- a/app/webhooks/mailgun.py
+++ b/app/webhooks/mailgun.py
@@ -1,0 +1,102 @@
+"""Mailgun inbound webhook handlers."""
+
+import hashlib
+import hmac
+import re
+from email.utils import parseaddr
+from uuid import UUID
+
+from flask import current_app, request
+
+from app import db
+from app.models import Message
+from app.services import message_service
+from app.services.exceptions import AuthorizationError, InvalidActionError
+from app.webhooks import bp
+
+REPLY_RECIPIENT_RE = re.compile(r"^reply\+([0-9a-fA-F-]{36})$")
+
+
+def verify_mailgun_signature(timestamp, token, signature):
+    signing_key = current_app.config.get("MAILGUN_WEBHOOK_SIGNING_KEY")
+    if not signing_key or not timestamp or not token or not signature:
+        return False
+
+    digest = hmac.new(
+        signing_key.encode("utf-8"),
+        f"{timestamp}{token}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(digest, signature)
+
+
+def parse_reply_message_id(recipient):
+    _, address = parseaddr(recipient or "")
+    local_part = address.split("@", 1)[0].lower()
+    match = REPLY_RECIPIENT_RE.fullmatch(local_part)
+    if not match:
+        return None
+
+    try:
+        return UUID(match.group(1))
+    except ValueError:
+        return None
+
+
+def normalize_email(value):
+    _, address = parseaddr(value or "")
+    return address.strip().lower()
+
+
+def extract_reply_body(form):
+    for field_name in ("stripped-text", "body-plain"):
+        value = form.get(field_name)
+        if value and value.strip():
+            return value.strip()
+    return None
+
+
+def find_replying_user(message, sender_email):
+    if message.sender.email.lower() == sender_email:
+        return message.sender
+    if message.recipient.email.lower() == sender_email:
+        return message.recipient
+    return None
+
+
+@bp.post("/mailgun/messages")
+def receive_mailgun_message_reply():
+    form = request.form
+    if not verify_mailgun_signature(
+        form.get("timestamp"),
+        form.get("token"),
+        form.get("signature"),
+    ):
+        return "invalid signature", 406
+
+    message_id = parse_reply_message_id(form.get("recipient"))
+    if message_id is None:
+        return "invalid recipient", 406
+
+    original_message = db.session.get(Message, message_id)
+    if original_message is None:
+        return "unknown message", 406
+
+    replying_user = find_replying_user(original_message, normalize_email(form.get("sender")))
+    if replying_user is None:
+        return "sender is not in this conversation", 406
+
+    body = extract_reply_body(form)
+    if body is None:
+        return "empty reply", 406
+
+    try:
+        message_service.reply_to_message(original_message, replying_user.id, body)
+    except (AuthorizationError, InvalidActionError) as exc:
+        current_app.logger.info("Mailgun reply rejected: %s", exc)
+        return "invalid reply", 406
+    except Exception:
+        current_app.logger.exception("Mailgun reply failed")
+        return "reply failed", 500
+
+    return "", 200

--- a/config.py
+++ b/config.py
@@ -154,6 +154,8 @@ class Config:
     # Mailgun configuration
     MAILGUN_API_KEY = os.environ.get("MAILGUN_API_KEY")
     MAILGUN_DOMAIN = os.environ.get("MAILGUN_DOMAIN")
+    MAILGUN_INBOUND_DOMAIN = os.environ.get("MAILGUN_INBOUND_DOMAIN") or MAILGUN_DOMAIN
+    MAILGUN_WEBHOOK_SIGNING_KEY = os.environ.get("MAILGUN_WEBHOOK_SIGNING_KEY")
     MAILGUN_API_URL = (
         f"https://api.mailgun.net/v3/{os.environ.get('MAILGUN_DOMAIN')}/messages"
         if os.environ.get("MAILGUN_DOMAIN")

--- a/tests/integration/test_mailgun_inbound_replies.py
+++ b/tests/integration/test_mailgun_inbound_replies.py
@@ -1,0 +1,122 @@
+import hashlib
+import hmac
+
+from app import db
+from app.models import Message
+from tests.factories import ItemFactory, MessageFactory, UserFactory
+
+SIGNING_KEY = "test-signing-key"
+
+
+def mailgun_payload(message_id, *, sender, body="Sure, that works.", signature=None):
+    timestamp = "1760000000"
+    token = "test-token"
+    if signature is None:
+        signature = hmac.new(
+            SIGNING_KEY.encode("utf-8"),
+            f"{timestamp}{token}".encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    return {
+        "timestamp": timestamp,
+        "token": token,
+        "signature": signature,
+        "sender": sender,
+        "recipient": f"Meutch Replies <reply+{message_id}@reply.example.com>",
+        "stripped-text": body,
+        "body-plain": f"{body}\n\nOn yesterday, someone wrote:",
+    }
+
+
+class TestMailgunInboundReplies:
+    def test_mailgun_reply_creates_message_reply(self, client, app):
+        with app.app_context():
+            app.config["MAILGUN_WEBHOOK_SIGNING_KEY"] = SIGNING_KEY
+            sender = UserFactory(email="sender@example.com")
+            recipient = UserFactory(email="recipient@example.com")
+            item = ItemFactory(owner=recipient)
+            original = MessageFactory(
+                sender=sender,
+                recipient=recipient,
+                item=item,
+                body="Can I borrow this?",
+            )
+            db.session.commit()
+            original_id = original.id
+            sender_id = sender.id
+            recipient_id = recipient.id
+            item_id = item.id
+
+        response = client.post(
+            "/webhooks/mailgun/messages",
+            data=mailgun_payload(original_id, sender="recipient@example.com", body="Yes."),
+        )
+
+        assert response.status_code == 200
+
+        with app.app_context():
+            reply = Message.query.filter_by(parent_id=original_id).one()
+            assert reply.sender_id == recipient_id
+            assert reply.recipient_id == sender_id
+            assert reply.item_id == item_id
+            assert reply.body == "Yes."
+
+    def test_mailgun_reply_rejects_bad_signature(self, client, app):
+        with app.app_context():
+            app.config["MAILGUN_WEBHOOK_SIGNING_KEY"] = SIGNING_KEY
+            original = MessageFactory()
+            db.session.commit()
+            original_id = original.id
+            recipient_email = original.recipient.email
+
+        response = client.post(
+            "/webhooks/mailgun/messages",
+            data=mailgun_payload(
+                original_id,
+                sender=recipient_email,
+                signature="bad-signature",
+            ),
+        )
+
+        assert response.status_code == 406
+
+        with app.app_context():
+            assert Message.query.filter_by(parent_id=original_id).count() == 0
+
+    def test_mailgun_reply_rejects_non_participant_sender(self, client, app):
+        with app.app_context():
+            app.config["MAILGUN_WEBHOOK_SIGNING_KEY"] = SIGNING_KEY
+            original = MessageFactory()
+            outsider = UserFactory(email="outsider@example.com")
+            db.session.commit()
+            original_id = original.id
+            outsider_email = outsider.email
+
+        response = client.post(
+            "/webhooks/mailgun/messages",
+            data=mailgun_payload(original_id, sender=outsider_email),
+        )
+
+        assert response.status_code == 406
+
+        with app.app_context():
+            assert Message.query.filter_by(parent_id=original_id).count() == 0
+
+    def test_mailgun_reply_rejects_empty_body(self, client, app):
+        with app.app_context():
+            app.config["MAILGUN_WEBHOOK_SIGNING_KEY"] = SIGNING_KEY
+            original = MessageFactory()
+            db.session.commit()
+            original_id = original.id
+            recipient_email = original.recipient.email
+
+        payload = mailgun_payload(original_id, sender=recipient_email, body="")
+        payload["body-plain"] = "   "
+
+        response = client.post("/webhooks/mailgun/messages", data=payload)
+
+        assert response.status_code == 406
+
+        with app.app_context():
+            assert Message.query.filter_by(parent_id=original_id).count() == 0

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -9,12 +9,34 @@ from app.utils.email import (
     build_digest_email_content,
     send_account_deletion_email,
     send_digest_email,
+    send_email,
 )
 from tests.factories import UserFactory
 
 
 class TestEmailUtils:
     """Test email utility functions."""
+
+    def test_send_email_includes_reply_to_header(self, app):
+        with app.app_context():
+            app.config["MAILGUN_DOMAIN"] = "mg.example.com"
+            app.config["MAILGUN_API_KEY"] = "key-12345"
+            app.config["EMAIL_ALLOWLIST"] = None
+
+            with patch("app.utils.email.requests.post") as mock_post:
+                mock_post.return_value.status_code = 200
+
+                result = send_email(
+                    "recipient@example.com",
+                    "Test Subject",
+                    "Test body",
+                    reply_to="Meutch Replies <reply+123@reply.example.com>",
+                )
+
+                assert result is True
+                assert mock_post.call_args.kwargs["data"]["h:Reply-To"] == (
+                    "Meutch Replies <reply+123@reply.example.com>"
+                )
 
     def test_send_account_deletion_email_content(self):
         """Test that account deletion email contains correct content."""

--- a/tests/unit/test_message_notifications.py
+++ b/tests/unit/test_message_notifications.py
@@ -1,10 +1,9 @@
-import pytest
-from unittest.mock import patch, MagicMock
-from flask import url_for
+from unittest.mock import MagicMock, patch
 
-from app.models import User, Item, Message
-from app.utils.email import send_message_notification_email
-from tests.factories import UserFactory, ItemFactory, MessageFactory
+import pytest
+
+from app.utils.email import build_message_reply_address, send_message_notification_email
+from tests.factories import ItemFactory, MessageFactory, UserFactory
 
 
 class TestMessageNotifications:
@@ -41,6 +40,33 @@ class TestMessageNotifications:
                 assert 'John Doe' in call_args[0][2]  # text content includes sender name
                 assert 'Hi, I am interested in this item!' in call_args[0][2]  # text content includes message body
                 assert call_args[0][3] is not None  # HTML content provided as 4th positional argument
+
+    def test_send_message_notification_email_sets_reply_to(self, app):
+        """Test message notifications include a reply-to address for email replies."""
+        with app.app_context():
+            app.config["MAILGUN_INBOUND_DOMAIN"] = "reply.example.com"
+            sender = UserFactory(email="sender@test.com")
+            recipient = UserFactory(email="recipient@test.com")
+            item = ItemFactory(name="Test Item", owner=recipient)
+            message = MessageFactory(sender=sender, recipient=recipient, item=item)
+
+            with patch("app.utils.email.send_email") as mock_send_email:
+                mock_send_email.return_value = True
+
+                result = send_message_notification_email(message)
+
+                assert result is True
+                assert mock_send_email.call_args.kwargs["reply_to"] == (
+                    f"Meutch Replies <reply+{message.id}@reply.example.com>"
+                )
+
+    def test_build_message_reply_address_returns_none_without_domain(self, app):
+        with app.app_context():
+            app.config["MAILGUN_INBOUND_DOMAIN"] = None
+            app.config["MAILGUN_DOMAIN"] = None
+            message = MessageFactory()
+
+            assert build_message_reply_address(message) is None
 
     def test_send_message_notification_email_loan_request(self, app):
         """Test sending email notification for a loan request message."""


### PR DESCRIPTION
## Summary
- set message notification Reply-To addresses to `reply+<message_id>@...`
- add a Mailgun inbound webhook at `/webhooks/mailgun/messages` that verifies Mailgun signatures and creates normal conversation replies
- document the Mailgun inbound route/env vars and add tests for success and rejection cases

Closes #423

## Testing
- `FLASK_ENV=development uv run pytest` (1140 passed)
- `uv run ruff check app/utils/email.py app/webhooks tests/unit/test_email.py tests/unit/test_message_notifications.py tests/integration/test_mailgun_inbound_replies.py config.py`
- sent a dummy Mailgun-style POST to `http://bin.mailgun.net/5cd2610` and got HTTP 200

## Deployment note
Set `MAILGUN_WEBHOOK_SIGNING_KEY`, optionally set `MAILGUN_INBOUND_DOMAIN`, and configure Mailgun inbound routing to forward parsed messages to `/webhooks/mailgun/messages`.