### PR TITLE
Enable replying to messages by email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Claimed giveaways no longer show a "Borrowed" status badge in the conversation "Item Status" card — they now correctly display "Rehomed" ([#398](https://github.com/sfirke/meutch/pull/398)).
 - Can no longer edit a fulfilled giveaway ([#406](https://github.com/sfirke/meutch/pull/406)).
 - Clicking "View Loan" on My Activity page now takes you to the current loan, not the first time the item was loaned (affected both borrowers and lenders) ([#410](https://github.com/sfirke/meutch/pull/410)).
+- Don't show details in email digest for requests marked fulfilled or giveaways marked completed ([#427](https://github.com/sfirke/meutch/pull/427)).
 
 ### API development (continued)
 - Add API loan activity reads and loan actions, including active borrowing/lending views plus loan request, approve/deny, cancel, complete, and extend endpoints ([#393](https://github.com/sfirke/meutch/pull/393)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Can no longer edit a fulfilled giveaway ([#406](https://github.com/sfirke/meutch/pull/406)).
 - Clicking "View Loan" on My Activity page now takes you to the current loan, not the first time the item was loaned (affected both borrowers and lenders) ([#410](https://github.com/sfirke/meutch/pull/410)).
 - Don't show details in email digest for requests marked fulfilled or giveaways marked completed ([#427](https://github.com/sfirke/meutch/pull/427)).
+- Streamlined email digest fulfilled/claimed rendering: unified phrasing across both resolution variants, replaced green status pills with a subtle gray "New" label for items the user hasn't seen before, kept descriptions only for first-time items, and grouped new-resolved entries before previously-seen resolutions within each section for faster scanning.
 
 ### API development (continued)
 - Add API loan activity reads and loan actions, including active borrowing/lending views plus loan request, approve/deny, cancel, complete, and extend endpoints ([#393](https://github.com/sfirke/meutch/pull/393)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 
 ### Features
 **Minor**:
+- Message notification emails can now be replied to by email; Mailgun inbound replies create normal conversation replies in Meutch ([#423](https://github.com/sfirke/meutch/issues/423)).
 - Added a Privacy Policy and Terms & Conditions, linked from the site footer ([#421](https://github.com/sfirke/meutch/pull/421)).
 - Make it the default to view one's own activity in feed, add a toggle to disable if desired ([#414](https://github.com/sfirke/meutch/pull/414)).
 - New members who have not joined any circles yet are now redirected into circle discovery after login, with a stronger onboarding prompt and personalized recommendations that preview what each suggested circle would unlock ([#395](https://github.com/sfirke/meutch/pull/395)).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -40,6 +40,16 @@ DO_SPACES_BUCKET=<your-bucket-name>
 ```bash
 MAILGUN_API_KEY=<your-mailgun-api-key>
 MAILGUN_DOMAIN=<your-mailgun-domain>
+MAILGUN_WEBHOOK_SIGNING_KEY=<your-mailgun-webhook-signing-key>
+
+# Optional: use a separate inbound domain for reply-by-email addresses.
+MAILGUN_INBOUND_DOMAIN=<your-inbound-mailgun-domain>
+```
+
+For reply-by-email, configure a Mailgun inbound route that forwards parsed messages to:
+
+```text
+https://your-domain.com/webhooks/mailgun/messages
 ```
 
 ### Optional: Mobile API JWT Auth

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -88,6 +88,11 @@ def create_app(config_class=None):
 
     app.register_blueprint(share_bp, url_prefix="/share")
 
+    from app.webhooks import bp as webhooks_bp
+
+    app.register_blueprint(webhooks_bp, url_prefix="/webhooks")
+    csrf.exempt(webhooks_bp)
+
     from app.api import v1_bp as api_v1_bp
     from app.api.v1.errors import build_http_error_response, is_api_request_path
 

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -640,7 +640,7 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         "Giveaways \u2014 Claimed", claimed_giveaways, include_description=True, include_image=False
     )
     append_text_section("Requests \u2014 Posted", posted_requests, include_description=True)
-    append_text_section("Requests \u2014 Fulfilled", fulfilled_requests, include_description=True)
+    append_text_section("Requests \u2014 Fulfilled", fulfilled_requests, include_description=False)
 
     if circle_joins:
         grouped_joins = _group_circle_joins_for_digest(circle_joins)
@@ -787,7 +787,7 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         {build_html_section('Giveaways \u2014 Posted', posted_giveaways, include_description=True)}
         {build_html_section('Giveaways \u2014 Claimed', claimed_giveaways, include_description=True, include_image=False)}
         {build_html_section('Requests \u2014 Posted', posted_requests, include_description=True)}
-        {build_html_section('Requests \u2014 Fulfilled', fulfilled_requests, include_description=True)}
+        {build_html_section('Requests \u2014 Fulfilled', fulfilled_requests, include_description=False)}
         {_build_circle_joins_html_section(circle_joins)}
         {build_html_section('Loans', loans)}
 

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -571,6 +571,9 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
     # Split giveaways into posted (still available) and claimed
     posted_giveaways = [g for g in giveaways if g.get("resolution_status") != "claimed"]
     claimed_giveaways = [g for g in giveaways if g.get("resolution_status") == "claimed"]
+    # Split requests into posted (still open) and fulfilled
+    posted_requests = [r for r in requests if r.get("resolution_status") != "fulfilled"]
+    fulfilled_requests = [r for r in requests if r.get("resolution_status") == "fulfilled"]
 
     events = digest_payload.get("events")
     if events is None:
@@ -636,7 +639,8 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
     append_text_section(
         "Giveaways \u2014 Claimed", claimed_giveaways, include_description=True, include_image=False
     )
-    append_text_section("Requests", requests, include_description=True)
+    append_text_section("Requests \u2014 Posted", posted_requests, include_description=True)
+    append_text_section("Requests \u2014 Fulfilled", fulfilled_requests, include_description=True)
 
     if circle_joins:
         grouped_joins = _group_circle_joins_for_digest(circle_joins)
@@ -782,7 +786,8 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
 
         {build_html_section('Giveaways \u2014 Posted', posted_giveaways, include_description=True)}
         {build_html_section('Giveaways \u2014 Claimed', claimed_giveaways, include_description=True, include_image=False)}
-        {build_html_section('Requests', requests, include_description=True)}
+        {build_html_section('Requests \u2014 Posted', posted_requests, include_description=True)}
+        {build_html_section('Requests \u2014 Fulfilled', fulfilled_requests, include_description=True)}
         {_build_circle_joins_html_section(circle_joins)}
         {build_html_section('Loans', loans)}
 

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -575,6 +575,16 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
     posted_requests = [r for r in requests if r.get("resolution_status") != "fulfilled"]
     fulfilled_requests = [r for r in requests if r.get("resolution_status") == "fulfilled"]
 
+    # Sort fulfilled/claimed so new-resolved-in-window items appear first.
+    # Python sort is stable, so within each subgroup the existing order
+    # (created_at descending from build_digest_payload) is preserved.
+    claimed_giveaways.sort(
+        key=lambda e: (0 if e.get("digest_variant") == "new-resolved-in-window" else 1)
+    )
+    fulfilled_requests.sort(
+        key=lambda e: (0 if e.get("digest_variant") == "new-resolved-in-window" else 1)
+    )
+
     events = digest_payload.get("events")
     if events is None:
         events = giveaways + requests + circle_joins + loans
@@ -613,22 +623,26 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         text_lines.append(f"{section_title}:")
         for event in events:
             actor = event["actor_name"]
-            is_resolution_only = event.get("digest_variant") == "resolved-in-window"
+            is_resolution_only = event.get("digest_variant") in (
+                "resolved-in-window",
+                "new-resolved-in-window",
+            )
+            is_new_in_window = event.get("digest_variant") == "new-resolved-in-window"
             if is_resolution_only:
                 # For giveaways, the message already includes the actor name
                 if event["event_type"] == "giveaway":
-                    text_lines.append(f"- {_digest_resolution_only_text(event)}")
+                    line = f"- {_digest_resolution_only_text(event)}"
                 else:
-                    text_lines.append(f"- {actor}: {_digest_resolution_only_text(event)}")
+                    line = f"- {actor}: {_digest_resolution_only_text(event)}"
             else:
                 title = _digest_event_title(event)
                 action = event["action"]
-                resolution_label = _digest_resolution_label(event)
                 line = f"- {actor} {action}: {title}"
-                if resolution_label:
-                    line = f"{line} [{resolution_label}]"
-                text_lines.append(line)
-            if include_description and not is_resolution_only and event.get("description"):
+            if is_new_in_window:
+                line = f"{line} [New]"
+            text_lines.append(line)
+            show_desc = (not is_resolution_only and include_description) or is_new_in_window
+            if show_desc and event.get("description"):
                 text_lines.append(f"  {event['description']}")
             if include_image and event.get("image_url"):
                 text_lines.append(f"  Image: {event['image_url']}")
@@ -674,9 +688,14 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         for event in events:
             actor = event["actor_name"]
             link = _digest_event_url(event)
-            is_resolution_only = event.get("digest_variant") == "resolved-in-window"
+            is_resolution_only = event.get("digest_variant") in (
+                "resolved-in-window",
+                "new-resolved-in-window",
+            )
+            is_new_in_window = event.get("digest_variant") == "new-resolved-in-window"
+            show_desc = (not is_resolution_only and include_description) or is_new_in_window
             description_html = ""
-            if include_description and not is_resolution_only and event.get("description"):
+            if show_desc and event.get("description"):
                 description_html = (
                     f"<p style=\"margin: 6px 0 0 0; color: #555;\">{event['description']}</p>"
                 )
@@ -693,23 +712,18 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
             if is_resolution_only:
                 # For giveaways, the message already includes the actor name
                 if event["event_type"] == "giveaway":
-                    activity_html = f"{_digest_resolution_only_text(event)}<br>"
+                    activity_html = f"{_digest_resolution_only_text(event)}"
                 else:
                     activity_html = (
-                        f"<strong>{actor}</strong>: {_digest_resolution_only_text(event)}<br>"
+                        f"<strong>{actor}</strong>: {_digest_resolution_only_text(event)}"
                     )
+                if is_new_in_window:
+                    activity_html += ' <span style="color: #6c757d; font-size: 12px;">New</span>'
+                activity_html += "<br>"
             else:
                 item_title = _digest_event_title(event)
                 action = event["action"]
-                resolution_label = _digest_resolution_label(event)
-                label_html = ""
-                if resolution_label:
-                    label_html = (
-                        f' <span style="display: inline-block; margin-left: 6px; padding: 1px 8px; '
-                        f'background-color: #198754; color: #fff; border-radius: 999px; font-size: 12px;">'
-                        f"{resolution_label}</span>"
-                    )
-                activity_html = f"<strong>{actor}</strong> {action}: {item_title}{label_html}<br>"
+                activity_html = f"<strong>{actor}</strong> {action}: {item_title}<br>"
 
             items_html.append(
                 f"""

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -732,15 +732,15 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
             description_html = ""
             if show_desc and event.get("description"):
                 description_html = (
-                    f"<p style=\"margin: 6px 0 0 0; color: #555;\">{event['description']}</p>"
+                    f'<p style="margin: 6px 0 0 0; color: #555;">{event["description"]}</p>'
                 )
 
             image_html = ""
             if include_image and event.get("image_url"):
                 image_html = (
-                    f"<div style=\"margin: 8px 0;\">"
-                    f"<img src=\"{event['image_url']}\" alt=\"Activity image\" "
-                    f"style=\"max-width: 100%; width: 220px; height: auto; border-radius: 8px;\">"
+                    f'<div style="margin: 8px 0;">'
+                    f'<img src="{event["image_url"]}" alt="Activity image" '
+                    f'style="max-width: 100%; width: 220px; height: auto; border-radius: 8px;">'
                     f"</div>"
                 )
 
@@ -774,7 +774,7 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         return f"""
         <h3 style=\"margin-top: 24px; color: #333;\">{title}</h3>
         <ul style=\"padding-left: 20px;\">
-            {''.join(items_html)}
+            {"".join(items_html)}
         </ul>
         """
 
@@ -791,15 +791,15 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
             image_html = ""
             if group["image_url"]:
                 image_html = (
-                    f"<div style=\"margin: 8px 0;\">"
-                    f"<img src=\"{group['image_url']}\" alt=\"Circle image\" "
-                    f"style=\"max-width: 100%; width: 220px; height: auto; border-radius: 8px;\">"
+                    f'<div style="margin: 8px 0;">'
+                    f'<img src="{group["image_url"]}" alt="Circle image" '
+                    f'style="max-width: 100%; width: 220px; height: auto; border-radius: 8px;">'
                     f"</div>"
                 )
             items_html.append(
                 f"""
                 <li style=\"margin-bottom: 10px;\">
-                    <strong>{label}</strong> joined {group['circle_name']}: {names}<br>
+                    <strong>{label}</strong> joined {group["circle_name"]}: {names}<br>
                     {image_html}
                     <a href=\"{link}\" style=\"color: #007bff; text-decoration: none;\">View circle</a>
                 </li>
@@ -808,7 +808,7 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
         return f"""
         <h3 style=\"margin-top: 24px; color: #333;\">Circle Joins</h3>
         <ul style=\"padding-left: 20px;\">
-            {''.join(items_html)}
+            {"".join(items_html)}
         </ul>
         """
 
@@ -833,12 +833,12 @@ def build_digest_email_content(user, digest_payload, manage_url, unsubscribe_url
 
         {summary_html}
 
-        {build_html_section('Giveaways \u2014 Posted', posted_giveaways, include_description=True)}
-        {build_html_section('Giveaways \u2014 Claimed', claimed_giveaways, include_description=True, include_image=False)}
-        {build_html_section('Requests \u2014 Posted', posted_requests, include_description=True)}
-        {build_html_section('Requests \u2014 Fulfilled', fulfilled_requests, include_description=False)}
+        {build_html_section("Giveaways \u2014 Posted", posted_giveaways, include_description=True)}
+        {build_html_section("Giveaways \u2014 Claimed", claimed_giveaways, include_description=True, include_image=False)}
+        {build_html_section("Requests \u2014 Posted", posted_requests, include_description=True)}
+        {build_html_section("Requests \u2014 Fulfilled", fulfilled_requests, include_description=False)}
         {_build_circle_joins_html_section(circle_joins)}
-        {build_html_section('Loans', loans)}
+        {build_html_section("Loans", loans)}
 
         <hr style=\"margin: 28px 0; border: none; border-top: 1px solid #ddd;\">
         <p style=\"font-size: 14px; color: #666;\">
@@ -900,7 +900,7 @@ This is a friendly reminder that the item you borrowed is due back soon.
 
 Item: {loan.item.name}
 Owner: {owner.first_name} {owner.last_name}
-Due Date: {loan.end_date.strftime('%B %d, %Y')} (in 3 days)
+Due Date: {loan.end_date.strftime("%B %d, %Y")} (in 3 days)
 
 Please make arrangements to return the item by the due date. If you need more time, please contact the owner to discuss extending the loan.
 
@@ -926,7 +926,7 @@ The Meutch Team
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Item:</strong> {loan.item.name}</p>
             <p><strong>Owner:</strong> {owner.first_name} {owner.last_name}</p>
-            <p><strong>Due Date:</strong> {loan.end_date.strftime('%B %d, %Y')}</p>
+            <p><strong>Due Date:</strong> {loan.end_date.strftime("%B %d, %Y")}</p>
         </div>
 
         <p style="color: #666; font-size: 14px;">
@@ -982,7 +982,7 @@ This is a reminder that the item you borrowed is due back today.
 
 Item: {loan.item.name}
 Owner: {owner.first_name} {owner.last_name}
-Due Date: Today, {loan.end_date.strftime('%B %d, %Y')}
+Due Date: Today, {loan.end_date.strftime("%B %d, %Y")}
 
 Please return the item to the owner as soon as possible. If you need more time or have already returned it, please contact the owner to coordinate.
 
@@ -1008,7 +1008,7 @@ The Meutch Team
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Item:</strong> {loan.item.name}</p>
             <p><strong>Owner:</strong> {owner.first_name} {owner.last_name}</p>
-            <p><strong>Due Date:</strong> Today, {loan.end_date.strftime('%B %d, %Y')}</p>
+            <p><strong>Due Date:</strong> Today, {loan.end_date.strftime("%B %d, %Y")}</p>
         </div>
 
         <p style="color: #666; font-size: 14px;">
@@ -1066,7 +1066,7 @@ This is a notification that your item is due to be returned today.
 
 Item: {loan.item.name}
 Borrower: {borrower.first_name} {borrower.last_name}
-Due Date: Today, {loan.end_date.strftime('%B %d, %Y')}
+Due Date: Today, {loan.end_date.strftime("%B %d, %Y")}
 
 If you need to coordinate the return, please reach out to them. Or you can extend the loan to give them more time:
 {extend_url}
@@ -1093,7 +1093,7 @@ The Meutch Team
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Item:</strong> {loan.item.name}</p>
             <p><strong>Borrower:</strong> {borrower.first_name} {borrower.last_name}</p>
-            <p><strong>Due Date:</strong> Today, {loan.end_date.strftime('%B %d, %Y')}</p>
+            <p><strong>Due Date:</strong> Today, {loan.end_date.strftime("%B %d, %Y")}</p>
         </div>
 
         <p style="color: #666; font-size: 14px;">
@@ -1153,7 +1153,7 @@ This is a reminder that the item you borrowed is now overdue.
 
 Item: {loan.item.name}
 Owner: {owner.first_name} {owner.last_name}
-Due Date: {loan.end_date.strftime('%B %d, %Y')}
+Due Date: {loan.end_date.strftime("%B %d, %Y")}
 Days Overdue: {days_overdue}
 
 Please return the item to the owner as soon as possible. If you need more time, please contact the owner immediately to request an extension or discuss the situation.
@@ -1174,13 +1174,13 @@ The Meutch Team
         <h2 style="color: #333;">Overdue Item Reminder</h2>
 
         <div style="background-color: #f8d7da; padding: 20px; border-radius: 8px; border-left: 4px solid #dc3545; margin: 20px 0;">
-            <p style="margin: 0;"><strong>⚠️ Your borrowed item is {days_overdue} day{'s' if days_overdue != 1 else ''} overdue</strong></p>
+            <p style="margin: 0;"><strong>⚠️ Your borrowed item is {days_overdue} day{"s" if days_overdue != 1 else ""} overdue</strong></p>
         </div>
 
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Item:</strong> {loan.item.name}</p>
             <p><strong>Owner:</strong> {owner.first_name} {owner.last_name}</p>
-            <p><strong>Due Date:</strong> {loan.end_date.strftime('%B %d, %Y')}</p>
+            <p><strong>Due Date:</strong> {loan.end_date.strftime("%B %d, %Y")}</p>
             <p><strong>Days Overdue:</strong> <span style="color: #dc3545; font-weight: bold;">{days_overdue}</span></p>
         </div>
 
@@ -1239,7 +1239,7 @@ This is a notification that your loaned item is now overdue.
 
 Item: {loan.item.name}
 Borrower: {borrower.first_name} {borrower.last_name}
-Due Date: {loan.end_date.strftime('%B %d, %Y')}
+Due Date: {loan.end_date.strftime("%B %d, %Y")}
 Days Overdue: {days_overdue}
 
 If you need to coordinate the return, please reach out to them. Or you can extend the loan to give them more time:
@@ -1261,13 +1261,13 @@ The Meutch Team
         <h2 style="color: #333;">Loaned Item Overdue</h2>
 
         <div style="background-color: #f8d7da; padding: 20px; border-radius: 8px; border-left: 4px solid #dc3545; margin: 20px 0;">
-            <p style="margin: 0;"><strong>⚠️ Your loaned item is {days_overdue} day{'s' if days_overdue != 1 else ''} overdue</strong></p>
+            <p style="margin: 0;"><strong>⚠️ Your loaned item is {days_overdue} day{"s" if days_overdue != 1 else ""} overdue</strong></p>
         </div>
 
         <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
             <p><strong>Item:</strong> {loan.item.name}</p>
             <p><strong>Borrower:</strong> {borrower.first_name} {borrower.last_name}</p>
-            <p><strong>Due Date:</strong> {loan.end_date.strftime('%B %d, %Y')}</p>
+            <p><strong>Due Date:</strong> {loan.end_date.strftime("%B %d, %Y")}</p>
             <p><strong>Days Overdue:</strong> <span style="color: #dc3545; font-weight: bold;">{days_overdue}</span></p>
         </div>
 

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -191,6 +191,26 @@ def send_message_notification_email(message):
         subject = f"Meutch - New Message about {context_label}"
         email_type = "message"
 
+    can_reply_by_email = not message.is_loan_request_message
+    if can_reply_by_email:
+        response_text = f"""Reply to this email directly, or view the conversation on Meutch:
+{conversation_url}"""
+        response_html = f"""
+        <p style="color: #666; font-size: 14px;">
+            You can reply to this email directly, or
+            <a href="{conversation_url}" style="color: #007bff;">view the conversation on Meutch</a>.
+        </p>
+        """
+    else:
+        response_text = f"""To view the full conversation on Meutch, click here:
+{conversation_url}"""
+        response_html = f"""
+        <p style="color: #666; font-size: 14px;">
+            To view the full conversation on Meutch,
+            <a href="{conversation_url}" style="color: #007bff;">click here</a>.
+        </p>
+        """
+
     text_content = f"""
 Hello {recipient.first_name},
 
@@ -202,8 +222,7 @@ From: {sender.first_name} {sender.last_name}
 Message:
 {message.body}
 
-To view the full conversation and respond, click here:
-{conversation_url}
+{response_text}
 
 You can also log into your Meutch account to view all your messages at any time.
 
@@ -230,13 +249,11 @@ The Meutch Team
         <div style="text-align: center; margin: 30px 0;">
             <a href="{conversation_url}"
                style="background-color: #007bff; color: white; padding: 12px 25px; text-decoration: none; border-radius: 5px; display: inline-block;">
-                View Conversation & Respond
+                View Conversation
             </a>
         </div>
 
-        <p style="color: #666; font-size: 14px;">
-            You can also log into your Meutch account to view all your messages at any time.
-        </p>
+        {response_html}
 
         <hr style="margin-top: 30px; border: none; border-top: 1px solid #ddd;">
         <p style="color: #999; font-size: 12px;">
@@ -252,7 +269,7 @@ The Meutch Team
         subject,
         text_content,
         html_content,
-        reply_to=build_message_reply_address(message),
+        reply_to=build_message_reply_address(message) if can_reply_by_email else None,
     )
 
 

--- a/app/utils/email.py
+++ b/app/utils/email.py
@@ -4,7 +4,7 @@ from flask import current_app, url_for
 from app.utils.digest_tokens import generate_digest_manage_token
 
 
-def send_email(to_email, subject, text_content, html_content=None):
+def send_email(to_email, subject, text_content, html_content=None, reply_to=None):
     """Send email using Mailgun API"""
     try:
         api_key = current_app.config.get("MAILGUN_API_KEY")
@@ -29,6 +29,9 @@ def send_email(to_email, subject, text_content, html_content=None):
 
         if html_content:
             data["html"] = html_content
+
+        if reply_to:
+            data["h:Reply-To"] = reply_to
 
         response = requests.post(
             f"https://api.mailgun.net/v3/{domain}/messages", auth=("api", api_key), data=data
@@ -113,6 +116,15 @@ The Meutch Team
     """.strip()
 
     return send_email(user.email, subject, text_content)
+
+
+def build_message_reply_address(message):
+    domain = current_app.config.get("MAILGUN_INBOUND_DOMAIN") or current_app.config.get(
+        "MAILGUN_DOMAIN"
+    )
+    if not domain:
+        return None
+    return f"Meutch Replies <reply+{message.id}@{domain}>"
 
 
 def send_message_notification_email(message):
@@ -235,7 +247,13 @@ The Meutch Team
     </html>
     """
 
-    return send_email(recipient.email, subject, text_content, html_content)
+    return send_email(
+        recipient.email,
+        subject,
+        text_content,
+        html_content,
+        reply_to=build_message_reply_address(message),
+    )
 
 
 def send_circle_join_request_notification_email(join_request):

--- a/app/webhooks/__init__.py
+++ b/app/webhooks/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("webhooks", __name__)
+
+from app.webhooks import mailgun  # noqa: E402, F401

--- a/app/webhooks/mailgun.py
+++ b/app/webhooks/mailgun.py
@@ -1,0 +1,102 @@
+"""Mailgun inbound webhook handlers."""
+
+import hashlib
+import hmac
+import re
+from email.utils import parseaddr
+from uuid import UUID
+
+from flask import current_app, request
+
+from app import db
+from app.models import Message
+from app.services import message_service
+from app.services.exceptions import AuthorizationError, InvalidActionError
+from app.webhooks import bp
+
+REPLY_RECIPIENT_RE = re.compile(r"^reply\+([0-9a-fA-F-]{36})$")
+
+
+def verify_mailgun_signature(timestamp, token, signature):
+    signing_key = current_app.config.get("MAILGUN_WEBHOOK_SIGNING_KEY")
+    if not signing_key or not timestamp or not token or not signature:
+        return False
+
+    digest = hmac.new(
+        signing_key.encode("utf-8"),
+        f"{timestamp}{token}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(digest, signature)
+
+
+def parse_reply_message_id(recipient):
+    _, address = parseaddr(recipient or "")
+    local_part = address.split("@", 1)[0].lower()
+    match = REPLY_RECIPIENT_RE.fullmatch(local_part)
+    if not match:
+        return None
+
+    try:
+        return UUID(match.group(1))
+    except ValueError:
+        return None
+
+
+def normalize_email(value):
+    _, address = parseaddr(value or "")
+    return address.strip().lower()
+
+
+def extract_reply_body(form):
+    for field_name in ("stripped-text", "body-plain"):
+        value = form.get(field_name)
+        if value and value.strip():
+            return value.strip()
+    return None
+
+
+def find_replying_user(message, sender_email):
+    if message.sender.email.lower() == sender_email:
+        return message.sender
+    if message.recipient.email.lower() == sender_email:
+        return message.recipient
+    return None
+
+
+@bp.post("/mailgun/messages")
+def receive_mailgun_message_reply():
+    form = request.form
+    if not verify_mailgun_signature(
+        form.get("timestamp"),
+        form.get("token"),
+        form.get("signature"),
+    ):
+        return "invalid signature", 406
+
+    message_id = parse_reply_message_id(form.get("recipient"))
+    if message_id is None:
+        return "invalid recipient", 406
+
+    original_message = db.session.get(Message, message_id)
+    if original_message is None:
+        return "unknown message", 406
+
+    replying_user = find_replying_user(original_message, normalize_email(form.get("sender")))
+    if replying_user is None:
+        return "sender is not in this conversation", 406
+
+    body = extract_reply_body(form)
+    if body is None:
+        return "empty reply", 406
+
+    try:
+        message_service.reply_to_message(original_message, replying_user.id, body)
+    except (AuthorizationError, InvalidActionError) as exc:
+        current_app.logger.info("Mailgun reply rejected: %s", exc)
+        return "invalid reply", 406
+    except Exception:
+        current_app.logger.exception("Mailgun reply failed")
+        return "reply failed", 500
+
+    return "", 200

--- a/config.py
+++ b/config.py
@@ -154,6 +154,8 @@ class Config:
     # Mailgun configuration
     MAILGUN_API_KEY = os.environ.get("MAILGUN_API_KEY")
     MAILGUN_DOMAIN = os.environ.get("MAILGUN_DOMAIN")
+    MAILGUN_INBOUND_DOMAIN = os.environ.get("MAILGUN_INBOUND_DOMAIN") or MAILGUN_DOMAIN
+    MAILGUN_WEBHOOK_SIGNING_KEY = os.environ.get("MAILGUN_WEBHOOK_SIGNING_KEY")
     MAILGUN_API_URL = (
         f"https://api.mailgun.net/v3/{os.environ.get('MAILGUN_DOMAIN')}/messages"
         if os.environ.get("MAILGUN_DOMAIN")

--- a/tests/integration/test_mailgun_inbound_replies.py
+++ b/tests/integration/test_mailgun_inbound_replies.py
@@ -1,0 +1,122 @@
+import hashlib
+import hmac
+
+from app import db
+from app.models import Message
+from tests.factories import ItemFactory, MessageFactory, UserFactory
+
+SIGNING_KEY = "test-signing-key"
+
+
+def mailgun_payload(message_id, *, sender, body="Sure, that works.", signature=None):
+    timestamp = "1760000000"
+    token = "test-token"
+    if signature is None:
+        signature = hmac.new(
+            SIGNING_KEY.encode("utf-8"),
+            f"{timestamp}{token}".encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    return {
+        "timestamp": timestamp,
+        "token": token,
+        "signature": signature,
+        "sender": sender,
+        "recipient": f"Meutch Replies <reply+{message_id}@reply.example.com>",
+        "stripped-text": body,
+        "body-plain": f"{body}\n\nOn yesterday, someone wrote:",
+    }
+
+
+class TestMailgunInboundReplies:
+    def test_mailgun_reply_creates_message_reply(self, client, app):
+        with app.app_context():
+            app.config["MAILGUN_WEBHOOK_SIGNING_KEY"] = SIGNING_KEY
+            sender = UserFactory(email="sender@example.com")
+            recipient = UserFactory(email="recipient@example.com")
+            item = ItemFactory(owner=recipient)
+            original = MessageFactory(
+                sender=sender,
+                recipient=recipient,
+                item=item,
+                body="Can I borrow this?",
+            )
+            db.session.commit()
+            original_id = original.id
+            sender_id = sender.id
+            recipient_id = recipient.id
+            item_id = item.id
+
+        response = client.post(
+            "/webhooks/mailgun/messages",
+            data=mailgun_payload(original_id, sender="recipient@example.com", body="Yes."),
+        )
+
+        assert response.status_code == 200
+
+        with app.app_context():
+            reply = Message.query.filter_by(parent_id=original_id).one()
+            assert reply.sender_id == recipient_id
+            assert reply.recipient_id == sender_id
+            assert reply.item_id == item_id
+            assert reply.body == "Yes."
+
+    def test_mailgun_reply_rejects_bad_signature(self, client, app):
+        with app.app_context():
+            app.config["MAILGUN_WEBHOOK_SIGNING_KEY"] = SIGNING_KEY
+            original = MessageFactory()
+            db.session.commit()
+            original_id = original.id
+            recipient_email = original.recipient.email
+
+        response = client.post(
+            "/webhooks/mailgun/messages",
+            data=mailgun_payload(
+                original_id,
+                sender=recipient_email,
+                signature="bad-signature",
+            ),
+        )
+
+        assert response.status_code == 406
+
+        with app.app_context():
+            assert Message.query.filter_by(parent_id=original_id).count() == 0
+
+    def test_mailgun_reply_rejects_non_participant_sender(self, client, app):
+        with app.app_context():
+            app.config["MAILGUN_WEBHOOK_SIGNING_KEY"] = SIGNING_KEY
+            original = MessageFactory()
+            outsider = UserFactory(email="outsider@example.com")
+            db.session.commit()
+            original_id = original.id
+            outsider_email = outsider.email
+
+        response = client.post(
+            "/webhooks/mailgun/messages",
+            data=mailgun_payload(original_id, sender=outsider_email),
+        )
+
+        assert response.status_code == 406
+
+        with app.app_context():
+            assert Message.query.filter_by(parent_id=original_id).count() == 0
+
+    def test_mailgun_reply_rejects_empty_body(self, client, app):
+        with app.app_context():
+            app.config["MAILGUN_WEBHOOK_SIGNING_KEY"] = SIGNING_KEY
+            original = MessageFactory()
+            db.session.commit()
+            original_id = original.id
+            recipient_email = original.recipient.email
+
+        payload = mailgun_payload(original_id, sender=recipient_email, body="")
+        payload["body-plain"] = "   "
+
+        response = client.post("/webhooks/mailgun/messages", data=payload)
+
+        assert response.status_code == 406
+
+        with app.app_context():
+            assert Message.query.filter_by(parent_id=original_id).count() == 0

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -9,12 +9,34 @@ from app.utils.email import (
     build_digest_email_content,
     send_account_deletion_email,
     send_digest_email,
+    send_email,
 )
 from tests.factories import UserFactory
 
 
 class TestEmailUtils:
     """Test email utility functions."""
+
+    def test_send_email_includes_reply_to_header(self, app):
+        with app.app_context():
+            app.config["MAILGUN_DOMAIN"] = "mg.example.com"
+            app.config["MAILGUN_API_KEY"] = "key-12345"
+            app.config["EMAIL_ALLOWLIST"] = None
+
+            with patch("app.utils.email.requests.post") as mock_post:
+                mock_post.return_value.status_code = 200
+
+                result = send_email(
+                    "recipient@example.com",
+                    "Test Subject",
+                    "Test body",
+                    reply_to="Meutch Replies <reply+123@reply.example.com>",
+                )
+
+                assert result is True
+                assert mock_post.call_args.kwargs["data"]["h:Reply-To"] == (
+                    "Meutch Replies <reply+123@reply.example.com>"
+                )
 
     def test_send_account_deletion_email_content(self):
         """Test that account deletion email contains correct content."""

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -302,10 +302,15 @@ class TestEmailUtils:
                 unsubscribe_url="https://example.com/digest/unsubscribe/token123",
             )
 
-            assert "Alex posted a giveaway: Free Chair [Claimed]" in content["text"]
-            assert "Taylor requested: Need a ladder [Fulfilled]" in content["text"]
-            assert ">Claimed</span>" in content["html"]
-            assert ">Fulfilled</span>" in content["html"]
+            assert "Free Chair offered by Alex was claimed [New]" in content["text"]
+            assert "Taylor: Need a ladder was marked fulfilled [New]" in content["text"]
+            # Descriptions should be included for new-resolved-in-window items
+            assert "Great chair in good condition" in content["text"]
+            assert "Need for one weekend project" in content["text"]
+            assert ">New</span>" in content["html"]
+            # Green status pill should NOT appear for new-resolved-in-window items
+            assert ">Claimed</span>" not in content["html"]
+            assert ">Fulfilled</span>" not in content["html"]
 
     def test_build_digest_email_content_renders_resolution_only_copy(self, app):
         with app.app_context():
@@ -386,6 +391,125 @@ class TestEmailUtils:
             assert "Image: https://example.com/chair.jpg" not in content["text"]
             assert "Free Chair offered by Alex was claimed" in content["html"]
             assert "Need a ladder was marked fulfilled" in content["html"]
+
+    def test_build_digest_email_content_orders_new_in_window_items_first(self, app):
+        with app.app_context():
+            user = UserFactory(first_name="Digest", digest_frequency="weekly")
+            fulfilled_new_id = uuid.uuid4()
+            fulfilled_old_id = uuid.uuid4()
+            claimed_new_id = uuid.uuid4()
+            claimed_old_id = uuid.uuid4()
+            payload = {
+                "summary_stats": {
+                    "total_new_items": 2,
+                    "giveaways_count": 1,
+                    "borrow_requests_count": 1,
+                },
+                "events": [
+                    {
+                        "event_type": "request",
+                        "request_id": fulfilled_old_id,
+                        "actor_name": "After",
+                        "title": "Old Request",
+                        "action": "requested",
+                        "digest_variant": "resolved-in-window",
+                        "resolution_status": "fulfilled",
+                    },
+                    {
+                        "event_type": "request",
+                        "request_id": fulfilled_new_id,
+                        "actor_name": "First",
+                        "title": "New Request",
+                        "action": "requested",
+                        "digest_variant": "new-resolved-in-window",
+                        "resolution_status": "fulfilled",
+                    },
+                    {
+                        "event_type": "giveaway",
+                        "item_id": claimed_new_id,
+                        "actor_name": "Early",
+                        "title": "New Giveaway",
+                        "action": "posted a giveaway",
+                        "digest_variant": "new-resolved-in-window",
+                        "resolution_status": "claimed",
+                    },
+                    {
+                        "event_type": "giveaway",
+                        "item_id": claimed_old_id,
+                        "actor_name": "Late",
+                        "title": "Old Giveaway",
+                        "action": "posted a giveaway",
+                        "digest_variant": "resolved-in-window",
+                        "resolution_status": "claimed",
+                    },
+                ],
+                "requests": [
+                    {
+                        "event_type": "request",
+                        "request_id": fulfilled_old_id,
+                        "actor_name": "After",
+                        "title": "Old Request",
+                        "action": "requested",
+                        "digest_variant": "resolved-in-window",
+                        "resolution_status": "fulfilled",
+                    },
+                    {
+                        "event_type": "request",
+                        "request_id": fulfilled_new_id,
+                        "actor_name": "First",
+                        "title": "New Request",
+                        "action": "requested",
+                        "digest_variant": "new-resolved-in-window",
+                        "resolution_status": "fulfilled",
+                    },
+                ],
+                "giveaways": [
+                    {
+                        "event_type": "giveaway",
+                        "item_id": claimed_old_id,
+                        "actor_name": "Late",
+                        "title": "Old Giveaway",
+                        "action": "posted a giveaway",
+                        "digest_variant": "resolved-in-window",
+                        "resolution_status": "claimed",
+                    },
+                    {
+                        "event_type": "giveaway",
+                        "item_id": claimed_new_id,
+                        "actor_name": "Early",
+                        "title": "New Giveaway",
+                        "action": "posted a giveaway",
+                        "digest_variant": "new-resolved-in-window",
+                        "resolution_status": "claimed",
+                    },
+                ],
+                "circle_joins": [],
+                "loans": [],
+            }
+
+            content = build_digest_email_content(
+                user,
+                payload,
+                manage_url="https://example.com/digest/manage/token123",
+                unsubscribe_url="https://example.com/digest/unsubscribe/token123",
+            )
+
+            # "New Request" (new-resolved-in-window) should appear before
+            # "Old Request" (resolved-in-window) in the fulfilled section.
+            new_req_pos = content["text"].find("New Request")
+            old_req_pos = content["text"].find("Old Request")
+            assert new_req_pos != -1 and old_req_pos != -1
+            assert (
+                new_req_pos < old_req_pos
+            ), "new-resolved-in-window request should appear before resolved-in-window"
+
+            # Same ordering check for giveaways in claimed section.
+            new_gw_pos = content["text"].find("New Giveaway")
+            old_gw_pos = content["text"].find("Old Giveaway")
+            assert new_gw_pos != -1 and old_gw_pos != -1
+            assert (
+                new_gw_pos < old_gw_pos
+            ), "new-resolved-in-window giveaway should appear before resolved-in-window"
 
     def test_send_digest_email_sends_when_payload_has_only_resolution_events(self, app):
         with app.app_context():

--- a/tests/unit/test_message_notifications.py
+++ b/tests/unit/test_message_notifications.py
@@ -1,10 +1,9 @@
-import pytest
-from unittest.mock import patch, MagicMock
-from flask import url_for
+from unittest.mock import MagicMock, patch
 
-from app.models import User, Item, Message
-from app.utils.email import send_message_notification_email
-from tests.factories import UserFactory, ItemFactory, MessageFactory
+import pytest
+
+from app.utils.email import build_message_reply_address, send_message_notification_email
+from tests.factories import ItemFactory, MessageFactory, UserFactory
 
 
 class TestMessageNotifications:
@@ -41,6 +40,33 @@ class TestMessageNotifications:
                 assert 'John Doe' in call_args[0][2]  # text content includes sender name
                 assert 'Hi, I am interested in this item!' in call_args[0][2]  # text content includes message body
                 assert call_args[0][3] is not None  # HTML content provided as 4th positional argument
+
+    def test_send_message_notification_email_sets_reply_to(self, app):
+        """Test message notifications include a reply-to address for email replies."""
+        with app.app_context():
+            app.config["MAILGUN_INBOUND_DOMAIN"] = "reply.example.com"
+            sender = UserFactory(email="sender@test.com")
+            recipient = UserFactory(email="recipient@test.com")
+            item = ItemFactory(name="Test Item", owner=recipient)
+            message = MessageFactory(sender=sender, recipient=recipient, item=item)
+
+            with patch("app.utils.email.send_email") as mock_send_email:
+                mock_send_email.return_value = True
+
+                result = send_message_notification_email(message)
+
+                assert result is True
+                assert mock_send_email.call_args.kwargs["reply_to"] == (
+                    f"Meutch Replies <reply+{message.id}@reply.example.com>"
+                )
+
+    def test_build_message_reply_address_returns_none_without_domain(self, app):
+        with app.app_context():
+            app.config["MAILGUN_INBOUND_DOMAIN"] = None
+            app.config["MAILGUN_DOMAIN"] = None
+            message = MessageFactory()
+
+            assert build_message_reply_address(message) is None
 
     def test_send_message_notification_email_loan_request(self, app):
         """Test sending email notification for a loan request message."""

--- a/tests/unit/test_message_notifications.py
+++ b/tests/unit/test_message_notifications.py
@@ -13,33 +13,39 @@ class TestMessageNotifications:
         """Test sending email notification for a regular message."""
         with app.app_context():
             # Create test users and item
-            sender = UserFactory(email='sender@test.com', first_name='John', last_name='Doe')
-            recipient = UserFactory(email='recipient@test.com', first_name='Jane', last_name='Smith')
-            item = ItemFactory(name='Test Item', owner=recipient)
-            
+            sender = UserFactory(email="sender@test.com", first_name="John", last_name="Doe")
+            recipient = UserFactory(
+                email="recipient@test.com", first_name="Jane", last_name="Smith"
+            )
+            item = ItemFactory(name="Test Item", owner=recipient)
+
             # Create a regular message
             message = MessageFactory(
                 sender=sender,
-                recipient=recipient, 
+                recipient=recipient,
                 item=item,
-                body='Hi, I am interested in this item!'
+                body="Hi, I am interested in this item!",
             )
-            
-            with patch('app.utils.email.send_email') as mock_send_email:
+
+            with patch("app.utils.email.send_email") as mock_send_email:
                 mock_send_email.return_value = True
-                
+
                 result = send_message_notification_email(message)
-                
+
                 assert result is True
                 mock_send_email.assert_called_once()
-                
+
                 # Check the call arguments
                 call_args = mock_send_email.call_args
-                assert call_args[0][0] == 'recipient@test.com'  # to_email
-                assert 'New Message about Test Item' in call_args[0][1]  # subject
-                assert 'John Doe' in call_args[0][2]  # text content includes sender name
-                assert 'Hi, I am interested in this item!' in call_args[0][2]  # text content includes message body
-                assert call_args[0][3] is not None  # HTML content provided as 4th positional argument
+                assert call_args[0][0] == "recipient@test.com"  # to_email
+                assert "New Message about Test Item" in call_args[0][1]  # subject
+                assert "John Doe" in call_args[0][2]  # text content includes sender name
+                assert (
+                    "Hi, I am interested in this item!" in call_args[0][2]
+                )  # text content includes message body
+                assert (
+                    call_args[0][3] is not None
+                )  # HTML content provided as 4th positional argument
                 assert "Reply to this email directly" in call_args[0][2]
                 assert "reply to this email directly" in call_args[0][3]
 
@@ -74,41 +80,39 @@ class TestMessageNotifications:
         """Test sending email notification for a loan request message."""
         with app.app_context():
             from tests.factories import LoanRequestFactory
-            
+
             # Create test users and item
-            sender = UserFactory(email='borrower@test.com', first_name='John', last_name='Doe')
-            recipient = UserFactory(email='owner@test.com', first_name='Jane', last_name='Smith')
-            item = ItemFactory(name='Test Item', owner=recipient)
-            
+            sender = UserFactory(email="borrower@test.com", first_name="John", last_name="Doe")
+            recipient = UserFactory(email="owner@test.com", first_name="Jane", last_name="Smith")
+            item = ItemFactory(name="Test Item", owner=recipient)
+
             # Create a loan request
-            loan_request = LoanRequestFactory(
-                item=item,
-                borrower=sender,
-                status='pending'
-            )
-            
+            loan_request = LoanRequestFactory(item=item, borrower=sender, status="pending")
+
             # Create a loan request message
             message = MessageFactory(
                 sender=sender,
-                recipient=recipient, 
+                recipient=recipient,
                 item=item,
-                body='Can I borrow this item please?',
-                loan_request=loan_request
+                body="Can I borrow this item please?",
+                loan_request=loan_request,
             )
-            
-            with patch('app.utils.email.send_email') as mock_send_email:
+
+            with patch("app.utils.email.send_email") as mock_send_email:
                 mock_send_email.return_value = True
-                
+
                 result = send_message_notification_email(message)
-                
+
                 assert result is True
                 mock_send_email.assert_called_once()
-                
+
                 # Check the call arguments
                 call_args = mock_send_email.call_args
-                assert call_args[0][0] == 'owner@test.com'  # to_email
-                assert 'New Loan Request for Test Item' in call_args[0][1]  # subject for pending loan request
-                assert 'loan request' in call_args[0][2]  # text content indicates loan request
+                assert call_args[0][0] == "owner@test.com"  # to_email
+                assert (
+                    "New Loan Request for Test Item" in call_args[0][1]
+                )  # subject for pending loan request
+                assert "loan request" in call_args[0][2]  # text content indicates loan request
                 assert "Reply to this email directly" not in call_args[0][2]
                 assert "reply to this email directly" not in call_args[0][3]
                 assert "and respond" not in call_args[0][2]
@@ -120,16 +124,17 @@ class TestMessageNotifications:
         with app.app_context():
             # Create a message with non-existent user IDs
             import uuid
+
             fake_message = MagicMock()
             fake_message.sender_id = uuid.uuid4()
             fake_message.recipient_id = uuid.uuid4()
-            
-            with patch('app.utils.email.send_email') as mock_send_email:
-                with patch('app.models.User.query') as mock_query:
+
+            with patch("app.utils.email.send_email") as mock_send_email:
+                with patch("app.models.User.query") as mock_query:
                     mock_query.get.return_value = None  # Simulate users not found
-                    
+
                     result = send_message_notification_email(fake_message)
-                    
+
                     assert result is False
                     mock_send_email.assert_not_called()
 
@@ -137,23 +142,20 @@ class TestMessageNotifications:
         """Test handling of email sending failure."""
         with app.app_context():
             # Create test users and item
-            sender = UserFactory(email='sender@test.com')
-            recipient = UserFactory(email='recipient@test.com')
-            item = ItemFactory(name='Test Item', owner=recipient)
-            
+            sender = UserFactory(email="sender@test.com")
+            recipient = UserFactory(email="recipient@test.com")
+            item = ItemFactory(name="Test Item", owner=recipient)
+
             # Create a regular message
             message = MessageFactory(
-                sender=sender,
-                recipient=recipient, 
-                item=item,
-                body='Test message'
+                sender=sender, recipient=recipient, item=item, body="Test message"
             )
-            
-            with patch('app.utils.email.send_email') as mock_send_email:
+
+            with patch("app.utils.email.send_email") as mock_send_email:
                 mock_send_email.return_value = False  # Simulate email failure
-                
+
                 result = send_message_notification_email(message)
-                
+
                 assert result is False
                 mock_send_email.assert_called_once()
 
@@ -161,46 +163,42 @@ class TestMessageNotifications:
         """Test sending email notification for a canceled loan request."""
         with app.app_context():
             from tests.factories import LoanRequestFactory
-            
+
             # Create test users and item
-            sender = UserFactory(email='borrower@test.com', first_name='John', last_name='Doe')
-            recipient = UserFactory(email='owner@test.com', first_name='Jane', last_name='Smith')
-            item = ItemFactory(name='Test Item', owner=recipient)
-            
+            sender = UserFactory(email="borrower@test.com", first_name="John", last_name="Doe")
+            recipient = UserFactory(email="owner@test.com", first_name="Jane", last_name="Smith")
+            item = ItemFactory(name="Test Item", owner=recipient)
+
             # Create a canceled loan request
-            loan_request = LoanRequestFactory(
-                item=item,
-                borrower=sender,
-                status='canceled'
-            )
-            
+            loan_request = LoanRequestFactory(item=item, borrower=sender, status="canceled")
+
             # Create a loan cancellation message
             message = MessageFactory(
                 sender=sender,
-                recipient=recipient, 
+                recipient=recipient,
                 item=item,
-                body='Loan request has been canceled by the borrower.',
-                loan_request=loan_request
+                body="Loan request has been canceled by the borrower.",
+                loan_request=loan_request,
             )
-            
-            with patch('app.utils.email.send_email') as mock_send_email:
+
+            with patch("app.utils.email.send_email") as mock_send_email:
                 mock_send_email.return_value = True
-                
+
                 result = send_message_notification_email(message)
-                
+
                 assert result is True
                 mock_send_email.assert_called_once()
-                
+
                 # Verify the email content
                 args, kwargs = mock_send_email.call_args
                 to_email, subject, text_content, html_content = args
-                
-                assert to_email == 'owner@test.com'
-                assert 'Loan Request Canceled' in subject
-                assert 'Test Item' in subject
-                assert 'loan cancellation' in text_content.lower()
-                assert 'canceled by the borrower' in text_content
-                assert 'loan cancellation' in html_content.lower()
+
+                assert to_email == "owner@test.com"
+                assert "Loan Request Canceled" in subject
+                assert "Test Item" in subject
+                assert "loan cancellation" in text_content.lower()
+                assert "canceled by the borrower" in text_content
+                assert "loan cancellation" in html_content.lower()
                 assert "Reply to this email directly" not in text_content
                 assert "reply to this email directly" not in html_content
                 assert kwargs["reply_to"] is None
@@ -209,31 +207,33 @@ class TestMessageNotifications:
         """Test that invalid loan request status raises ValueError."""
         with app.app_context():
             from tests.factories import LoanRequestFactory
-            
+
             # Create test users and item
-            sender = UserFactory(email='borrower@test.com', first_name='John', last_name='Doe')
-            recipient = UserFactory(email='owner@test.com', first_name='Jane', last_name='Smith')
-            item = ItemFactory(name='Test Item', owner=recipient)
-            
+            sender = UserFactory(email="borrower@test.com", first_name="John", last_name="Doe")
+            recipient = UserFactory(email="owner@test.com", first_name="Jane", last_name="Smith")
+            item = ItemFactory(name="Test Item", owner=recipient)
+
             # Create a loan request with invalid status
             loan_request = LoanRequestFactory(
                 item=item,
                 borrower=sender,
-                status='invalid_status'  # This should trigger the ValueError
+                status="invalid_status",  # This should trigger the ValueError
             )
-            
+
             # Create a loan request message
             message = MessageFactory(
                 sender=sender,
-                recipient=recipient, 
+                recipient=recipient,
                 item=item,
-                body='Test message with invalid status.',
-                loan_request=loan_request
+                body="Test message with invalid status.",
+                loan_request=loan_request,
             )
-            
+
             # Should raise ValueError for unknown status
             with pytest.raises(ValueError) as exc_info:
                 send_message_notification_email(message)
-            
+
             assert "Unknown loan request status 'invalid_status'" in str(exc_info.value)
-            assert "Valid statuses are: pending, approved, denied, completed, canceled" in str(exc_info.value)
+            assert "Valid statuses are: pending, approved, denied, completed, canceled" in str(
+                exc_info.value
+            )

--- a/tests/unit/test_message_notifications.py
+++ b/tests/unit/test_message_notifications.py
@@ -40,6 +40,8 @@ class TestMessageNotifications:
                 assert 'John Doe' in call_args[0][2]  # text content includes sender name
                 assert 'Hi, I am interested in this item!' in call_args[0][2]  # text content includes message body
                 assert call_args[0][3] is not None  # HTML content provided as 4th positional argument
+                assert "Reply to this email directly" in call_args[0][2]
+                assert "reply to this email directly" in call_args[0][3]
 
     def test_send_message_notification_email_sets_reply_to(self, app):
         """Test message notifications include a reply-to address for email replies."""
@@ -107,6 +109,11 @@ class TestMessageNotifications:
                 assert call_args[0][0] == 'owner@test.com'  # to_email
                 assert 'New Loan Request for Test Item' in call_args[0][1]  # subject for pending loan request
                 assert 'loan request' in call_args[0][2]  # text content indicates loan request
+                assert "Reply to this email directly" not in call_args[0][2]
+                assert "reply to this email directly" not in call_args[0][3]
+                assert "and respond" not in call_args[0][2]
+                assert "& Respond" not in call_args[0][3]
+                assert mock_send_email.call_args.kwargs["reply_to"] is None
 
     def test_send_message_notification_email_missing_users(self, app):
         """Test handling of missing users."""
@@ -194,6 +201,9 @@ class TestMessageNotifications:
                 assert 'loan cancellation' in text_content.lower()
                 assert 'canceled by the borrower' in text_content
                 assert 'loan cancellation' in html_content.lower()
+                assert "Reply to this email directly" not in text_content
+                assert "reply to this email directly" not in html_content
+                assert kwargs["reply_to"] is None
 
     def test_send_message_notification_email_invalid_status(self, app):
         """Test that invalid loan request status raises ValueError."""


### PR DESCRIPTION
## Summary
- Add Mailgun inbound webhook for reply-by-email on regular message notifications
- Set `Reply-To` to `reply+<message_id>@MAILGUN_INBOUND_DOMAIN` only for regular messages
- Keep loan request/status notification emails non-replyable
- Add staging/deployment notes and webhook tests

## Staging setup
Needs these env vars:
- `MAILGUN_WEBHOOK_SIGNING_KEY`
- `MAILGUN_INBOUND_DOMAIN`

Suggested staging value:

`MAILGUN_INBOUND_DOMAIN=replies-staging.meutch.com`

`MAILGUN_WEBHOOK_SIGNING_KEY` comes from Mailgun: in the Mailgun dashboard, go to webhook/security settings and copy the HTTP webhook signing key.

Mailgun receiving route should forward parsed messages to:
`STAGING_DOMAIN/webhooks/mailgun/messages`

Example route:
```text
match_recipient("^reply\\+(.*)@replies-staging.meutch.com$")
forward("STAGING_DOMAIN/webhooks/mailgun/messages")
stop()
```

## Testing
- `uv run ruff check app/utils/email.py app/webhooks tests/unit/test_email.py tests/unit/test_message_notifications.py tests/integration/test_mailgun_inbound_replies.py config.py`
- `FLASK_ENV=development uv run pytest tests/unit/test_config.py tests/unit/test_email.py tests/unit/test_message_notifications.py tests/unit/services/test_message_service.py tests/integration/test_api_messages.py tests/integration/test_mailgun_inbound_replies.py`
