### PR TITLE
fix: be able to view circle join request user's name on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Stay up on what's happening with Meutch. Improvements are constantly pushed to the main instance at https://meutch.com - this lets you know what changed since the last time you logged in.
 
+## August 2026
+
+### Bug fixes
+- Circle join requests now show the requester's name on mobile portrait layouts — previously the name collapsed out of view, leaving only the avatar and action buttons ([#465](https://github.com/sfirke/meutch/pull/465)).
+
 ## July 2026
 
 ### Features

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -693,6 +693,17 @@ footer h6 {
     .join-request-item .btn-sm {
         padding: 0.4rem 0.75rem;
     }
+
+    /* Join request items — stack the inner flex container so the name
+       doesn't collapse against the action buttons on narrow screens */
+    .join-request-item > .d-flex {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .join-request-item .member-list-name {
+        min-width: 80px;
+    }
 }
 
 @media (max-width: 576px) {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -691,7 +691,7 @@ footer h6 {
 
     .circle-member-item .btn-sm,
     .join-request-item .btn-sm {
-        padding: 0.4rem 0.75rem;
+        padding: 0.5rem 1rem;
     }
 
     /* Join request items — stack the inner flex container so the name

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -675,9 +675,9 @@ footer h6 {
         padding: 1rem;
     }
 
-    /* Circle member list — stack vertically on mobile */
-    .circle-member-item,
-    .join-request-item {
+    /* note: .join-request-item is stacked via its inner > .d-flex (below);
+       this rule only applies to .circle-member-item, the flex <li> */
+    .circle-member-item {
         flex-direction: column !important;
         align-items: stretch !important;
         gap: 0.5rem !important;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -701,7 +701,9 @@ footer h6 {
         gap: 0.5rem;
     }
 
-    .join-request-item .member-list-name {
+    /* the <a> wraps only the requester name; the message <p> shares the
+       member-list-name class and must not be affected */
+    .join-request-item a .member-list-name {
         min-width: 80px;
     }
 }


### PR DESCRIPTION
Fix #464 