### PR TITLE
fix: help when reregistering email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
   - Frontend changes to finish the work in ([#439](https://github.com/sfirke/meutch/pull/439)).
 
 **Minor**:
-- Registration now shows contextual guidance when a user signs up with an already-registered email — unconfirmed users are prompted to resend the confirmation link, and confirmed users are directed to the forgot-password flow ([#388](https://github.com/sfirke/meutch/pull/388)).
+- Registration now shows contextual guidance when a user signs up with an already-registered email — unconfirmed users are prompted to resend the confirmation link, and confirmed users are directed to the forgot-password flow ([#456](https://github.com/sfirke/meutch/pull/456)).
 - Message notification emails can now be replied to by email; Mailgun inbound replies create normal conversation replies in Meutch ([#449](https://github.com/sfirke/meutch/issues/449)).
 - Added a Contact Us form so authenticated users can message the Meutch team directly from the app, replacing the external GitHub Issues link in the footer ([#448](https://github.com/sfirke/meutch/pull/448)).
 - Improved the giveaway request and handoff experience - no more needing to click "I want this!", instead owners can choose from anyone who messages. Also allows for marking giveaways handed off outside of Meutch ([#445](https://github.com/sfirke/meutch/pull/445)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
   - Frontend changes to finish the work in ([#439](https://github.com/sfirke/meutch/pull/439)).
 
 **Minor**:
+- Registration now shows contextual guidance when a user signs up with an already-registered email — unconfirmed users are prompted to resend the confirmation link, and confirmed users are directed to the forgot-password flow ([#388](https://github.com/sfirke/meutch/pull/388)).
 - Message notification emails can now be replied to by email; Mailgun inbound replies create normal conversation replies in Meutch ([#449](https://github.com/sfirke/meutch/issues/449)).
 - Added a Contact Us form so authenticated users can message the Meutch team directly from the app, replacing the external GitHub Issues link in the footer ([#448](https://github.com/sfirke/meutch/pull/448)).
 - Improved the giveaway request and handoff experience - no more needing to click "I want this!", instead owners can choose from anyone who messages. Also allows for marking giveaways handed off outside of Meutch ([#445](https://github.com/sfirke/meutch/pull/445)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Stay up on what's happening with Meutch. Improvements are constantly pushed to t
 - Improved the giveaway request and handoff experience - no more needing to click "I want this!", instead owners can choose from anyone who messages. Also allows for marking giveaways handed off outside of Meutch ([#445](https://github.com/sfirke/meutch/pull/445)).
 - On the View Circle page, show the members 20/page instead of all at once ([#433](https://github.com/sfirke/meutch/pull/433)).
 - Community Activity now hides claimed giveaways by default and includes a filter to show them when desired ([#424](https://github.com/sfirke/meutch/issues/424)).
+- Claimed giveaway cards in the home feed are now visually distinct — dimmed with a gray border and reduced opacity — making it clear at a glance which giveaways are no longer available ([#455](https://github.com/sfirke/meutch/pull/455)).
 
 ### Developer Experience
 - Remove legacy `item`/`request`/`circle` kwargs from `MessageFactory`; all test call sites now use `conversation=` directly via `ConversationFactory` ([#437](https://github.com/sfirke/meutch/pull/437)).

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -14,6 +14,7 @@ from app.forms import (
     ResetPasswordForm,
 )
 from app.services import auth_service
+from app.services.exceptions import ConflictError
 
 logger = logging.getLogger(__name__)
 logger.debug("Loading app.auth.routes")
@@ -118,22 +119,26 @@ def register():
     if form.validate_on_submit():
         next_page = request.args.get("next")
         safe_next = next_page if (next_page and _is_safe_url(next_page)) else None
-        registration_result = auth_service.register_user(
-            email=form.email.data,
-            first_name=form.first_name.data,
-            last_name=form.last_name.data,
-            password=form.password.data,
-            digest_frequency=form.digest_frequency.data,
-            location_method=form.location_method.data,
-            next_url=safe_next,
-            street=form.street.data,
-            city=form.city.data,
-            state=form.state.data,
-            zip_code=form.zip_code.data,
-            country=form.country.data,
-            latitude=form.latitude.data,
-            longitude=form.longitude.data,
-        )
+        try:
+            registration_result = auth_service.register_user(
+                email=form.email.data,
+                first_name=form.first_name.data,
+                last_name=form.last_name.data,
+                password=form.password.data,
+                digest_frequency=form.digest_frequency.data,
+                location_method=form.location_method.data,
+                next_url=safe_next,
+                street=form.street.data,
+                city=form.city.data,
+                state=form.state.data,
+                zip_code=form.zip_code.data,
+                country=form.country.data,
+                latitude=form.latitude.data,
+                longitude=form.longitude.data,
+            )
+        except ConflictError as exc:
+            flash(str(exc), "warning")
+            return render_template("auth/register.html", title="Register", form=form)
 
         if registration_result.location_method == "skip":
             flash(

--- a/app/forms_auth.py
+++ b/app/forms_auth.py
@@ -167,14 +167,22 @@ class RegistrationForm(FlaskForm):
     submit = SubmitField("Register")
 
     def validate_email(self, email):
-        """Check if email is already registered"""
-        from app import db
+        """Check if email is already registered with contextual status."""
+        from app.services.auth_service import check_existing_email
 
-        user = User.query.filter(db.func.lower(User.email) == db.func.lower(email.data)).first()
-        if user:
-            raise ValidationError(
-                "This email is already registered. Please choose a different one."
-            )
+        result = check_existing_email(email.data)
+        if result.exists:
+            if result.is_confirmed:
+                self.email_status = "confirmed"
+                raise ValidationError(
+                    "This email is already registered. Use the forgot-password link below to regain access."
+                )
+            else:
+                self.email_status = "unconfirmed"
+                raise ValidationError(
+                    "This email is already registered but hasn't been confirmed yet. "
+                    "Use the resend-confirmation link below or try a different email."
+                )
 
     def validate(self, extra_validators=None):
         """Custom validation to ensure required fields are filled based on location method"""

--- a/app/services/api_token_service.py
+++ b/app/services/api_token_service.py
@@ -190,10 +190,19 @@ def is_token_revoked(token_payload):
 
 def register_api_user(**user_data):
     """Register a new API user while preserving web-auth workflow behavior."""
-    existing_user = User.query.filter(
-        db.func.lower(User.email) == db.func.lower(user_data["email"])
-    ).first()
-    if existing_user is not None:
-        raise ConflictError("This email is already registered.")
+    existing = auth_service.check_existing_email(user_data["email"])
+    if existing.exists:
+        if existing.is_confirmed:
+            raise ConflictError(
+                "An account with this email is already registered. "
+                "Use the forgot-password flow to regain access.",
+                details={"email_status": "confirmed"},
+            )
+        else:
+            raise ConflictError(
+                "An account with this email exists but hasn't been confirmed. "
+                "Check your email or request a new confirmation.",
+                details={"email_status": "unconfirmed"},
+            )
 
     return auth_service.register_user(**user_data)

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -48,7 +48,7 @@ class ExistingEmailResult:
     is_confirmed: bool = False
 
 
-def check_existing_email(email):
+def check_existing_email(email) -> ExistingEmailResult:
     """Check if an email is already registered and whether the user is confirmed.
 
     Returns an ExistingEmailResult with:

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -151,12 +151,14 @@ def register_user(
         if existing.is_confirmed:
             raise ConflictError(
                 "An account with this email is already registered. "
-                "If this is your account, use the forgot password link to regain access."
+                "If this is your account, use the forgot password link to regain access.",
+                details={"email_status": "confirmed"},
             ) from None
         else:
             raise ConflictError(
                 "An account with this email exists but hasn't been confirmed yet. "
-                "Please check your email for the confirmation link or request a new one."
+                "Please check your email for the confirmation link or request a new one.",
+                details={"email_status": "unconfirmed"},
             ) from None
     email_sent = send_confirmation_email(user, next_url=next_url)
     return RegistrationResult(

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -2,9 +2,12 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy.exc import IntegrityError
+
 from app import db
 from app.models import User
 from app.services import location_service
+from app.services.exceptions import ConflictError
 from app.utils.email import send_confirmation_email, send_password_reset_email
 
 logger = logging.getLogger(__name__)
@@ -37,6 +40,26 @@ PASSWORD_RESET_TOKEN_STATUS_EXPIRED = "expired"
 PASSWORD_RESET_STATUS_SUCCESS = "success"
 PASSWORD_RESET_STATUS_INVALID = "invalid"
 PASSWORD_RESET_STATUS_EXPIRED = "expired"
+
+
+@dataclass(frozen=True)
+class ExistingEmailResult:
+    exists: bool
+    is_confirmed: bool = False
+
+
+def check_existing_email(email):
+    """Check if an email is already registered and whether the user is confirmed.
+
+    Returns an ExistingEmailResult with:
+    - exists: whether the email is registered
+    - is_confirmed: whether the existing user has confirmed their email
+        (only meaningful if exists is True)
+    """
+    user = _get_user_by_email(email)
+    if user is None:
+        return ExistingEmailResult(exists=False)
+    return ExistingEmailResult(exists=True, is_confirmed=user.is_confirmed())
 
 
 @dataclass
@@ -120,7 +143,21 @@ def register_user(
     )
 
     db.session.add(user)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        existing = check_existing_email(email)
+        if existing.is_confirmed:
+            raise ConflictError(
+                "An account with this email is already registered. "
+                "If this is your account, use the forgot password link to regain access."
+            ) from None
+        else:
+            raise ConflictError(
+                "An account with this email exists but hasn't been confirmed yet. "
+                "Please check your email for the confirmation link or request a new one."
+            ) from None
     email_sent = send_confirmation_email(user, next_url=next_url)
     return RegistrationResult(
         user=user,

--- a/app/services/exceptions.py
+++ b/app/services/exceptions.py
@@ -20,6 +20,10 @@ class ConflictError(ServiceError):
 
     flash_category = "warning"
 
+    def __init__(self, message=None, *, details=None):
+        super().__init__(message or "")
+        self.details = details or {}
+
 
 class InformationalError(ServiceError):
     """The workflow cannot proceed, but the state is otherwise normal."""

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1737,6 +1737,11 @@ footer h6 {
     background: #f8f9fa;
 }
 
+.giveaway-card-claimed {
+    opacity: 0.65;
+    background: #f8f9fa;
+}
+
 .request-avatar img {
     object-fit: cover;
     border: 2px solid var(--border-color, #dee2e6);

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -37,10 +37,10 @@
                     <span class="text-danger">{{ error }}</span>
                 {% endfor %}
                 {% if form.email_status == 'unconfirmed' %}
-                    <br><a href="{{ url_for('auth.resend_confirmation') }}">Resend confirmation email</a>
+                    <br><a href="{{ url_for('auth.resend_confirmation') }}" class="btn btn-link btn-sm p-0"><i class="fas fa-envelope me-1"></i>Resend confirmation email</a>
                 {% endif %}
                 {% if form.email_status == 'confirmed' %}
-                    <br><a href="{{ url_for('auth.forgot_password') }}">Forgot your password?</a>
+                    <br><a href="{{ url_for('auth.forgot_password') }}" class="btn btn-link btn-sm p-0"><i class="fas fa-key me-1"></i>Forgot your password?</a>
                 {% endif %}
             </span>
         </p>

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -35,6 +35,12 @@
             {% for error in form.email.errors %}
                 <span style="color: red;">{{ error }}</span>
             {% endfor %}
+            {% if form.email_status == 'unconfirmed' %}
+                <br><a href="{{ url_for('auth.resend_confirmation') }}">Resend confirmation email</a>
+            {% endif %}
+            {% if form.email_status == 'confirmed' %}
+                <br><a href="{{ url_for('auth.forgot_password') }}">Forgot your password?</a>
+            {% endif %}
         </p>
 
         <!-- Password -->

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -31,16 +31,18 @@
         <!-- Email -->
         <p>
             {{ form.email.label }}<br>
-            {{ form.email(size=32) }}<br>
-            {% for error in form.email.errors %}
-                <span style="color: red;">{{ error }}</span>
-            {% endfor %}
-            {% if form.email_status == 'unconfirmed' %}
-                <br><a href="{{ url_for('auth.resend_confirmation') }}">Resend confirmation email</a>
-            {% endif %}
-            {% if form.email_status == 'confirmed' %}
-                <br><a href="{{ url_for('auth.forgot_password') }}">Forgot your password?</a>
-            {% endif %}
+            {{ form.email(size=32, aria_describedby="email-help") }}<br>
+            <span id="email-help" role="alert">
+                {% for error in form.email.errors %}
+                    <span class="text-danger">{{ error }}</span>
+                {% endfor %}
+                {% if form.email_status == 'unconfirmed' %}
+                    <br><a href="{{ url_for('auth.resend_confirmation') }}">Resend confirmation email</a>
+                {% endif %}
+                {% if form.email_status == 'confirmed' %}
+                    <br><a href="{{ url_for('auth.forgot_password') }}">Forgot your password?</a>
+                {% endif %}
+            </span>
         </p>
 
         <!-- Password -->

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -15,7 +15,7 @@
             {{ form.first_name.label }}<br>
             {{ form.first_name(size=32) }}<br>
             {% for error in form.first_name.errors %}
-                <span style="color: red;">{{ error }}</span>
+                <span class="text-danger">{{ error }}</span>
             {% endfor %}
         </p>
 
@@ -24,7 +24,7 @@
             {{ form.last_name.label }}<br>
             {{ form.last_name(size=32) }}<br>
             {% for error in form.last_name.errors %}
-                <span style="color: red;">{{ error }}</span>
+                <span class="text-danger">{{ error }}</span>
             {% endfor %}
         </p>
 
@@ -50,7 +50,7 @@
             {{ form.password.label }}<br>
             {{ form.password(size=32) }}<br>
             {% for error in form.password.errors %}
-                <span style="color: red;">{{ error }}</span>
+                <span class="text-danger">{{ error }}</span>
             {% endfor %}
         </p>
 
@@ -59,7 +59,7 @@
             {{ form.confirm_password.label }}<br>
             {{ form.confirm_password(size=32) }}<br>
             {% for error in form.confirm_password.errors %}
-                <span style="color: red;">{{ error }}</span>
+                <span class="text-danger">{{ error }}</span>
             {% endfor %}
         </p>
 
@@ -69,7 +69,7 @@
             <p class="text-muted mb-2">Meutch sends digest emails with a recap of activity in your circles. How often would you like to receive it?</p>
             {{ form.digest_frequency(class="form-select") }}
             {% for error in form.digest_frequency.errors %}
-                <span style="color: red;">{{ error }}</span>
+                <span class="text-danger">{{ error }}</span>
             {% endfor %}
         </div>
 
@@ -101,7 +101,7 @@
                 </div>
             {% endfor %}
             {% for error in form.location_method.errors %}
-                <span style="color: red;">{{ error }}</span>
+                <span class="text-danger">{{ error }}</span>
             {% endfor %}
         </div>
 
@@ -117,7 +117,7 @@
                 {{ form.street.label }}<br>
                 {{ form.street(size=64) }}<br>
                 {% for error in form.street.errors %}
-                    <span style="color: red;">{{ error }}</span>
+                    <span class="text-danger">{{ error }}</span>
                 {% endfor %}
             </p>
 
@@ -126,7 +126,7 @@
                 {{ form.city.label }}<br>
                 {{ form.city(size=32) }}<br>
                 {% for error in form.city.errors %}
-                    <span style="color: red;">{{ error }}</span>
+                    <span class="text-danger">{{ error }}</span>
                 {% endfor %}
             </p>
 
@@ -135,7 +135,7 @@
                 {{ form.state.label }}<br>
                 {{ form.state(size=32) }}<br>
                 {% for error in form.state.errors %}
-                    <span style="color: red;">{{ error }}</span>
+                    <span class="text-danger">{{ error }}</span>
                 {% endfor %}
             </p>
 
@@ -144,7 +144,7 @@
                 {{ form.zip_code.label }}<br>
                 {{ form.zip_code(size=10) }}<br>
                 {% for error in form.zip_code.errors %}
-                    <span style="color: red;">{{ error }}</span>
+                    <span class="text-danger">{{ error }}</span>
                 {% endfor %}
             </p>
 
@@ -153,7 +153,7 @@
                 {{ form.country.label }}<br>
                 {{ form.country() }}<br>
                 {% for error in form.country.errors %}
-                    <span style="color: red;">{{ error }}</span>
+                    <span class="text-danger">{{ error }}</span>
                 {% endfor %}
             </p>
         </div>
@@ -178,7 +178,7 @@
                 {{ form.latitude(size=32, step="any", placeholder="e.g., 40.7128") }}<br>
                 <small class="text-muted">Between -90 and 90 degrees</small><br>
                 {% for error in form.latitude.errors %}
-                    <span style="color: red;">{{ error }}</span>
+                    <span class="text-danger">{{ error }}</span>
                 {% endfor %}
             </p>
 
@@ -188,7 +188,7 @@
                 {{ form.longitude(size=32, step="any", placeholder="e.g., -74.0060") }}<br>
                 <small class="text-muted">Between -180 and 180 degrees</small><br>
                 {% for error in form.longitude.errors %}
-                    <span style="color: red;">{{ error }}</span>
+                    <span class="text-danger">{{ error }}</span>
                 {% endfor %}
             </p>
         </div>
@@ -215,7 +215,7 @@
                 {{ form.age_confirm.label(class="form-check-label") }}
             </div>
             {% for error in form.age_confirm.errors %}
-                <span style="color: red;">{{ error }}</span>
+                <span class="text-danger">{{ error }}</span>
             {% endfor %}
             <small class="text-muted">
                 Read our <a href="{{ url_for('main.terms') }}" target="_blank">Terms &amp; Conditions</a>.

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -117,9 +117,12 @@
         <div class="d-grid gap-3 mb-4 activity-feed-list">
             {% for event in feed_events %}
                 {% set actor_initials = (event.actor_name|replace(' ', ''))[:2]|upper %}
+                {% set is_claimed_giveaway = event.event_type == 'giveaway' and event.claim_status == 'claimed' %}
                 {% set border_class = '' %}
                 {% if event.event_type == 'request' %}
                     {% set border_class = 'border-start border-4 border-primary' %}
+                {% elif is_claimed_giveaway %}
+                    {% set border_class = 'border-start border-4 border-secondary' %}
                 {% elif event.event_type == 'giveaway' %}
                     {% set border_class = 'border-start border-4 border-success' %}
                 {% elif event.event_type == 'lent' %}
@@ -127,7 +130,7 @@
                 {% elif event.event_type == 'circle_join' %}
                     {% set border_class = 'border-start border-4 border-info' %}
                 {% endif %}
-                <article class="card shadow-sm border-0 activity-feed-card {{ border_class }}">
+                <article class="card shadow-sm border-0 activity-feed-card{% if is_claimed_giveaway %} giveaway-card-claimed{% endif %} {{ border_class }}">
                     <div class="card-body py-3">
                         <div class="d-flex align-items-center mb-2 gap-2 text-muted" style="font-size: 0.9rem;">
                             {% if event.actor_avatar_url %}

--- a/tests/integration/test_api_auth.py
+++ b/tests/integration/test_api_auth.py
@@ -394,7 +394,4 @@ class TestApiAuth:
         payload = response.get_json()
         assert payload["error"]["code"] == "CONFLICT"
         assert payload["error"]["details"]["email_status"] == "unconfirmed"
-        assert (
-            "not been confirmed" in payload["error"]["message"].lower()
-            or "hasn't been confirmed" in payload["error"]["message"].lower()
-        )
+        assert "hasn't been confirmed" in payload["error"]["message"].lower()

--- a/tests/integration/test_api_auth.py
+++ b/tests/integration/test_api_auth.py
@@ -367,4 +367,34 @@ class TestApiAuth:
         )
 
         assert response.status_code == 409
-        assert response.get_json()["error"]["code"] == "CONFLICT"
+        payload = response.get_json()
+        assert payload["error"]["code"] == "CONFLICT"
+        assert payload["error"]["details"]["email_status"] == "confirmed"
+        assert "already registered" in payload["error"]["message"].lower()
+        assert "forgot-password" in payload["error"]["message"].lower()
+
+    def test_register_rejects_duplicate_unconfirmed_email(self, client, app):
+        with app.app_context():
+            user = UserFactory(email_confirmed=False)
+            db.session.commit()
+            user_email = user.email
+
+        response = client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": user_email,
+                "first_name": "Dupe",
+                "last_name": "User",
+                "password": "somepassword123",
+                "location_method": "skip",
+            },
+        )
+
+        assert response.status_code == 409
+        payload = response.get_json()
+        assert payload["error"]["code"] == "CONFLICT"
+        assert payload["error"]["details"]["email_status"] == "unconfirmed"
+        assert (
+            "not been confirmed" in payload["error"]["message"].lower()
+            or "hasn't been confirmed" in payload["error"]["message"].lower()
+        )

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -404,13 +404,11 @@ class TestAuthenticationRoutes:
 
             assert response.status_code == 200
             assert b"already registered" in response.data
+            response_text = response.get_data(as_text=True).lower()
+            assert "hasn&#39;t been confirmed" in response_text
             assert (
-                b"hasn&#39;t been confirmed" in response.data
-                or b"hasn't been confirmed" in response.data
-            )
-            assert (
-                b"Resend confirmation email" in response.data
-                or b"resend-confirmation" in response.data
+                "resend confirmation email" in response_text
+                or "resend-confirmation" in response_text
             )
 
     def test_register_password_mismatch(self, client):

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -363,14 +363,14 @@ class TestAuthenticationRoutes:
         assert "/login" in response.location
         assert "next=" not in response.location
 
-    def test_register_duplicate_email(self, client, app, auth_user):
-        """Test registration with duplicate email."""
+    def test_register_duplicate_email_confirmed(self, client, app, auth_user):
+        """Test registration with duplicate confirmed email shows forgot-password link."""
         with app.app_context():
-            user = auth_user()  # Call the function to get fresh user
+            user = auth_user()
             response = client.post(
                 "/register",
                 data={
-                    "email": user.email,  # Use existing email
+                    "email": user.email,
                     "first_name": "Duplicate",
                     "last_name": "User",
                     "location_method": "skip",
@@ -381,8 +381,36 @@ class TestAuthenticationRoutes:
             )
 
             assert response.status_code == 200
+            assert b"already registered" in response.data
+            assert b"Forgot your password" in response.data or b"forgot-password" in response.data
+
+    def test_register_duplicate_email_unconfirmed(self, client, app):
+        """Test registration with duplicate unconfirmed email shows resend-confirmation link."""
+        with app.app_context():
+            user = UserFactory(email_confirmed=False)
+            db.session.commit()
+            response = client.post(
+                "/register",
+                data={
+                    "email": user.email,
+                    "first_name": "Duplicate",
+                    "last_name": "User",
+                    "location_method": "skip",
+                    "password": "duplicatepassword123",
+                    "confirm_password": "duplicatepassword123",
+                    "age_confirm": True,
+                },
+            )
+
+            assert response.status_code == 200
+            assert b"already registered" in response.data
             assert (
-                b"This email is already registered. Please choose a different one." in response.data
+                b"hasn&#39;t been confirmed" in response.data
+                or b"hasn't been confirmed" in response.data
+            )
+            assert (
+                b"Resend confirmation email" in response.data
+                or b"resend-confirmation" in response.data
             )
 
     def test_register_password_mismatch(self, client):

--- a/tests/integration/test_completed_giveaway_visibility.py
+++ b/tests/integration/test_completed_giveaway_visibility.py
@@ -56,6 +56,29 @@ class TestCompletedGiveawayVisibility:
         # "View Item" should appear exactly once (only for the unclaimed giveaway)
         assert html.count("View Item") == 1
 
+        # Claimed giveaway card should have gray border and dimmer class
+        # Find the claimed giveaway article by looking for the name and checking classes
+        # We use the fact that the claimed card's HTML contains both the name and the CSS classes
+
+        # Check claimed giveaway card has border-secondary and giveaway-card-claimed
+        # Find the article block containing the claimed item name
+        claimed_start = html.find(claimed_name)
+        # Search backwards for the opening <article tag
+        claimed_article_start = html.rfind("<article", 0, claimed_start)
+        claimed_article_end = html.find("</article>", claimed_start) + len("</article>")
+        claimed_article_html = html[claimed_article_start:claimed_article_end]
+        assert "border-secondary" in claimed_article_html
+        assert "giveaway-card-claimed" in claimed_article_html
+        assert "border-success" not in claimed_article_html
+
+        # Check unclaimed giveaway card has border-success but NOT giveaway-card-claimed
+        unclaimed_start = html.find(unclaimed_name)
+        unclaimed_article_start = html.rfind("<article", 0, unclaimed_start)
+        unclaimed_article_end = html.find("</article>", unclaimed_start) + len("</article>")
+        unclaimed_article_html = html[unclaimed_article_start:unclaimed_article_end]
+        assert "border-success" in unclaimed_article_html
+        assert "giveaway-card-claimed" not in unclaimed_article_html
+
     def test_claimed_giveaway_hidden_by_default_on_home_page(self, client, app, auth_user):
         """Test that recently claimed giveaways are hidden by default on home page."""
         user_email = None

--- a/tests/unit/services/test_auth_service.py
+++ b/tests/unit/services/test_auth_service.py
@@ -1,8 +1,12 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
+import pytest
+from sqlalchemy.exc import IntegrityError
+
 from app import db
 from app.services import auth_service
+from app.services.exceptions import ConflictError
 from conftest import TEST_PASSWORD
 from tests.factories import UserFactory
 
@@ -87,6 +91,87 @@ class TestAuthService:
             db.session.refresh(user)
             assert result.status == auth_service.CONFIRM_EMAIL_STATUS_EXPIRED
             assert user.email_confirmed is False
+
+    def test_check_existing_email_confirmed(self, app):
+        with app.app_context():
+            user = UserFactory(email_confirmed=True)
+            db.session.commit()
+
+            result = auth_service.check_existing_email(user.email)
+
+            assert result.exists is True
+            assert result.is_confirmed is True
+
+    def test_check_existing_email_unconfirmed(self, app):
+        with app.app_context():
+            user = UserFactory(email_confirmed=False)
+            db.session.commit()
+
+            result = auth_service.check_existing_email(user.email)
+
+            assert result.exists is True
+            assert result.is_confirmed is False
+
+    def test_check_existing_email_nonexistent(self, app):
+        with app.app_context():
+            result = auth_service.check_existing_email("nobody@example.com")
+
+            assert result.exists is False
+            assert result.is_confirmed is False
+
+    def test_register_user_catches_integrity_error_confirmed(self, app):
+        with app.app_context():
+            _user = UserFactory(email="conflict@example.com", email_confirmed=True)
+            db.session.commit()
+
+            with (
+                patch("app.services.auth_service.send_confirmation_email", return_value=True),
+                patch.object(
+                    auth_service.db.session,
+                    "commit",
+                    side_effect=IntegrityError("mock", "orig", "stmt"),
+                ),
+            ):
+                with pytest.raises(ConflictError) as excinfo:
+                    auth_service.register_user(
+                        email="conflict@example.com",
+                        first_name="Conflict",
+                        last_name="User",
+                        password=TEST_PASSWORD,
+                        digest_frequency="weekly",
+                        location_method="skip",
+                    )
+
+            assert "already registered" in str(excinfo.value).lower()
+            assert "forgot password" in str(excinfo.value).lower()
+
+    def test_register_user_catches_integrity_error_unconfirmed(self, app):
+        with app.app_context():
+            _user = UserFactory(email="unconfirmed@example.com", email_confirmed=False)
+            db.session.commit()
+
+            with (
+                patch("app.services.auth_service.send_confirmation_email", return_value=True),
+                patch.object(
+                    auth_service.db.session,
+                    "commit",
+                    side_effect=IntegrityError("mock", "orig", "stmt"),
+                ),
+            ):
+                with pytest.raises(ConflictError) as excinfo:
+                    auth_service.register_user(
+                        email="unconfirmed@example.com",
+                        first_name="Unconfirmed",
+                        last_name="User",
+                        password=TEST_PASSWORD,
+                        digest_frequency="weekly",
+                        location_method="skip",
+                    )
+
+            assert (
+                "hasn't been confirmed" in str(excinfo.value).lower()
+                or "not confirmed" in str(excinfo.value).lower()
+            )
 
     def test_resend_confirmation_email_for_user_returns_already_confirmed(self, app):
         with app.app_context():

--- a/tests/unit/services/test_auth_service.py
+++ b/tests/unit/services/test_auth_service.py
@@ -168,10 +168,7 @@ class TestAuthService:
                         location_method="skip",
                     )
 
-            assert (
-                "hasn't been confirmed" in str(excinfo.value).lower()
-                or "not confirmed" in str(excinfo.value).lower()
-            )
+            assert "hasn't been confirmed" in str(excinfo.value).lower()
 
     def test_resend_confirmation_email_for_user_returns_already_confirmed(self, app):
         with app.app_context():

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -154,7 +154,7 @@ class TestRegistrationForm:
             form = RegistrationForm(data=form_data)
             assert form.validate() is False
             assert (
-                "This email is already registered. Please choose a different one."
+                "This email is already registered. Use the forgot-password link below to regain access."
                 in form.email.errors
             )
 


### PR DESCRIPTION
Fix #388 

Now if you try to register with an email that already is in the system, it will direct you to "forgot my password" or "confirm my email" depending on what step of the process you're at.