### PR TITLE
fix: remove "view item" button on claimed giveaways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Get dev data seeding working again, it broke in #436 ([#450](https://github.com/sfirke/meutch/pull/450)).
 
 ### Bug fixes
+- Hide "View Item" link for claimed giveaway events in the home feed — clicking it previously led to a page stating the item was already claimed ([#TODO](https://github.com/sfirke/meutch/pull/TODO)).
 - Streamlined email digest fulfilled/claimed rendering: unified phrasing across both resolution variants, replaced green status pills with a subtle gray "New" label for items the user hasn't seen before, kept descriptions only for first-time items, and grouped new-resolved entries before previously-seen resolutions ([#427](https://github.com/sfirke/meutch/pull/427)).
 - Improve formatting of buttons, especially on mobile, for the circle admin interface as well as site admin and item detail card ([#434](https://github.com/sfirke/meutch/pull/434)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Get dev data seeding working again, it broke in #436 ([#450](https://github.com/sfirke/meutch/pull/450)).
 
 ### Bug fixes
-- Hide "View Item" link for claimed giveaway events in the home feed — clicking it previously led to a page stating the item was already claimed ([#TODO](https://github.com/sfirke/meutch/pull/TODO)).
+- Hide "View Item" link for claimed giveaway events in the home feed - clicking it previously led to a page stating the item was already claimed ([#453](https://github.com/sfirke/meutch/pull/453)).
 - Streamlined email digest fulfilled/claimed rendering: unified phrasing across both resolution variants, replaced green status pills with a subtle gray "New" label for items the user hasn't seen before, kept descriptions only for first-time items, and grouped new-resolved entries before previously-seen resolutions ([#427](https://github.com/sfirke/meutch/pull/427)).
 - Improve formatting of buttons, especially on mobile, for the circle admin interface as well as site admin and item detail card ([#434](https://github.com/sfirke/meutch/pull/434)).
 

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -177,7 +177,7 @@
                                 <div class="mt-2">
                                     {% if event.event_type == 'request' and event.request_id %}
                                         <a href="{{ url_for('requests.detail', request_id=event.request_id) }}" class="btn btn-sm text-primary p-0 border-0 fw-semibold text-decoration-none">View Request <i class="fas fa-chevron-right small ms-1"></i></a>
-                                    {% elif event.event_type == 'giveaway' and event.item_id %}
+                                    {% elif event.event_type == 'giveaway' and event.item_id and event.claim_status != 'claimed' %}
                                         <a href="{{ url_for('main.item_detail', item_id=event.item_id) }}" class="btn btn-sm text-primary p-0 border-0 fw-semibold text-decoration-none">View Item <i class="fas fa-chevron-right small ms-1"></i></a>
                                     {% elif event.event_type == 'lent' and event.item_id %}
                                         <a href="{{ url_for('main.item_detail', item_id=event.item_id) }}" class="btn btn-sm text-primary p-0 border-0 fw-semibold text-decoration-none">View Item <i class="fas fa-chevron-right small ms-1"></i></a>

--- a/tests/integration/test_completed_giveaway_visibility.py
+++ b/tests/integration/test_completed_giveaway_visibility.py
@@ -10,6 +10,52 @@ from tests.factories import CircleFactory, ItemFactory, UserFactory
 class TestCompletedGiveawayVisibility:
     """Test that completed giveaways stay hidden in browse surfaces but can appear in the home feed."""
 
+    def test_claimed_giveaway_hides_view_item_link(self, client, app, auth_user):
+        """Test that claimed giveaway events in the home feed hide the 'View Item' link."""
+        user_email = None
+        with app.app_context():
+            circle = CircleFactory()
+            owner = UserFactory()
+            claimer = UserFactory()
+            current_user = auth_user()
+            user_email = current_user.email
+
+            circle.members.extend([owner, claimer, current_user])
+
+            # Create an unclaimed giveaway (should show "View Item")
+            unclaimed = ItemFactory(
+                owner=owner,
+                is_giveaway=True,
+                giveaway_visibility="default",
+                claim_status="unclaimed",
+            )
+            unclaimed_name = unclaimed.name
+
+            # Create a recently-claimed giveaway (should NOT show "View Item")
+            claimed = ItemFactory(
+                owner=owner,
+                is_giveaway=True,
+                giveaway_visibility="default",
+                claim_status="claimed",
+                claimed_by=claimer,
+                claimed_at=datetime.now(UTC) - timedelta(days=5),
+            )
+            claimed_name = claimed.name
+
+            db.session.commit()
+
+        login_user(client, email=user_email)
+        response = client.get("/?distance=&show_claimed_giveaways=1")
+        assert response.status_code == 200
+        html = response.data.decode()
+
+        # Both giveaways should appear in the feed
+        assert unclaimed_name in html
+        assert claimed_name in html
+
+        # "View Item" should appear exactly once (only for the unclaimed giveaway)
+        assert html.count("View Item") == 1
+
     def test_claimed_giveaway_hidden_by_default_on_home_page(self, client, app, auth_user):
         """Test that recently claimed giveaways are hidden by default on home page."""
         user_email = None


### PR DESCRIPTION
Fix #429 