### PR TITLE
fix: gray out claimed giveaways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
   - Frontend changes to finish the work in ([#439](https://github.com/sfirke/meutch/pull/439)).
 
 **Minor**:
-- Claimed giveaway cards in the home feed are now visually distinct — dimmed with a gray border and reduced opacity — making it clear at a glance which giveaways are no longer available ([#416](https://github.com/sfirke/meutch/pull/416)).
 - Message notification emails can now be replied to by email; Mailgun inbound replies create normal conversation replies in Meutch ([#449](https://github.com/sfirke/meutch/issues/449)).
 - Added a Contact Us form so authenticated users can message the Meutch team directly from the app, replacing the external GitHub Issues link in the footer ([#448](https://github.com/sfirke/meutch/pull/448)).
 - Improved the giveaway request and handoff experience - no more needing to click "I want this!", instead owners can choose from anyone who messages. Also allows for marking giveaways handed off outside of Meutch ([#445](https://github.com/sfirke/meutch/pull/445)).
 - On the View Circle page, show the members 20/page instead of all at once ([#433](https://github.com/sfirke/meutch/pull/433)).
 - Community Activity now hides claimed giveaways by default and includes a filter to show them when desired ([#424](https://github.com/sfirke/meutch/issues/424)).
+- Claimed giveaway cards in the home feed are now visually distinct — dimmed with a gray border and reduced opacity — making it clear at a glance which giveaways are no longer available ([#455](https://github.com/sfirke/meutch/pull/455)).
 
 ### Developer Experience
 - Remove legacy `item`/`request`/`circle` kwargs from `MessageFactory`; all test call sites now use `conversation=` directly via `ConversationFactory` ([#437](https://github.com/sfirke/meutch/pull/437)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
   - Frontend changes to finish the work in ([#439](https://github.com/sfirke/meutch/pull/439)).
 
 **Minor**:
+- Claimed giveaway cards in the home feed are now visually distinct — dimmed with a gray border and reduced opacity — making it clear at a glance which giveaways are no longer available ([#416](https://github.com/sfirke/meutch/pull/416)).
 - Message notification emails can now be replied to by email; Mailgun inbound replies create normal conversation replies in Meutch ([#449](https://github.com/sfirke/meutch/issues/449)).
 - Added a Contact Us form so authenticated users can message the Meutch team directly from the app, replacing the external GitHub Issues link in the footer ([#448](https://github.com/sfirke/meutch/pull/448)).
 - Improved the giveaway request and handoff experience - no more needing to click "I want this!", instead owners can choose from anyone who messages. Also allows for marking giveaways handed off outside of Meutch ([#445](https://github.com/sfirke/meutch/pull/445)).

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1737,6 +1737,11 @@ footer h6 {
     background: #f8f9fa;
 }
 
+.giveaway-card-claimed {
+    opacity: 0.65;
+    background: #f8f9fa;
+}
+
 .request-avatar img {
     object-fit: cover;
     border: 2px solid var(--border-color, #dee2e6);

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -121,13 +121,17 @@
                 {% if event.event_type == 'request' %}
                     {% set border_class = 'border-start border-4 border-primary' %}
                 {% elif event.event_type == 'giveaway' %}
-                    {% set border_class = 'border-start border-4 border-success' %}
+                    {% if event.claim_status == 'claimed' %}
+                        {% set border_class = 'border-start border-4 border-secondary' %}
+                    {% else %}
+                        {% set border_class = 'border-start border-4 border-success' %}
+                    {% endif %}
                 {% elif event.event_type == 'lent' %}
                     {% set border_class = 'border-start border-4 border-secondary' %}
                 {% elif event.event_type == 'circle_join' %}
                     {% set border_class = 'border-start border-4 border-info' %}
                 {% endif %}
-                <article class="card shadow-sm border-0 activity-feed-card {{ border_class }}">
+                <article class="card shadow-sm border-0 activity-feed-card{% if event.event_type == 'giveaway' and event.claim_status == 'claimed' %} giveaway-card-claimed{% endif %} {{ border_class }}">
                     <div class="card-body py-3">
                         <div class="d-flex align-items-center mb-2 gap-2 text-muted" style="font-size: 0.9rem;">
                             {% if event.actor_avatar_url %}

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -117,21 +117,20 @@
         <div class="d-grid gap-3 mb-4 activity-feed-list">
             {% for event in feed_events %}
                 {% set actor_initials = (event.actor_name|replace(' ', ''))[:2]|upper %}
+                {% set is_claimed_giveaway = event.event_type == 'giveaway' and event.claim_status == 'claimed' %}
                 {% set border_class = '' %}
                 {% if event.event_type == 'request' %}
                     {% set border_class = 'border-start border-4 border-primary' %}
+                {% elif is_claimed_giveaway %}
+                    {% set border_class = 'border-start border-4 border-secondary' %}
                 {% elif event.event_type == 'giveaway' %}
-                    {% if event.claim_status == 'claimed' %}
-                        {% set border_class = 'border-start border-4 border-secondary' %}
-                    {% else %}
-                        {% set border_class = 'border-start border-4 border-success' %}
-                    {% endif %}
+                    {% set border_class = 'border-start border-4 border-success' %}
                 {% elif event.event_type == 'lent' %}
                     {% set border_class = 'border-start border-4 border-secondary' %}
                 {% elif event.event_type == 'circle_join' %}
                     {% set border_class = 'border-start border-4 border-info' %}
                 {% endif %}
-                <article class="card shadow-sm border-0 activity-feed-card{% if event.event_type == 'giveaway' and event.claim_status == 'claimed' %} giveaway-card-claimed{% endif %} {{ border_class }}">
+                <article class="card shadow-sm border-0 activity-feed-card{% if is_claimed_giveaway %} giveaway-card-claimed{% endif %} {{ border_class }}">
                     <div class="card-body py-3">
                         <div class="d-flex align-items-center mb-2 gap-2 text-muted" style="font-size: 0.9rem;">
                             {% if event.actor_avatar_url %}

--- a/tests/integration/test_completed_giveaway_visibility.py
+++ b/tests/integration/test_completed_giveaway_visibility.py
@@ -56,6 +56,29 @@ class TestCompletedGiveawayVisibility:
         # "View Item" should appear exactly once (only for the unclaimed giveaway)
         assert html.count("View Item") == 1
 
+        # Claimed giveaway card should have gray border and dimmer class
+        # Find the claimed giveaway article by looking for the name and checking classes
+        # We use the fact that the claimed card's HTML contains both the name and the CSS classes
+
+        # Check claimed giveaway card has border-secondary and giveaway-card-claimed
+        # Find the article block containing the claimed item name
+        claimed_start = html.find(claimed_name)
+        # Search backwards for the opening <article tag
+        claimed_article_start = html.rfind("<article", 0, claimed_start)
+        claimed_article_end = html.find("</article>", claimed_start) + len("</article>")
+        claimed_article_html = html[claimed_article_start:claimed_article_end]
+        assert "border-secondary" in claimed_article_html
+        assert "giveaway-card-claimed" in claimed_article_html
+        assert "border-success" not in claimed_article_html
+
+        # Check unclaimed giveaway card has border-success but NOT giveaway-card-claimed
+        unclaimed_start = html.find(unclaimed_name)
+        unclaimed_article_start = html.rfind("<article", 0, unclaimed_start)
+        unclaimed_article_end = html.find("</article>", unclaimed_start) + len("</article>")
+        unclaimed_article_html = html[unclaimed_article_start:unclaimed_article_end]
+        assert "border-success" in unclaimed_article_html
+        assert "giveaway-card-claimed" not in unclaimed_article_html
+
     def test_claimed_giveaway_hidden_by_default_on_home_page(self, client, app, auth_user):
         """Test that recently claimed giveaways are hidden by default on home page."""
         user_email = None


### PR DESCRIPTION
Fix #416 - claimed giveaways in the home feed get reduced opacity and a gray border color instead of green